### PR TITLE
feat(shell): usage analytics Phase 1 instrumentation (#36 #37 #38)

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,4 +1,5 @@
 const esbuild = require("esbuild");
+const pkg = require("./package.json");
 
 esbuild
   .build({
@@ -15,6 +16,7 @@ esbuild
     },
     define: {
       "process.env.NODE_ENV": '"production"',
+      __APP_VERSION__: JSON.stringify(pkg.version),
     },
   })
   .catch(() => process.exit(1));

--- a/src/code.ts
+++ b/src/code.ts
@@ -9,6 +9,8 @@ import {
 } from "./shared/error-handler";
 import { createLogger } from "./shared/logging";
 import { bindSession } from "./shared/operations/registry";
+import { captureUsage } from "./shared/analytics/capture";
+import { dumpUsageEvents } from "./shared/analytics/buffer";
 
 // Configuration
 const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds
@@ -35,6 +37,12 @@ figma.showUI(__html__, RESIZE_DEFAULT);
 // Bind the MCP Operation Session for the lifetime of this plugin run.
 // MVP supports one Session at a time; reload tears it down.
 bindSession(`sess_${figma.fileKey ?? "unknown"}_${Date.now().toString(36)}`);
+
+// Usage analytics (Phase 1): expose the dev-only buffer dump on the plugin
+// global so it can be inspected from the Figma dev console. Inert in
+// production (reads in-memory state only). See issues #36–#38 and
+// docs/prd-usage-analytics-phase1.md (FR8).
+(globalThis as Record<string, unknown>).__dumpUsageEvents = dumpUsageEvents;
 
 // Module handlers map
 const handlers: Record<
@@ -138,6 +146,19 @@ figma.ui.onmessage = async (msg: unknown) => {
   };
 
   logger.debug(`Received message: ${target}:${action}`, { payload, requestId });
+
+  // Usage analytics: classify and emit a structured event for this message.
+  // Never throws into the user action — captureUsage swallows internally (FR9).
+  // Only {target, action} identity is recorded; payload is never copied (FR6).
+  captureUsage(
+    { target, action, payload },
+    {
+      fileKey: figma.fileKey ?? null,
+      rootId: figma.root.id,
+      rootName: figma.root.name,
+    },
+    __APP_VERSION__,
+  );
 
   try {
     // Handle shell-specific actions

--- a/src/shared/analytics/buffer.test.ts
+++ b/src/shared/analytics/buffer.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import {
+  appendUsageEvent,
+  clearUsageBuffer,
+  getBufferSize,
+  getRecentEvents,
+} from "./buffer";
+import type { UsageEvent } from "./types";
+
+function makeEvent(module: string, action: string | null): UsageEvent {
+  return {
+    schemaVersion: 1,
+    type: action === null ? "module_open" : "action",
+    module,
+    action,
+    fileKey: "abc",
+    fileName: "F",
+    pluginVersion: "1.7.0",
+    sessionId: "s",
+    clientTs: "2026-06-21T10:00:00.000Z",
+  };
+}
+
+beforeEach(() => {
+  clearUsageBuffer();
+});
+
+describe("usage ring buffer", () => {
+  it("starts empty", () => {
+    expect(getBufferSize()).toBe(0);
+    expect(getRecentEvents()).toEqual([]);
+  });
+
+  it("appends events in order", () => {
+    appendUsageEvent(makeEvent("audit", "generate-report"));
+    appendUsageEvent(makeEvent("utilities", "do-thing"));
+    expect(getBufferSize()).toBe(2);
+    expect(getRecentEvents().map((e) => e.module)).toEqual([
+      "audit",
+      "utilities",
+    ]);
+  });
+
+  it("caps at the configured size (last 200) by dropping the oldest", () => {
+    for (let i = 0; i < 205; i++) {
+      appendUsageEvent(makeEvent(`m${i}`, "a"));
+    }
+    expect(getBufferSize()).toBe(200);
+    const events = getRecentEvents();
+    expect(events[0].module).toBe("m5");
+    expect(events[199].module).toBe("m204");
+  });
+
+  it("returns a copy so callers cannot mutate the internal buffer", () => {
+    appendUsageEvent(makeEvent("audit", "x"));
+    const events = getRecentEvents();
+    events.pop();
+    expect(getBufferSize()).toBe(1);
+  });
+
+  it("does not persist across a clear (empties to zero)", () => {
+    appendUsageEvent(makeEvent("audit", "x"));
+    clearUsageBuffer();
+    expect(getBufferSize()).toBe(0);
+    expect(getRecentEvents()).toEqual([]);
+  });
+});

--- a/src/shared/analytics/buffer.ts
+++ b/src/shared/analytics/buffer.ts
@@ -1,0 +1,37 @@
+// In-memory ring buffer of the most recent usage events, for dev observability.
+// Bounded; cleared on plugin close (module-scope state, no persistence).
+// See docs/prd-usage-analytics-phase1.md (FR8) and issue #38.
+
+import type { UsageEvent } from "./types";
+
+const MAX_BUFFER_SIZE = 200;
+const buffer: UsageEvent[] = [];
+
+export function appendUsageEvent(event: UsageEvent): void {
+  buffer.push(event);
+  if (buffer.length > MAX_BUFFER_SIZE) {
+    buffer.shift();
+  }
+}
+
+export function getRecentEvents(): UsageEvent[] {
+  return buffer.slice();
+}
+
+export function getBufferSize(): number {
+  return buffer.length;
+}
+
+export function clearUsageBuffer(): void {
+  buffer.length = 0;
+}
+
+// Dev-only: dump the current buffer to the console and return it. Exposed to
+// the dev console via `globalThis.__dumpUsageEvents` in code.ts. Reads only
+// in-memory state — inert in production.
+export function dumpUsageEvents(): UsageEvent[] {
+  const events = getRecentEvents();
+  // eslint-disable-next-line no-console
+  console.log(`[usage] ${events.length} buffered event(s)`, events);
+  return events;
+}

--- a/src/shared/analytics/capture.test.ts
+++ b/src/shared/analytics/capture.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, beforeEach } from "vitest";
+
+import {
+  buildEvent,
+  captureUsage,
+  classifyMessage,
+  getAnalyticsSessionId,
+  initAnalyticsSession,
+  resetAnalyticsSession,
+} from "./capture";
+import { clearUsageBuffer, getBufferSize } from "./buffer";
+
+const FIGMA_CTX = {
+  fileKey: "abc123",
+  rootId: "root-id",
+  rootName: "Kido Mobile DS",
+};
+
+const NO_FILE_KEY_CTX = {
+  fileKey: null,
+  rootId: "root-id-fallback",
+  rootName: "Untitled",
+};
+
+beforeEach(() => {
+  resetAnalyticsSession();
+  clearUsageBuffer();
+});
+
+describe("classifyMessage", () => {
+  it("maps a module action to an `action` event", () => {
+    expect(
+      classifyMessage({ target: "ds-explorer", action: "build-component" }),
+    ).toEqual({
+      type: "action",
+      module: "ds-explorer",
+      action: "build-component",
+    });
+  });
+
+  it("maps the activeModule save-storage write to a `module_open` event", () => {
+    expect(
+      classifyMessage({
+        target: "shell",
+        action: "save-storage",
+        payload: { key: "activeModule", value: "audit" },
+      }),
+    ).toEqual({ type: "module_open", module: "audit", action: null });
+  });
+
+  it("drops the startup load-storage restore of activeModule (FR5)", () => {
+    expect(
+      classifyMessage({
+        target: "shell",
+        action: "load-storage",
+        payload: { key: "activeModule" },
+      }),
+    ).toBeNull();
+  });
+
+  it("drops shell save-storage for non-activeModule keys", () => {
+    expect(
+      classifyMessage({
+        target: "shell",
+        action: "save-storage",
+        payload: { key: "bridgeMode", value: true },
+      }),
+    ).toBeNull();
+  });
+
+  it("drops resize-ui", () => {
+    expect(
+      classifyMessage({
+        target: "shell",
+        action: "resize-ui",
+        payload: { width: 400 },
+      }),
+    ).toBeNull();
+  });
+
+  it("drops mcp-bridge traffic (FR4)", () => {
+    expect(
+      classifyMessage({ target: "mcp-bridge", action: "dispatch" }),
+    ).toBeNull();
+  });
+
+  it("does not surface payload contents on the identity", () => {
+    const identity = classifyMessage({
+      target: "utilities",
+      action: "do-thing",
+      payload: { secret: "leak" },
+    });
+    expect(identity).toEqual({
+      type: "action",
+      module: "utilities",
+      action: "do-thing",
+    });
+  });
+});
+
+describe("buildEvent", () => {
+  it("attaches all schema-v1 fields", () => {
+    const event = buildEvent(
+      { type: "action", module: "audit", action: "generate-report" },
+      FIGMA_CTX,
+      "sess-1",
+      "1.7.0",
+      new Date("2026-06-21T10:00:00.000Z"),
+    );
+    expect(event).toEqual({
+      schemaVersion: 1,
+      type: "action",
+      module: "audit",
+      action: "generate-report",
+      fileKey: "abc123",
+      fileName: "Kido Mobile DS",
+      pluginVersion: "1.7.0",
+      sessionId: "sess-1",
+      clientTs: "2026-06-21T10:00:00.000Z",
+    });
+  });
+
+  it("falls back to root.id when fileKey is null (FR7)", () => {
+    const event = buildEvent(
+      { type: "action", module: "audit", action: "x" },
+      NO_FILE_KEY_CTX,
+      "sess-1",
+      "1.7.0",
+    );
+    expect(event.fileKey).toBe("root-id-fallback");
+  });
+
+  it("sets action to null for module_open", () => {
+    const event = buildEvent(
+      { type: "module_open", module: "audit", action: null },
+      FIGMA_CTX,
+      "sess-1",
+      "1.7.0",
+    );
+    expect(event.action).toBeNull();
+    expect(event.type).toBe("module_open");
+  });
+});
+
+describe("analytics session", () => {
+  it("mints a sessionId once and reuses it", () => {
+    const a = initAnalyticsSession();
+    const b = initAnalyticsSession();
+    expect(a).toBe(b);
+    expect(a).toMatch(/^anon_/);
+  });
+
+  it("captureUsage uses a stable sessionId across events", () => {
+    captureUsage(
+      { target: "audit", action: "generate-report" },
+      FIGMA_CTX,
+      "1.7.0",
+    );
+    captureUsage(
+      { target: "utilities", action: "do-thing" },
+      FIGMA_CTX,
+      "1.7.0",
+    );
+    const sid = getAnalyticsSessionId();
+    expect(sid).toMatch(/^anon_/);
+  });
+});
+
+describe("captureUsage (end-to-end)", () => {
+  it("emits one action event and appends to the buffer", () => {
+    captureUsage(
+      { target: "audit", action: "generate-report" },
+      FIGMA_CTX,
+      "1.7.0",
+    );
+    expect(getBufferSize()).toBe(1);
+  });
+
+  it("emits a module_open event for the activeModule write", () => {
+    captureUsage(
+      {
+        target: "shell",
+        action: "save-storage",
+        payload: { key: "activeModule", value: "audit" },
+      },
+      FIGMA_CTX,
+      "1.7.0",
+    );
+    expect(getBufferSize()).toBe(1);
+  });
+
+  it("emits nothing for noise (mcp-bridge, load-storage, resize-ui)", () => {
+    captureUsage(
+      { target: "mcp-bridge", action: "dispatch" },
+      FIGMA_CTX,
+      "1.7.0",
+    );
+    captureUsage(
+      {
+        target: "shell",
+        action: "load-storage",
+        payload: { key: "activeModule" },
+      },
+      FIGMA_CTX,
+      "1.7.0",
+    );
+    captureUsage(
+      { target: "shell", action: "resize-ui", payload: { width: 400 } },
+      FIGMA_CTX,
+      "1.7.0",
+    );
+    expect(getBufferSize()).toBe(0);
+  });
+
+  it("swallows a thrown error without throwing (FR9)", () => {
+    // A payload whose `key` getter throws exercises the FR9 safety wrap.
+    const throwingPayload = {
+      get key(): string {
+        throw new Error("boom");
+      },
+    };
+    expect(() =>
+      captureUsage(
+        { target: "shell", action: "save-storage", payload: throwingPayload },
+        FIGMA_CTX,
+        "1.7.0",
+      ),
+    ).not.toThrow();
+    expect(getBufferSize()).toBe(0);
+  });
+});

--- a/src/shared/analytics/capture.ts
+++ b/src/shared/analytics/capture.ts
@@ -1,0 +1,121 @@
+// Usage event capture for the plugin thread.
+// See docs/prd-usage-analytics-phase1.md (FR1–FR9) and docs/usage-analytics-plan.md.
+//
+// One capture hook in src/code.ts calls `captureUsage` for every well-formed
+// UI→plugin message. `classifyMessage` decides whether the message becomes an
+// `action` event, a `module_open` event, or is dropped as noise (FR2, FR4, FR5).
+// `buildEvent` attaches figma context + sessionId + pluginVersion (FR3, FR7).
+// The whole path is wrapped so a failure can never affect a user action (FR9).
+
+import { appendUsageEvent } from "./buffer";
+import type { EventIdentity, UsageEvent } from "./types";
+
+// The incoming message shape, as destructured in code.ts.
+export interface IncomingMessage {
+  target: string;
+  action: string;
+  payload?: unknown;
+}
+
+// Figma context needed to build an event. Passed in from code.ts so the
+// builder is testable without the figma global.
+export interface FigmaContext {
+  fileKey: string | null;
+  rootId: string;
+  rootName: string;
+}
+
+let analyticsSessionId: string | null = null;
+
+// Minted once per plugin open; reused on every event. Lazy on first capture
+// so a session with no user actions allocates nothing. Minted on the plugin
+// thread (where figma context lives) rather than the UI thread to avoid a
+// round-trip — satisfies FR7's "once per plugin open, on every event" intent.
+export function initAnalyticsSession(): string {
+  if (!analyticsSessionId) {
+    const nonce = Math.random().toString(36).slice(2, 10);
+    analyticsSessionId = `anon_${Date.now().toString(36)}_${nonce}`;
+  }
+  return analyticsSessionId;
+}
+
+export function getAnalyticsSessionId(): string | null {
+  return analyticsSessionId;
+}
+
+// Test-only: reset the session between tests.
+export function resetAnalyticsSession(): void {
+  analyticsSessionId = null;
+}
+
+// Classify an incoming message into an event identity, or null to drop.
+// Reads `payload.key` only to distinguish the activeModule write from other
+// shell storage traffic — never copies payload contents into an event (FR6).
+export function classifyMessage(msg: IncomingMessage): EventIdentity | null {
+  // FR4: mcp-bridge is agent-driven, not user-driven.
+  if (msg.target === "mcp-bridge") {
+    return null;
+  }
+
+  if (msg.target === "shell") {
+    // FR2/FR4: the activeModule save-storage write is a genuine user switch.
+    if (msg.action === "save-storage") {
+      const p = msg.payload as { key?: string; value?: unknown } | undefined;
+      if (p?.key === "activeModule") {
+        return { type: "module_open", module: String(p.value), action: null };
+      }
+    }
+    // FR5: load-storage (including the startup activeModule restore) and all
+    // other shell housekeeping (save-storage for other keys, resize-ui) is noise.
+    return null;
+  }
+
+  // Everything else — the 10 user-facing modules' actions.
+  return { type: "action", module: msg.target, action: msg.action };
+}
+
+export function buildEvent(
+  identity: EventIdentity,
+  ctx: FigmaContext,
+  sessionId: string,
+  pluginVersion: string,
+  now: Date = new Date(),
+): UsageEvent {
+  return {
+    schemaVersion: 1,
+    type: identity.type,
+    module: identity.module,
+    action: identity.action,
+    fileKey: ctx.fileKey ?? ctx.rootId,
+    fileName: ctx.rootName,
+    pluginVersion,
+    sessionId,
+    clientTs: now.toISOString(),
+  };
+}
+
+// FR8: emit a structured event to the console (clearly tagged) and the ring buffer.
+export function emitUsageEvent(event: UsageEvent): void {
+  // eslint-disable-next-line no-console
+  console.log("[usage]", JSON.stringify(event));
+  appendUsageEvent(event);
+}
+
+// Single entry point from code.ts. Never throws (FR9).
+export function captureUsage(
+  msg: IncomingMessage,
+  ctx: FigmaContext,
+  pluginVersion: string,
+): void {
+  try {
+    const identity = classifyMessage(msg);
+    if (!identity) {
+      return;
+    }
+    const sessionId = initAnalyticsSession();
+    const event = buildEvent(identity, ctx, sessionId, pluginVersion);
+    emitUsageEvent(event);
+  } catch {
+    // FR9: swallow silently — instrumentation must never affect a user action.
+  }
+}

--- a/src/shared/analytics/types.ts
+++ b/src/shared/analytics/types.ts
@@ -1,0 +1,24 @@
+// Schema v1 usage event shape, captured in the plugin thread.
+// See docs/prd-usage-analytics-phase1.md (FR3) and docs/usage-analytics-plan.md.
+
+export type UsageEventType = "action" | "module_open";
+
+export interface UsageEvent {
+  schemaVersion: 1;
+  type: UsageEventType;
+  module: string;
+  action: string | null;
+  fileKey: string;
+  fileName: string;
+  pluginVersion: string;
+  sessionId: string;
+  clientTs: string;
+}
+
+// The identity part of an event, derived from an incoming message before
+// figma context is attached. `null` means "drop this message" (denylist).
+export interface EventIdentity {
+  type: UsageEventType;
+  module: string;
+  action: string | null;
+}


### PR DESCRIPTION
## Summary

Implements all three Phase 1 slices of parent #34 (Usage Analytics — Internal Instrumentation) in one vertical PR: capture, classify, and observe usage events end-to-end in the plugin thread. Dev-only and inert — console + in-memory buffer, no persistence, no network, no `manifest.json` change.

- Closes #36 — Capture & emit a single usage event end-to-end
- Closes #37 — Classify action vs `module_open` vs noise
- Closes #38 — Dev observability: ring buffer + on-demand dump

Spec: `docs/prd-usage-analytics-phase1.md` (FR1–FR9) · `docs/usage-analytics-plan.md`.

## What landed

**`src/shared/analytics/`** (new subsystem, parallel to `operations/`):
- `types.ts` — schema-v1 `UsageEvent` + `EventIdentity`.
- `capture.ts` — `classifyMessage` (denylist + `module_open` mapping), `buildEvent` (figma context + sessionId + pluginVersion), `captureUsage` (single entry point, FR9 try/catch swallow), lazy per-open `sessionId`.
- `buffer.ts` — bounded 200-entry ring buffer + dev-only `dumpUsageEvents`.

**`src/code.ts`** — one capture hook in the `figma.ui.onmessage` dispatcher (right after the existing `logger.debug`, the choke point FR1 identifies). Exposes `globalThis.__dumpUsageEvents` for dev inspection from the Figma dev console. No per-module changes.

**`esbuild.config.js`** — injects `__APP_VERSION__` from `package.json` into the plugin bundle (the UI bundle already had it via Vite; the plugin thread didn't). `__APP_VERSION__` was already `declare const` in `src/image-assets.d.ts`, so no new global declaration or eslint change was needed.

## How the acceptance criteria map

### #36 — capture & emit
- [x] Every well-formed `{target, action}` message produces exactly one structured event (`captureUsage` → `classifyMessage` → `buildEvent` → `emitUsageEvent`).
- [x] Schema-v1 fields all populated; `fileKey` falls back to `figma.root.id` when `figma.fileKey` is null/undefined (normalized at the call site).
- [x] `sessionId` minted once per plugin open, reused on every event (`initAnalyticsSession` is idempotent).
- [x] No payload contents in any event — `classifyMessage` reads `payload.key` only to distinguish the `activeModule` write; the event shape has no payload field.
- [x] A thrown error during construction never reaches the user action (`captureUsage` wraps the whole path in `try/catch` and swallows; covered by a test with a throwing `key` getter).
- [x] Existing logs/timings unchanged — the hook is a single non-blocking call after the existing `logger.debug`.

### #37 — classify
- [x] `target: "shell", action: "save-storage", payload.key === "activeModule"` → one `module_open` event with `action: null` and `module = payload.value`.
- [x] Startup `load-storage` of `activeModule` (app rehydration in `ShellContext`) emits **zero** `module_open` — all `load-storage` is denied.
- [x] Shell housekeeping (`save-storage` for other keys, `load-storage`, `resize-ui`) and `target: "mcp-bridge"` emit no events.
- [x] All 10 user-facing modules' actions still emit `action` events (any non-shell, non-mcp-bridge target).
- [x] No event contains payload data.

### #38 — dev observability
- [x] Emitted events append to a bounded buffer capped at 200 (oldest dropped on overflow).
- [x] `globalThis.__dumpUsageEvents()` returns and prints the current buffer.
- [x] Buffer is module-scope — cleared on plugin close, no `clientStorage`/file persistence.
- [x] No user-visible behavior; append is O(1) amortized (push + occasional shift).

## Verification

```
npm run typecheck    # clean
npm run lint         # 0 errors (no new warnings; console.log gated by eslint-disable directives)
npm run format:check # all files pass
npm test             # 64 passed (43 iconfinder + 21 analytics)
npm run build        # UI 4.75 MB, code.js 110.2 kB; __APP_VERSION__ + __dumpUsageEvents present in dist/code.js
```

New tests (`src/shared/analytics/`):
- `capture.test.ts` (16) — classify for action / `module_open` / noise / FR5 restore / FR4 mcp-bridge / no-payload; buildEvent fields + `fileKey` fallback + `module_open` null action; session mint-once + stable across events; end-to-end emit + FR9 swallow.
- `buffer.test.ts` (5) — empty / append / cap-at-200-drops-oldest / copy-on-read / clear.

## Notes / follow-ups

- **sessionId is minted on the plugin thread**, not the UI thread as the PRD FR7 parenthetical suggests. Rationale: capture happens on the plugin thread where `figma.fileKey`/`figma.root` live; a UI-thread id would need a relay round-trip for no gain. Satisfies the actual requirement ("once per plugin open, on every event"). Flagging in case you want the PRD wording updated.
- **Version bump intentionally omitted.** PRD §7 says "bump per semver if it ships." Leaving the `1.6.5 → 1.7.0` minor bump to the release script (`npm run release:minor`) rather than mixing a manual edit into this PR.
- **CI does not run `npm test`** — the 21 new tests are enforced only locally for now (pre-existing gap shared by the iconfinder tests). Worth a follow-up to add a vitest job to `.github/workflows/ci.yml`.
- Phase 2 relay will need `ShellMessage.type` extended (e.g. `"usage-event"`) in `src/shared/types.ts`; the event shape here is already JSON-serializable and ready for that.
