### PR TITLE
feat(tidy-doc): generate component documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,14 @@ The plugin ships with an MCP server that exposes a curated set of **Operations**
 | `tidy_ds_explorer_list_components` | Query | List the DS Explorer registry (name + library key + type), optionally filtered by a name glob. Names returned here are the valid inputs to `tidy_ds_explorer_get_component`. |
 | `tidy_ds_explorer_get_component` | Query | Import a DS Explorer component by name and return `{ properties, description, nestedInstances }`. Set `includeImage: true` for a base64 PNG preview (heavier — agent-only). Errors `INVALID_PARAMS` with `details.availableNames` on unknown name. Bridge timeout: 60 s. |
 | `tidy_ds_explorer_place_set` | Execute | Place a registered component SET onto a page as an editable clone, ready to be labelled by `tidy_component_labels_build`. Defaults to the current page and viewport centre. Returns the new `nodeId`. Errors `WRONG_NODE_TYPE` if the named component is a single component. Bridge timeout: 60 s. |
+| `tidy_doc_read_component` | Query | Read derived documentation facts for a selected/passed component: variant categorisation, anatomy breakdown facts, mode collections, and related-component candidates. |
+| `tidy_doc_build_page` | Execute | Build or replace a generated Documentation Page from a Doc Spec. Renders Variants, Component Breakdown, Mode, Usage Guidelines, and Related Components when present/applicable. Bridge timeout: 60 s. |
 
 Query / Plan / Execute are the three Operation flavours from [`ADR-0001`](docs/adr/0001-plan-execute-split-for-operations.md). Lookup via a Query, pass the resulting ids to an Execute.
 
 ### Slash commands
 
-Project-scoped wrappers in `.claude/commands/` expand into prompts that drive the tools above. They appear in `/` autocomplete after restarting Claude Code in this directory.
+Plugin-scoped wrappers in `claude-plugin/commands/` expand into prompts that drive the tools above. In the locally installed Claude Code plugin they appear namespaced as `/tidy-ds:<command>` after `/reload-plugins`.
 
 | Slash | What it does |
 | --- | --- |
@@ -110,6 +112,7 @@ Project-scoped wrappers in `.claude/commands/` expand into prompts that drive th
 | `/tidy-ds-template [--force]` | Wraps `tidy_ds_template_run`. Confirms first (since it's not idempotent); `--force` skips the prompt. |
 | `/tidy-labels [nodeId] [top=…] [left=…] [secondTop=…] [secondLeft=…] [groupSecondTop=true\|false] [groupSecondLeft=true\|false] [spacing=…] [fontSize=…] [extractElement=true\|false]` | Wraps `tidy_component_labels_get_variant_props` + `tidy_component_labels_build`. With no axis args, surfaces the variant properties and asks how to assign them. |
 | `/tidy-ds [name\|glob] [--image] [--place [x=…] [y=…] [pageId=…]]` | Wraps `tidy_ds_explorer_list_components`, `tidy_ds_explorer_get_component`, and `tidy_ds_explorer_place_set`. No args → lists registered names. A glob lists matches. An exact name fetches the component; `--image` adds a PNG preview; `--place` drops a clone of the set onto the page and returns a `nodeId` you can pipe into `/tidy-labels`. |
+| `/tidy-doc [nodeId] [status=…] [sections=…] [dry-run=true]` | Uses the bundled tidy-doc skill to call `tidy_doc_read_component`, author a Doc Spec, and call `tidy_doc_build_page`. See [`docs/tidy-doc.md`](docs/tidy-doc.md). |
 
 ### Troubleshooting
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "tidy-ds",
   "version": "0.0.0",
-  "description": "Tidy DS Toolbox agent surface — slash commands + bundled MCP server exposing the Tidy DS Operations (DS Explorer, component labels, misprint, DS template) to Claude Code over the localhost Figma bridge.",
+  "description": "Tidy DS Toolbox agent surface — slash commands + bundled MCP server exposing Tidy DS Operations (DS Explorer, component labels, misprint, DS template, tidy-doc component documentation) to Claude Code over the localhost Figma bridge.",
   "author": { "name": "Kido" },
-  "keywords": ["figma", "design-system", "mcp", "tidy-ds"],
+  "keywords": ["figma", "design-system", "documentation", "mcp", "tidy-ds"],
   "mcpServers": {
     "tidy-ds-toolbox": {
       "command": "node",

--- a/claude-plugin/commands/tidy-doc.md
+++ b/claude-plugin/commands/tidy-doc.md
@@ -1,0 +1,48 @@
+---
+description: Generate a complete component Documentation Page in Figma via tidy-doc read → author Doc Spec → build.
+allowed-tools:
+  - "mcp__tidy-ds-toolbox__tidy_doc_read_component"
+  - "mcp__plugin_tidy-ds_tidy-ds-toolbox__tidy_doc_read_component"
+  - "mcp__tidy-ds-toolbox__tidy_doc_build_page"
+  - "mcp__plugin_tidy-ds_tidy-ds-toolbox__tidy_doc_build_page"
+---
+
+Generate a complete Documentation Page for a selected Figma component or component set.
+
+User-supplied arguments (may be empty): $ARGUMENTS
+
+## Before you start
+
+Use the bundled `tidy-doc` skill instructions. In particular:
+
+- Read `skills/tidy-doc/SKILL.md`.
+- Follow `skills/tidy-doc/kido-editorial-standard.md` for voice, tone, and length.
+- Follow `skills/tidy-doc/authoring-rules.md` for per-Section slot rules.
+- Use `skills/tidy-doc/button-exemplar.md` as the worked exemplar.
+
+## Argument parsing
+
+- First positional token (optional) is a Figma node id matching `^\d+:\d+$`. If absent, the Operations fall back to the current Figma selection.
+- Optional `status=<StatusEnum>` sets the page status. If omitted, use `IDEATION` unless the user explicitly tells you a different lifecycle state.
+- Optional `sections=<comma-list>` can restrict Sections (`variants,breakdown,mode,guidelines,related`). If absent, author every Section that has meaningful derived facts/content.
+- Optional `dry-run=true` means call `tidy_doc_read_component`, author and print the Doc Spec, but do **not** call `tidy_doc_build_page`.
+
+## Flow
+
+1. Call `tidy_doc_read_component` with `{ nodeId }` or `{}`.
+2. Author a complete Doc Spec from the returned derived facts. Never invent a variant, mode, measurement, or sibling name. Use only symbolic references returned by `read_component`:
+   - `variants` keys from `familyAxis.values`.
+   - `related` keys from `relatedCandidates[].name`.
+   - Do/Don't `props` axis names/values from the categorised axes (`familyAxis`, `stateAxis`, `sizeAxis`).
+   - `mode` carries only an optional caption; mode showcases are derived automatically.
+3. Log the Doc Spec in your response in a compact fenced `json` block unless the user asked not to. This is the inspectable plan surface; there is no separate approval gate.
+4. Unless `dry-run=true`, call `tidy_doc_build_page` with `{ nodeId?, docSpec }`.
+5. Report the returned `pageFrameId` and `sourceComponentId`, and tell the user the rendered page is the review surface. Re-runs replace the generated page wholesale.
+
+## Error handling
+
+- On `BRIDGE_DISCONNECTED`, tell the user to open the Tidy DS Toolbox Figma plugin in the file and run the command again.
+- On `WRONG_NODE_TYPE`, tell the user the target must be a `COMPONENT` or `COMPONENT_SET`.
+- On `INVALID_PARAMS` with `details.issues`, the Doc Spec failed schema validation. Shorten/restructure prose to fit the schema limits and retry once.
+- On `INVALID_PARAMS` with `details.unresolved`, re-author the affected references in one pass using the complete unresolved worklist. Use `didYouMean` hints when present. Then call `tidy_doc_build_page` again with the corrected Doc Spec.
+- If a Section would require facts or a scene not representable by the schema, drop that Section/sub-part rather than approximating or fabricating it.

--- a/claude-plugin/skills/tidy-doc/SKILL.md
+++ b/claude-plugin/skills/tidy-doc/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: tidy-doc
+description: Generate Figma component documentation pages with the Tidy DS Toolbox tidy-doc Operations. Use when the user asks to document a component, generate component docs, create a Documentation Page, or run tidy-doc.
+---
+
+# tidy-doc — orchestrating skill
+
+This skill authors the Doc Spec and drives the two `tidy-doc` Operations:
+
+1. `tidy_doc_read_component` — read live derived facts from the selected/passed Figma component.
+2. Author a Doc Spec using only those facts plus Kido editorial prose.
+3. `tidy_doc_build_page` — render or replace the Documentation Page.
+
+There is **no mandatory approval gate**. The rendered Figma page is the review surface; the Doc Spec is logged for on-demand inspection and cheap re-runs replace the generated page wholesale.
+
+## Required references
+
+Before authoring, read these files in this skill directory:
+
+- `kido-editorial-standard.md` — voice, tone, length, and wording rules.
+- `authoring-rules.md` — per-Section slot rules and never-invent constraints.
+- `button-exemplar.md` — worked Button example and calibration notes.
+
+## Trigger phrases
+
+Use this skill for requests like:
+
+- "document this component"
+- "generate docs for this button"
+- "build a Documentation Page"
+- "run tidy-doc"
+- `/tidy-ds:tidy-doc`
+
+## Operation flow
+
+1. Parse an optional node id from the user. If absent, rely on current Figma selection.
+2. Call `tidy_doc_read_component`.
+3. Study the returned facts:
+   - `familyAxis`, `stateAxis`, `sizeAxis`, `demoted`, `pinnedDefaults`
+   - `breakdown` anatomy facts
+   - `modeCollections`
+   - `relatedCandidates`
+4. Author a Doc Spec:
+   - `status` is required. Use user-supplied status if given, otherwise `IDEATION`.
+   - Include only Sections with meaningful content and/or derived renderable facts.
+   - Keep prose within the schema limits and the editorial standard.
+   - Use symbolic references exactly as returned by `read_component`.
+5. Print/log the Doc Spec as compact JSON unless the user asked not to.
+6. Call `tidy_doc_build_page` with `{ nodeId?, docSpec }`.
+7. Report `pageFrameId`, `sourceComponentId`, and any Sections intentionally skipped.
+
+## Never-invent rule
+
+The model may author judgment/prose, but it must never invent derived facts:
+
+- Never invent variant family values, state values, size values, mode ids, measurements, sibling component names, or icon/width/height facts.
+- Never copy measurements into the Doc Spec.
+- Never create a Do/Don't scenario that requires arbitrary nodes or other components. Drop it instead.
+- Never add empty filler just to satisfy a perceived minimum. Minimums are presence-only.
+
+## Re-authoring from unresolved references
+
+If `tidy_doc_build_page` returns `INVALID_PARAMS` with `details.unresolved`:
+
+1. Treat the array as a complete worklist.
+2. Fix every unresolved reference in one pass.
+3. Prefer each item’s `didYouMean` when present and compatible with the intended meaning.
+4. If no compatible real reference exists, drop that Section item/sub-part rather than approximating.
+5. Re-run `tidy_doc_build_page` once with the corrected Doc Spec.
+
+## Output style
+
+Keep the user-facing response short:
+
+- One sentence that the page was built/rebuilt.
+- `pageFrameId` and `sourceComponentId`.
+- Bullet list of Sections included/skipped.
+- If a retry happened, mention it and summarize fixed unresolved refs.

--- a/claude-plugin/skills/tidy-doc/authoring-rules.md
+++ b/claude-plugin/skills/tidy-doc/authoring-rules.md
@@ -1,0 +1,112 @@
+# tidy-doc authoring rules
+
+These rules translate `tidy_doc_read_component` facts into a Doc Spec for `tidy_doc_build_page`.
+
+## Envelope
+
+Always author:
+
+```json
+{ "status": "IDEATION" }
+```
+
+Use a different status only when the user supplies one:
+
+`IDEATION`, `in process`, `DESIGN COMPLETED`, `REVIEWING`, `DEV HAND-OFF`, `ON HOLD`, `CANCELED`, `LIVE`.
+
+Only include optional Section keys when they have meaningful authored content and/or derived renderable facts.
+
+## Variants
+
+Facts used:
+
+- `familyAxis.values` — the only valid `variants` object keys.
+- `familyAxis.name === null` with value `"default"` means a single unnamed family.
+- `stateAxis.values` tells what state-spanning row will render.
+- `pinnedDefaults` explains the non-spanned rest-state conditions.
+
+Authoring:
+
+- Add one entry per family you can describe usefully.
+- `description`: what this family is for, not how it is drawn.
+- `whenToUse`: optional specific conditions; omit if it would be filler.
+- If family is `"default"`, write about the component as a whole.
+- Never use size as a variant family; size belongs in Breakdown.
+
+## Component Breakdown
+
+Facts used:
+
+- `breakdown.heights` — size-axis height measurements and Fixed/Hug/Fill state.
+- `breakdown.width` — min/max width facts when present.
+- `breakdown.iconPlacement` — icon-related component property when detected.
+
+Authoring:
+
+- Include `breakdown` when at least one fact exists and a caption helps interpretation.
+- Captions are optional. Do not restate the exact measurement marker.
+- If no anatomy facts exist, omit `breakdown`; the builder also drops it if empty.
+
+## Mode
+
+Facts used:
+
+- `modeCollections` — multi-mode variable collections bound to the component.
+
+Authoring:
+
+- Include `mode` only when `modeCollections.length > 0`.
+- `caption`: optional; describe what users should compare across modes.
+- Do not list every mode in prose; the builder renders the capped cross-product automatically.
+- Do not invent or reference mode ids in prose.
+
+## Usage Guidelines
+
+Slots:
+
+- `whenToUse`: positive conditions.
+- `whenNotToUse`: negative conditions.
+- `general`: broad rules that do not fit the previous two lists.
+- `doDonts`: worked examples using source-component instances only.
+
+Authoring:
+
+- Include at least one non-empty sub-part or omit `guidelines`.
+- Keep bullets concrete and non-overlapping.
+- Do/Don't pairs require both `good` and `bad` scenes.
+- Each `SpecimenScene` uses 1–4 instances of the source component:
+
+```json
+{ "layout": "row", "instances": [{ "props": { "Type": "Primary" }, "labelOverride": "Optional label" }] }
+```
+
+Rules:
+
+- `props` axis names and values must exist in the categorised axes returned by `read_component`.
+- Use pinned defaults implicitly; only set props needed to show the scenario.
+- If the example needs arbitrary nodes, another component, screenshots, custom text blocks, or complex layout, drop it.
+
+## Related Components
+
+Facts used:
+
+- `relatedCandidates[].name` — the only valid `related` object keys.
+- Candidate order is the render order.
+
+Authoring:
+
+- Select only genuinely related siblings.
+- `guidance`: one sentence explaining when to use the sibling instead of or alongside the source.
+- Do not include a sibling just because it was a candidate.
+- If no candidate is actually related, omit `related`.
+
+## Handling unresolved references
+
+On a batched unresolved payload:
+
+- `slot: "variants", kind: "familyValue"` — replace/drop an invalid variants key.
+- `kind: "axisName"` — fix a Do/Don't scene axis name or drop the scene.
+- `kind: "axisValue"` — fix a Do/Don't scene value or drop the scene.
+- `slot: "related", kind: "siblingName"` — replace/drop a related key.
+
+Fix all entries in the payload before retrying.

--- a/claude-plugin/skills/tidy-doc/button-exemplar.md
+++ b/claude-plugin/skills/tidy-doc/button-exemplar.md
@@ -1,0 +1,121 @@
+# Button exemplar for tidy-doc
+
+Ground-truth reference:
+
+- Figma file key: `CdytzPWDTc7npImeQG0Pnc`
+- Source component node: `2543-1881`
+- Existing documentation node: `2556-2317`
+- Design notes source in this repo: `temp/documentation-idea.md`
+
+This exemplar calibrates prose density, Section intent, and schema limits. It is not copied verbatim into every generated page.
+
+## What the Button doc demonstrates
+
+### Section order
+
+The full documentation pattern is:
+
+1. Variants
+2. Component Breakdown
+3. Mode
+4. Usage Guidelines
+5. Related Components
+
+Cover/footer/branding are out of v1 scope.
+
+### Variants
+
+Button-like components usually split by type/kind family (for example `Primary`, `Secondary`, `Tertiary`, `Ghost`) and show state-spanning specimens (`Regular`/`Hover`/`Pressed`/`Disabled`, or equivalent). Good variant prose explains **decision context**:
+
+- Primary: the main action in a focused flow.
+- Secondary: supporting actions near a primary action.
+- Tertiary/Ghost: lower-emphasis actions or dense surfaces.
+
+Avoid visual-only prose like "This button is blue" unless the color itself is the usage distinction.
+
+### Component Breakdown
+
+The Button example uses anatomy documentation for size/height, width behavior, and icon support. Captions should interpret why the measurement matters, not duplicate the marker:
+
+- Good: "Height scales by size while preserving the same interaction target pattern."
+- Avoid: "The height is 40 px." (the marker already shows it)
+
+### Mode
+
+Mode examples document the component under theme/brand/density modes when bound variable collections exist. The caption should set the review intent:
+
+> Compare the component across supported themes to check contrast, emphasis, and token-driven color changes.
+
+The mode list itself is derived and rendered by the builder.
+
+### Usage Guidelines
+
+Good guidance is operational:
+
+- Use for the main action in a form, dialog, or focused workflow.
+- Avoid stacking multiple primary actions in the same decision area.
+- Keep labels action-oriented and concise.
+
+Do/Don't examples should be simple source-component scenes. If a Button example would require a full surrounding layout, illustration, or a second unrelated component, skip it.
+
+### Related Components
+
+The Button exemplar surfaces siblings by token containment, not prefix: `Icon Button`, `Link Button`, and `Severity Button` are all related to `Button`. Guidance should explain choice:
+
+- Use `Icon Button` when the action is compact and can be represented by a widely understood icon.
+- Use `Link Button` for navigational actions that should read like inline or low-emphasis text.
+- Use `Severity Button` when action emphasis is tied to destructive, warning, or success semantics.
+
+## Example Doc Spec shape
+
+This is illustrative. Real values must come from `tidy_doc_read_component` for the selected component.
+
+```json
+{
+  "status": "IDEATION",
+  "variants": {
+    "Primary": {
+      "description": "Use Primary for the main action in a focused flow.",
+      "whenToUse": ["When the page or dialog has one clear next step."]
+    },
+    "Secondary": {
+      "description": "Use Secondary for supporting actions that sit near a primary action.",
+      "whenToUse": ["When the action is useful but not the main path."]
+    }
+  },
+  "breakdown": {
+    "heightCaption": "Height scales by size while preserving consistent interaction targets.",
+    "iconPlacementCaption": "Icon variants reserve space for a leading symbol without changing the label rhythm."
+  },
+  "mode": {
+    "caption": "Compare modes to verify token-driven contrast and emphasis changes."
+  },
+  "guidelines": {
+    "whenToUse": ["Use for actions that submit, confirm, continue, or trigger a clear task."],
+    "whenNotToUse": ["Avoid multiple primary buttons in the same decision area."],
+    "general": ["Keep labels short, specific, and action-led."],
+    "doDonts": [
+      {
+        "description": "Reserve Primary for the main action in a group.",
+        "good": { "layout": "row", "instances": [{ "props": { "Type": "Primary" }, "labelOverride": "Save" }] },
+        "bad": { "layout": "row", "instances": [{ "props": { "Type": "Primary" }, "labelOverride": "Save" }, { "props": { "Type": "Primary" }, "labelOverride": "Cancel" }] }
+      }
+    ]
+  },
+  "related": {
+    "Icon Button": { "guidance": "Use Icon Button when the action is compact and the icon is universally understood." }
+  }
+}
+```
+
+## Limit calibration
+
+The current schema limits are intentionally short and match the exemplar's density:
+
+- variant descriptions ≤240
+- variant bullets ≤6 × ≤120
+- breakdown/mode captions ≤200
+- guideline lists ≤8 items
+- related guidance ≤160
+
+If real Button prose needs to exceed these limits, tune the schema and this exemplar together.

--- a/claude-plugin/skills/tidy-doc/kido-editorial-standard.md
+++ b/claude-plugin/skills/tidy-doc/kido-editorial-standard.md
@@ -1,0 +1,65 @@
+# Kido editorial standard for generated component documentation
+
+This standard governs authored prose in tidy-doc Doc Specs. Layout, measurements, modes, variant names, and specimens are generated from code/facts; this document covers the words the model authors.
+
+## Voice
+
+- Clear, practical, and design-system-native.
+- Write as guidance for a designer using the component in a product UI.
+- Prefer active voice and concrete usage conditions.
+- Be helpful without sounding promotional.
+
+Good:
+
+> Use Primary for the main action on a page or in a focused flow.
+
+Avoid:
+
+> Primary buttons are beautiful, flexible, and perfect for many situations.
+
+## Tone
+
+- Calm and direct.
+- No hype, jokes, or brand voice flourishes.
+- No speculative product claims.
+- No apologies or caveats unless the component facts genuinely require them.
+
+## Length
+
+Use the schema limits as hard maxima and these editorial targets as soft guidance:
+
+- Variant `description`: 1 sentence, usually 80–180 characters, max 240.
+- Variant `whenToUse`: 1–4 bullets, max 6; each bullet one specific condition.
+- Breakdown captions: 0–1 sentence, max 200. Omit when the measurement is self-explanatory.
+- Mode caption: 0–1 sentence, max 200. Explain what changes across modes, not the mode list itself.
+- Guidelines bullets: 2–5 bullets when present, never filler.
+- Do/Don't `description`: one short scenario/rationale, max 200.
+- Related `guidance`: 1 sentence in the form "Use X when …", max 160.
+
+## Wording rules
+
+- Prefer "Use … when …" for prescriptive guidance.
+- Prefer "Avoid … when …" for negative guidance.
+- Use component names exactly as returned by `read_component`.
+- Use variant values exactly as returned by `read_component` when referring to a concrete family/state/size.
+- Do not mention implementation details like `pinnedDefaults`, `setExplicitVariableModeForCollection`, or `Doc Spec` in rendered prose.
+- Do not over-explain obvious facts already shown by the specimen or marker.
+
+## Never invent
+
+Authored prose may interpret intent, but must not manufacture facts:
+
+- Do not invent variant values, modes, measurements, sibling names, icon support, width constraints, or state availability.
+- If the fact is absent, omit the corresponding statement or Section.
+- If a usage rule would require a non-component scene, drop the Do/Don't example.
+
+## Consistency calibration
+
+The Button exemplar is the calibration source for density and style:
+
+- Short paragraphs, not marketing copy.
+- Practical "when to use" bullets.
+- Anatomy captions only where they add interpretation.
+- Related guidance explains choice between real sibling components.
+
+If the exemplar and schema disagree, the schema wins. If the schema limits feel too tight in practice, file a follow-up to tune the Zod limits and this standard together.

--- a/docs/plugin-dev.md
+++ b/docs/plugin-dev.md
@@ -37,7 +37,7 @@ dist-plugin/                          ← marketplace root
 
 Then `/reload-plugins` (or restart Claude Code). The commands appear namespaced:
 `/tidy-ds:tidy-find`, `/tidy-ds:tidy-misprint`, `/tidy-ds:tidy-labels`,
-`/tidy-ds:tidy-ds`, `/tidy-ds:tidy-ds-template`.
+`/tidy-ds:tidy-ds`, `/tidy-ds:tidy-ds-template`, `/tidy-ds:tidy-doc`.
 
 The plugin's MCP server starts automatically; its tools are exposed as
 `mcp__plugin_tidy-ds_tidy-ds-toolbox__<operation>`.
@@ -58,6 +58,8 @@ plugin open and connected over the bridge. To verify end-to-end:
    bridge on `9876`.
 2. In Claude Code (with the plugin installed), run `/tidy-ds:tidy-find` and
    confirm it returns components from the open file.
+3. Select a component/component set in Figma and run `/tidy-ds:tidy-doc dry-run=true`
+   to confirm the tidy-doc skill can read facts and author a Doc Spec without rendering.
 3. On `BRIDGE_DISCONNECTED`, the Figma plugin isn't running — open it.
 
 ## Inner loop (no plugin)

--- a/docs/tidy-doc.md
+++ b/docs/tidy-doc.md
@@ -1,0 +1,173 @@
+# tidy-doc — generate component documentation pages
+
+`tidy-doc` generates a full Figma Documentation Page for a selected component or component set. It is driven from Claude Code through the Tidy DS Toolbox Claude plugin and the local Figma bridge.
+
+## What it builds
+
+A generated page is a fixed ordered set of Section cards:
+
+1. **Variants** — one family block per type/kind value, with authored prose and state-spanning specimens.
+2. **Component Breakdown** — derived anatomy facts: Height, Width, Icon placement.
+3. **Mode** — auto-detected variable-mode showcases, crossed and capped at 8.
+4. **Usage Guidelines** — when-to-use / when-not-to-use / general bullets plus Do/Don't examples.
+5. **Related Components** — selected sibling components from the file-wide candidate scan.
+
+Sections with no useful content or no applicable derived facts are skipped. The output is tool-owned: re-running deletes the previous generated page for that source component and rebuilds it.
+
+## Install / setup
+
+### 1. Build and load the Figma plugin
+
+```bash
+npm run build
+```
+
+In Figma Desktop:
+
+1. Plugins → Development → Import plugin from manifest.
+2. Select this repo's `manifest.json`.
+3. Run **Tidy DS Toolbox** in the file that contains the component.
+4. Keep the plugin window open so the localhost bridge stays connected.
+
+### 2. Install the Claude Code plugin locally
+
+```bash
+npm run build:plugin
+```
+
+In Claude Code:
+
+```text
+/plugin marketplace add /absolute/path/to/repo/dist-plugin
+/plugin install tidy-ds@tidy-ds-marketplace
+/reload-plugins
+```
+
+The MCP tools are exposed by the bundled server. The slash command is namespaced:
+
+```text
+/tidy-ds:tidy-doc
+```
+
+## Basic usage
+
+1. Select a `COMPONENT` or `COMPONENT_SET` in Figma.
+2. Ensure the Tidy DS Toolbox plugin is open.
+3. In Claude Code, run:
+
+```text
+/tidy-ds:tidy-doc
+```
+
+Claude will:
+
+1. call `tidy_doc_read_component`,
+2. author and print a compact Doc Spec,
+3. call `tidy_doc_build_page`,
+4. report the generated `pageFrameId`.
+
+No separate approval step is required. The rendered Figma page is the review surface.
+
+## Arguments
+
+```text
+/tidy-ds:tidy-doc [nodeId] [status=<StatusEnum>] [sections=<list>] [dry-run=true]
+```
+
+Examples:
+
+```text
+/tidy-ds:tidy-doc
+/tidy-ds:tidy-doc 2543:1881 status=REVIEWING
+/tidy-ds:tidy-doc sections=variants,breakdown,related
+/tidy-ds:tidy-doc dry-run=true
+```
+
+### `nodeId`
+
+Optional Figma node id. If omitted, the Operations use the current Figma selection.
+
+### `status`
+
+Optional page status. Allowed values:
+
+- `IDEATION`
+- `in process`
+- `DESIGN COMPLETED`
+- `REVIEWING`
+- `DEV HAND-OFF`
+- `ON HOLD`
+- `CANCELED`
+- `LIVE`
+
+Default: `IDEATION`.
+
+### `sections`
+
+Optional comma-list limiting authored Sections:
+
+```text
+variants,breakdown,mode,guidelines,related
+```
+
+Even when requested, a Section can still be skipped if the component has no derived facts for it.
+
+### `dry-run=true`
+
+Reads facts and authors the Doc Spec, but does not build the Figma page.
+
+Use this to inspect the proposed content before rendering.
+
+## How references work
+
+The Doc Spec never carries measurements or raw derived facts. It carries prose plus symbolic references:
+
+- `variants` keys must match `familyAxis.values` from `read_component`.
+- Do/Don't scene `props` must use real axis names and values.
+- `related` keys must match `relatedCandidates[].name`.
+- Mode showcases are derived automatically from `modeCollections`; the Doc Spec only provides an optional caption.
+
+`tidy_doc_build_page` re-reads the live component and rejects unresolved references in one batched payload with `didYouMean` hints. The skill then re-authors and retries once.
+
+## Editorial rules
+
+The shipped skill includes:
+
+- `claude-plugin/skills/tidy-doc/kido-editorial-standard.md`
+- `claude-plugin/skills/tidy-doc/authoring-rules.md`
+- `claude-plugin/skills/tidy-doc/button-exemplar.md`
+
+In short:
+
+- keep prose short, practical, and design-system-native;
+- never invent variant names, measurements, modes, or sibling names;
+- do not add filler to satisfy imagined minimums;
+- drop unrepresentable Do/Don't ideas rather than approximating them.
+
+## Troubleshooting
+
+### `BRIDGE_DISCONNECTED`
+
+Open the Tidy DS Toolbox Figma plugin in the file and run the command again.
+
+### `WRONG_NODE_TYPE`
+
+Select a `COMPONENT` or `COMPONENT_SET`, or pass a valid node id.
+
+### Schema validation errors
+
+The authored Doc Spec exceeded a length/count limit or malformed a slot. Shorten/restructure and retry.
+
+### Unresolved references
+
+The component changed or the Doc Spec referenced a non-existent symbolic value. Use the returned `details.unresolved` list and `didYouMean` hints to re-author all broken references in one pass.
+
+## Developer notes
+
+Canonical plugin assets live in `claude-plugin/` and are assembled into `dist-plugin/` by:
+
+```bash
+npm run build:plugin
+```
+
+The Figma-side implementation lives under `src/plugins/tidy-doc/`. The operation catalogue lives in `mcp-server/src/catalogue.ts`.

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -8,6 +8,7 @@
 
 import { z } from "zod";
 import type { OperationKind } from "../../src/shared/operations/types.ts";
+import { DocSpecSchema } from "../../src/plugins/tidy-doc/utils/docSpec.ts";
 
 export interface CatalogueEntry {
   id: string;
@@ -215,6 +216,40 @@ export const CATALOGUE: CatalogueEntry[] = [
         .describe(
           "How far to de-link the clone from Kido-DS. 'none' = keep all links (old behavior); 'detach' = detach nested instances into frames; 'styles' = localize paint/text/effect styles; 'full' (default) = both. Variables/tokens are always left bound to Kido-DS.",
         ),
+    },
+    timeoutMs: 60_000,
+  },
+  {
+    id: "tidy_doc_read_component",
+    kind: "query",
+    module: "tidy-doc",
+    summary:
+      "Return the derived variant categorisation for a component or component set: chosen family axis + values, state axis + values, demoted axes (folded into pinned rest-state defaults), and pinned rest-state defaults for every non-family axis. Pass nodeId, or omit it to use the current selection. Authoring a Doc Spec's `variants` keys against `familyAxis.values` is the intended next step.",
+    inputSchema: {
+      nodeId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional Figma node id of a COMPONENT or COMPONENT_SET. If omitted, the current selection is used.",
+        ),
+    },
+  },
+  {
+    id: "tidy_doc_build_page",
+    kind: "execute",
+    module: "tidy-doc",
+    summary:
+      "Build (or replace) a Documentation Page next to the source component: Chrome (card + header + status badge) plus a Variants Section with one specimen per keyed family value. Re-running for the same source deletes the prior page and rebuilds fresh. `docSpec.variants` keys must be real family-axis values from tidy_doc_read_component; an unresolved key fails the whole call with a batched INVALID_PARAMS error (`details.unresolved`, with `didYouMean` hints) rather than failing on the first bad key.",
+    inputSchema: {
+      nodeId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional Figma node id of a COMPONENT or COMPONENT_SET. If omitted, the current selection is used.",
+        ),
+      docSpec: DocSpecSchema.describe(
+        "The Doc Spec. `status` is required; `variants` maps a family-axis value (from tidy_doc_read_component) to an authored description (+ optional whenToUse bullets). breakdown/mode/guidelines/related are accepted for forward-compatibility but not yet rendered.",
+      ),
     },
     timeoutMs: 60_000,
   },

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -224,7 +224,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "query",
     module: "tidy-doc",
     summary:
-      "Return the derived variant categorisation for a component or component set: chosen family axis + values, state axis + values, demoted axes (folded into pinned rest-state defaults), and pinned rest-state defaults for every non-family axis. Pass nodeId, or omit it to use the current selection. Authoring a Doc Spec's `variants` keys against `familyAxis.values` is the intended next step.",
+      "Return the derived variant categorisation for a component or component set: chosen family axis + values, state axis + values, demoted axes (folded into pinned rest-state defaults), and pinned rest-state defaults for every non-family axis. Also returns `relatedCandidates`: a capped, ranked list of sibling components found by a file-wide name-token-overlap scan, excluding the source's own variants and its nested building-block components. Pass nodeId, or omit it to use the current selection. Authoring a Doc Spec's `variants` keys against `familyAxis.values`, and its `related` keys against `relatedCandidates`, is the intended next step.",
     inputSchema: {
       nodeId: z
         .string()
@@ -239,7 +239,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "execute",
     module: "tidy-doc",
     summary:
-      "Build (or replace) a Documentation Page next to the source component: Chrome (card + header + status badge) plus a Variants Section with one specimen per keyed family value. Re-running for the same source deletes the prior page and rebuilds fresh. `docSpec.variants` keys must be real family-axis values from tidy_doc_read_component; an unresolved key fails the whole call with a batched INVALID_PARAMS error (`details.unresolved`, with `didYouMean` hints) rather than failing on the first bad key.",
+      "Build (or replace) a Documentation Page next to the source component: Chrome (card + header + status badge) plus a Variants Section (one specimen per keyed family value) and a Related Components Section (one specimen per keyed sibling, in candidate-rank order). Re-running for the same source deletes the prior page and rebuilds fresh. `docSpec.variants` keys must be real family-axis values and `docSpec.related` keys must be real sibling-candidate names, both from tidy_doc_read_component; an unresolved key fails the whole call with a batched INVALID_PARAMS error (`details.unresolved`, with `didYouMean` hints) rather than failing on the first bad key.",
     inputSchema: {
       nodeId: z
         .string()

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -224,7 +224,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "query",
     module: "tidy-doc",
     summary:
-      "Return the derived variant categorisation for a component or component set: chosen family axis + values, state axis + values, demoted axes (folded into pinned rest-state defaults), and pinned rest-state defaults for every non-family axis. Pass nodeId, or omit it to use the current selection. Authoring a Doc Spec's `variants` keys against `familyAxis.values` is the intended next step.",
+      "Return the derived variant categorisation for a component or component set: chosen family axis + values, state axis + values, demoted axes (folded into pinned rest-state defaults), and pinned rest-state defaults for every non-family axis. Also returns `breakdown`: derived Component Breakdown facts — `heights` (real height + Fixed/Hug/Fill per size-axis value), `width` (minWidth/maxWidth, when set), and `iconPlacement` (detected icon property + values, when present). Pass nodeId, or omit it to use the current selection. Authoring a Doc Spec's `variants` keys against `familyAxis.values` is the intended next step.",
     inputSchema: {
       nodeId: z
         .string()
@@ -239,7 +239,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "execute",
     module: "tidy-doc",
     summary:
-      "Build (or replace) a Documentation Page next to the source component: Chrome (card + header + status badge) plus a Variants Section with one specimen per keyed family value. Re-running for the same source deletes the prior page and rebuilds fresh. `docSpec.variants` keys must be real family-axis values from tidy_doc_read_component; an unresolved key fails the whole call with a batched INVALID_PARAMS error (`details.unresolved`, with `didYouMean` hints) rather than failing on the first bad key.",
+      "Build (or replace) a Documentation Page next to the source component: Chrome (card + header + status badge) plus a Variants Section (one specimen per keyed family value) and a Component Breakdown Section (Height/Width/Icon placement sub-sections, each rendered only when the component exposes the fact). Re-running for the same source deletes the prior page and rebuilds fresh. `docSpec.variants` keys must be real family-axis values from tidy_doc_read_component; an unresolved key fails the whole call with a batched INVALID_PARAMS error (`details.unresolved`, with `didYouMean` hints) rather than failing on the first bad key.",
     inputSchema: {
       nodeId: z
         .string()
@@ -248,7 +248,7 @@ export const CATALOGUE: CatalogueEntry[] = [
           "Optional Figma node id of a COMPONENT or COMPONENT_SET. If omitted, the current selection is used.",
         ),
       docSpec: DocSpecSchema.describe(
-        "The Doc Spec. `status` is required; `variants` maps a family-axis value (from tidy_doc_read_component) to an authored description (+ optional whenToUse bullets). breakdown/mode/guidelines/related are accepted for forward-compatibility but not yet rendered.",
+        "The Doc Spec. `status` is required; `variants` maps a family-axis value (from tidy_doc_read_component) to an authored description (+ optional whenToUse bullets). `breakdown` (optional) triggers the Component Breakdown Section — presence-only optional captions (`heightCaption`/`widthCaption`/`iconPlacementCaption`); each sub-section still only renders when the corresponding derived fact exists, and the whole Section is dropped (and logged) if none do. mode/guidelines/related are accepted for forward-compatibility but not yet rendered.",
       ),
     },
     timeoutMs: 60_000,

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -233,6 +233,7 @@ export const CATALOGUE: CatalogueEntry[] = [
           "Optional Figma node id of a COMPONENT or COMPONENT_SET. If omitted, the current selection is used.",
         ),
     },
+    timeoutMs: 60_000,
   },
   {
     id: "tidy_doc_build_page",

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -224,7 +224,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "query",
     module: "tidy-doc",
     summary:
-      "Return the derived facts for a component or component set: variant categorisation (chosen family axis + values, state axis + values, demoted axes, pinned defaults), `breakdown` anatomy facts (height/width/icon placement), and `relatedCandidates` (ranked sibling components from a file-wide token-overlap scan). Pass nodeId, or omit it to use the current selection. Authoring a Doc Spec's `variants` keys against `familyAxis.values`, and its `related` keys against `relatedCandidates`, is the intended next step.",
+      "Return the derived facts for a component or component set: variant categorisation (chosen family axis + values, state axis + values, demoted axes, pinned defaults), `breakdown` anatomy facts (height/width/icon placement), `modeCollections` (multi-mode variable collections the component is bound to), and `relatedCandidates` (ranked sibling components from a file-wide token-overlap scan). Pass nodeId, or omit it to use the current selection. Authoring a Doc Spec's `variants` keys against `familyAxis.values`, and its `related` keys against `relatedCandidates`, is the intended next step.",
     inputSchema: {
       nodeId: z
         .string()
@@ -239,7 +239,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "execute",
     module: "tidy-doc",
     summary:
-      "Build (or replace) a Documentation Page next to the source component: Chrome (card + header + status badge) plus Variants, Component Breakdown, Usage Guidelines, and Related Components Sections when their Doc Spec keys and derived facts provide content. Re-running for the same source deletes the prior page and rebuilds fresh. Symbolic references (variant family values, Do/Don't axis values, related sibling names) are resolved against live derived facts and fail with a batched INVALID_PARAMS payload (`details.unresolved`, with `didYouMean` hints).",
+      "Build (or replace) a Documentation Page next to the source component: Chrome (card + header + status badge) plus Variants, Component Breakdown, Mode, Usage Guidelines, and Related Components Sections when their Doc Spec keys and derived facts provide content. Re-running for the same source deletes the prior page and rebuilds fresh. Symbolic references (variant family values, Do/Don't axis values, related sibling names) are resolved against live derived facts and fail with a batched INVALID_PARAMS payload (`details.unresolved`, with `didYouMean` hints)."
     inputSchema: {
       nodeId: z
         .string()
@@ -248,7 +248,7 @@ export const CATALOGUE: CatalogueEntry[] = [
           "Optional Figma node id of a COMPONENT or COMPONENT_SET. If omitted, the current selection is used.",
         ),
       docSpec: DocSpecSchema.describe(
-        "The Doc Spec. `status` is required; `variants` maps family-axis values to authored descriptions (+ optional whenToUse bullets). `breakdown` triggers derived anatomy sub-sections when facts exist. `guidelines` renders bullet lists and Do/Don't SpecimenScenes. `related` maps exact sibling-candidate names to authored guidance. `mode` is accepted for forward-compatibility but not yet rendered.",
+        "The Doc Spec. `status` is required; `variants` maps family-axis values to authored descriptions (+ optional whenToUse bullets). `breakdown` triggers derived anatomy sub-sections when facts exist. `mode` triggers auto-detected, capped mode showcases with an optional caption. `guidelines` renders bullet lists and Do/Don't SpecimenScenes. `related` maps exact sibling-candidate names to authored guidance.",
       ),
     },
     timeoutMs: 60_000,

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -239,7 +239,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "execute",
     module: "tidy-doc",
     summary:
-      "Build (or replace) a Documentation Page next to the source component: Chrome (card + header + status badge) plus Variants, Component Breakdown, Mode, Usage Guidelines, and Related Components Sections when their Doc Spec keys and derived facts provide content. Re-running for the same source deletes the prior page and rebuilds fresh. Symbolic references (variant family values, Do/Don't axis values, related sibling names) are resolved against live derived facts and fail with a batched INVALID_PARAMS payload (`details.unresolved`, with `didYouMean` hints)."
+      "Build (or replace) a Documentation Page next to the source component: Chrome (card + header + status badge) plus Variants, Component Breakdown, Mode, Usage Guidelines, and Related Components Sections when their Doc Spec keys and derived facts provide content. Re-running for the same source deletes the prior page and rebuilds fresh. Symbolic references (variant family values, Do/Don't axis values, related sibling names) are resolved against live derived facts and fail with a batched INVALID_PARAMS payload (`details.unresolved`, with `didYouMean` hints).",
     inputSchema: {
       nodeId: z
         .string()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "tidy-ds-toolbox",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tidy-ds-toolbox",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "ISC",
       "dependencies": {
         "@tabler/icons-react": "^3.35.0",
         "fflate": "^0.8.2",
         "pdf-lib": "^1.17.1",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -6678,10 +6679,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.13.tgz",
-      "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
-      "dev": true,
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tidy-ds-toolbox",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -63,6 +63,7 @@
     "fflate": "^0.8.2",
     "pdf-lib": "^1.17.1",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "zod": "^3.23.8"
   }
 }

--- a/scripts/assemble-plugin.mjs
+++ b/scripts/assemble-plugin.mjs
@@ -98,6 +98,10 @@ Update later with \`/plugin update\`.
 The \`/tidy-*\` commands are namespaced (\`/tidy-ds:tidy-find\`, …) and the MCP
 server starts automatically. The commands round-trip to the Tidy DS Toolbox
 Figma plugin over a localhost bridge — open that plugin in Figma for them to work.
+
+For component documentation, select a component or component set in Figma and run
+\`/tidy-ds:tidy-doc\` in Claude Code. See \`docs/tidy-doc.md\` in the source repo
+for the full usage guide.
 `;
 writeFileSync(join(outRoot, "README.md"), readme);
 
@@ -118,6 +122,7 @@ for (const cmd of [
   "tidy-labels",
   "tidy-ds",
   "tidy-ds-template",
+  "tidy-doc",
 ]) {
   assert(
     existsSync(join(pluginOut, "commands", `${cmd}.md`)),

--- a/src/code.ts
+++ b/src/code.ts
@@ -28,6 +28,12 @@ const LONG_RUNNING_ACTIONS = new Set([
   // timeout on large files. Emits progress updates while it runs.
   "color-finder:scan-colors",
   "color-finder:scan-image-palette",
+  // Every MCP-invoked Operation arrives here as target "mcp-bridge", action
+  // "dispatch" — the specific operation id is opaque at this layer, so a
+  // single blanket exemption is the only way to honor a catalogue entry's
+  // own timeoutMs (mcp-server/src/catalogue.ts), enforced instead at the
+  // Bridge layer (mcp-server/src/bridge-server.ts).
+  "mcp-bridge:dispatch",
 ]);
 
 // Create logger for main thread

--- a/src/moduleHandlers.ts
+++ b/src/moduleHandlers.ts
@@ -5,6 +5,7 @@ import type { AuditAction } from "./plugins/audit/types";
 import type { ReleaseNotesAction } from "./plugins/release-notes/types";
 import type { OffBoardingAction } from "./plugins/off-boarding/types";
 import type { TidyColorFinderAction } from "./plugins/color-finder/types";
+import type { TidyDocAction } from "./plugins/tidy-doc/types";
 import type { BuildData } from "./plugins/ds-explorer/types";
 
 import { dispatch as dispatchOperation } from "./shared/operations/registry";
@@ -25,6 +26,7 @@ import { releaseNotesHandler as releaseNotesLogic } from "./plugins/release-note
 import { offBoardingHandler as offBoardingLogic } from "./plugins/off-boarding/logic";
 import { iconFinderHandler as iconFinderLogic } from "./plugins/iconfinder/logic";
 import { tidyColorFinderHandler as colorFinderLogic } from "./plugins/color-finder/logic";
+import { tidyDocHandler as tidyDocLogic } from "./plugins/tidy-doc/logic";
 
 // Module handlers - static imports only
 const dsExplorerHandler = async (
@@ -136,6 +138,14 @@ const colorFinderHandler = async (
   );
 };
 
+const tidyDocModuleHandler = async (
+  action: string,
+  payload: unknown,
+  figma: PluginAPI,
+) => {
+  return await tidyDocLogic(action as TidyDocAction, payload, figma);
+};
+
 // MCP Bridge handler: the UI iframe holds the WebSocket to the MCP server and
 // relays each incoming BridgeRequest envelope here as { action: "dispatch",
 // payload: envelope }. We dispatch through the Operation registry and return
@@ -162,5 +172,6 @@ export const moduleHandlers: Record<
   "off-boarding": offBoardingHandler,
   iconfinder: iconFinderHandler,
   "color-finder": colorFinderHandler,
+  "tidy-doc": tidyDocModuleHandler,
   "mcp-bridge": mcpBridgeHandler,
 };

--- a/src/moduleRegistry.ts
+++ b/src/moduleRegistry.ts
@@ -11,6 +11,7 @@ import {
   IconPackage,
   IconSearch,
   IconPalette,
+  IconFileDescription,
 } from "@tabler/icons-react";
 import { DSExplorerUI } from "./plugins/ds-explorer/ui";
 import { ComponentLabelsUI } from "./plugins/component-labels/ui";
@@ -23,6 +24,7 @@ import { ReleaseNotesUI } from "./plugins/release-notes/ui";
 import { OffBoardingUI } from "./plugins/off-boarding/ui";
 import { IconFinderUI } from "./plugins/iconfinder/ui";
 import { TidyColorFinderUI } from "./plugins/color-finder/ui";
+import { TidyDocUI } from "./plugins/tidy-doc/ui";
 import { moduleHandlers } from "./moduleHandlers";
 
 export const moduleRegistry: ModuleRegistry = {
@@ -293,5 +295,16 @@ export const moduleRegistry: ModuleRegistry = {
       "untokenized",
       "inventory",
     ],
+  },
+  "tidy-doc": {
+    id: "tidy-doc",
+    label: "Tidy Doc",
+    state: "alpha",
+    icon: IconFileDescription,
+    ui: TidyDocUI,
+    handler: moduleHandlers["tidy-doc"],
+    permissionRequirements: ["activeselection"],
+    agentified: true,
+    keywords: ["documentation", "doc", "component", "generate", "variants"],
   },
 };

--- a/src/plugins/component-labels/operations.ts
+++ b/src/plugins/component-labels/operations.ts
@@ -3,56 +3,22 @@
 
 import { ErrorCode, OperationError } from "../../shared/operations/errors";
 import { registerOperation } from "../../shared/operations/registry";
+import { resolveComponentByIdOrSelection } from "../../shared/operations/resolveComponent";
 import { findAllVariantProps } from "./utils/getVariantProps";
 import { executeBuildLabels } from "./logic";
 import { LabelConfig, VariantProperty } from "./types";
+
+const COMPONENT_SET_ONLY = ["COMPONENT_SET"] as const;
 
 /**
  * Resolve the target component set from an optional nodeId, falling back to
  * the current selection. Throws typed errors if the target is missing or
  * not a component set.
  */
-async function resolveComponentSet(
+function resolveComponentSet(
   nodeId: string | undefined,
 ): Promise<ComponentSetNode> {
-  if (nodeId) {
-    const node = await figma.getNodeByIdAsync(nodeId);
-    if (!node) {
-      throw new OperationError(
-        ErrorCode.NOT_FOUND,
-        `node ${nodeId} not found`,
-        true,
-        { nodeId },
-      );
-    }
-    if (node.type !== "COMPONENT_SET") {
-      throw new OperationError(
-        ErrorCode.WRONG_NODE_TYPE,
-        `node ${nodeId} is ${node.type}, expected COMPONENT_SET`,
-        true,
-        { nodeId, type: node.type },
-      );
-    }
-    return node;
-  }
-
-  const selection = figma.currentPage.selection;
-  if (selection.length === 0) {
-    throw new OperationError(
-      ErrorCode.INVALID_PARAMS,
-      "no nodeId provided and nothing is selected — select a component set or pass nodeId",
-    );
-  }
-  const first = selection[0];
-  if (first.type !== "COMPONENT_SET") {
-    throw new OperationError(
-      ErrorCode.WRONG_NODE_TYPE,
-      `selected node is ${first.type}, expected COMPONENT_SET`,
-      true,
-      { nodeId: first.id, type: first.type },
-    );
-  }
-  return first;
+  return resolveComponentByIdOrSelection(nodeId, COMPONENT_SET_ONLY);
 }
 
 interface GetVariantPropsParams {

--- a/src/plugins/tidy-doc/logic.ts
+++ b/src/plugins/tidy-doc/logic.ts
@@ -34,7 +34,7 @@ async function documentSelection(): Promise<DocumentSelectionResult> {
     );
   }
 
-  const facts = deriveFacts(source);
+  const facts = await deriveFacts(source);
   const spec: DocSpec = {
     status: "IDEATION",
     variants: Object.fromEntries(

--- a/src/plugins/tidy-doc/logic.ts
+++ b/src/plugins/tidy-doc/logic.ts
@@ -1,0 +1,75 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Backend handler for the Tidy Doc module UI. Signature matches the parent
+// Tidy DS Toolbox module contract `(action, payload, figma?) => Promise<any>`.
+//
+// The primary consumer of tidy-doc is the skill calling the Operations in
+// operations.ts over MCP, not this UI — see CLAUDE.md/#51. This handler only
+// backs the minimal in-plugin shell: a bound fileKey readout and the
+// fallback "Document selection" button.
+
+import { TidyDocAction, GetContextResult, DocumentSelectionResult } from "./types";
+import { deriveFacts } from "./utils/deriveFacts";
+import { buildDocPage } from "./utils/buildDocPage";
+import type { DocSpec } from "./utils/docSpec";
+
+function getContext(): GetContextResult {
+  return { fileKey: figma.fileKey ?? null };
+}
+
+/**
+ * Facts-only build: no authored prose. Each family value's description is a
+ * derived sentence, never an invented judgment, so the fallback button's
+ * "facts-only" contract stays literal.
+ */
+async function documentSelection(): Promise<DocumentSelectionResult> {
+  const selection = figma.currentPage.selection;
+  if (selection.length !== 1) {
+    throw new Error("Select exactly one component or component set to document.");
+  }
+  const [source] = selection;
+  if (source.type !== "COMPONENT" && source.type !== "COMPONENT_SET") {
+    throw new Error(
+      `Selected node is ${source.type}, expected COMPONENT or COMPONENT_SET.`,
+    );
+  }
+
+  const facts = deriveFacts(source);
+  const spec: DocSpec = {
+    status: "IDEATION",
+    variants: Object.fromEntries(
+      facts.familyAxis.values.map((value) => [
+        value,
+        {
+          description:
+            facts.familyAxis.name === null
+              ? `The \`${source.name}\` component.`
+              : `\`${value}\` variant of \`${source.name}\`.`,
+        },
+      ]),
+    ),
+  };
+
+  const root = await buildDocPage(source, spec);
+  return {
+    pageFrameId: root.id,
+    sourceComponentId: source.id,
+    sourceComponentName: source.name,
+  };
+}
+
+export async function tidyDocHandler(
+  action: TidyDocAction,
+  _payload: unknown,
+  _figma?: PluginAPI,
+): Promise<unknown> {
+  switch (action) {
+    case "get-context":
+      return getContext();
+    case "document-selection":
+      return await documentSelection();
+    default:
+      console.warn(`Unknown action: ${action}`);
+      return null;
+  }
+}

--- a/src/plugins/tidy-doc/logic.ts
+++ b/src/plugins/tidy-doc/logic.ts
@@ -8,7 +8,11 @@
 // backs the minimal in-plugin shell: a bound fileKey readout and the
 // fallback "Document selection" button.
 
-import { TidyDocAction, GetContextResult, DocumentSelectionResult } from "./types";
+import {
+  TidyDocAction,
+  GetContextResult,
+  DocumentSelectionResult,
+} from "./types";
 import { deriveFacts } from "./utils/deriveFacts";
 import { buildDocPage } from "./utils/buildDocPage";
 import type { DocSpec } from "./utils/docSpec";
@@ -25,7 +29,9 @@ function getContext(): GetContextResult {
 async function documentSelection(): Promise<DocumentSelectionResult> {
   const selection = figma.currentPage.selection;
   if (selection.length !== 1) {
-    throw new Error("Select exactly one component or component set to document.");
+    throw new Error(
+      "Select exactly one component or component set to document.",
+    );
   }
   const [source] = selection;
   if (source.type !== "COMPONENT" && source.type !== "COMPONENT_SET") {

--- a/src/plugins/tidy-doc/operations.ts
+++ b/src/plugins/tidy-doc/operations.ts
@@ -32,7 +32,7 @@ registerOperation<ReadComponentParams, DerivedFacts>(
   },
   async (params) => {
     const source = await resolveComponent(params.nodeId);
-    return deriveFacts(source);
+    return await deriveFacts(source);
   },
 );
 

--- a/src/plugins/tidy-doc/operations.ts
+++ b/src/plugins/tidy-doc/operations.ts
@@ -1,0 +1,73 @@
+// Operation handlers for the tidy-doc module. Registered into the global
+// Operation registry at module load (via src/shared/operations/register-all.ts).
+
+import { ErrorCode, OperationError } from "../../shared/operations/errors";
+import { registerOperation } from "../../shared/operations/registry";
+import { resolveComponentByIdOrSelection } from "../../shared/operations/resolveComponent";
+import { deriveFacts } from "./utils/deriveFacts";
+import { buildDocPage } from "./utils/buildDocPage";
+import { DocSpecSchema, type DocSpec } from "./utils/docSpec";
+import type { DerivedFacts } from "./utils/facts";
+
+const ALLOWED_TYPES = ["COMPONENT", "COMPONENT_SET"] as const;
+
+function resolveComponent(
+  nodeId: string | undefined,
+): Promise<ComponentNode | ComponentSetNode> {
+  return resolveComponentByIdOrSelection(nodeId, ALLOWED_TYPES);
+}
+
+interface ReadComponentParams {
+  nodeId?: string;
+}
+
+registerOperation<ReadComponentParams, DerivedFacts>(
+  {
+    id: "tidy_doc_read_component",
+    kind: "query",
+    module: "tidy-doc",
+    summary:
+      "Return the derived variant categorisation for a selected/idened component or component set: family axis + values, state axis + values, demoted axes, pinned rest-state defaults.",
+    paramsExample: {},
+  },
+  async (params) => {
+    const source = await resolveComponent(params.nodeId);
+    return deriveFacts(source);
+  },
+);
+
+interface BuildPageParams {
+  nodeId?: string;
+  docSpec: DocSpec;
+}
+interface BuildPageResult {
+  pageFrameId: string;
+  sourceComponentId: string;
+}
+
+registerOperation<BuildPageParams, BuildPageResult>(
+  {
+    id: "tidy_doc_build_page",
+    kind: "execute",
+    module: "tidy-doc",
+    summary:
+      "Build (or replace) a Documentation Page next to the source component: Chrome (status badge) + a Variants Section with one specimen per keyed family. Re-running replaces the prior page for the same source. Rejects unresolved family-value references in a single batched error.",
+    paramsExample: { docSpec: { status: "IDEATION" } },
+  },
+  async (params) => {
+    const parsed = DocSpecSchema.safeParse(params.docSpec);
+    if (!parsed.success) {
+      throw new OperationError(
+        ErrorCode.INVALID_PARAMS,
+        "docSpec failed schema validation",
+        true,
+        { issues: parsed.error.issues },
+      );
+    }
+
+    const source = await resolveComponent(params.nodeId);
+    const root = await buildDocPage(source, parsed.data);
+
+    return { pageFrameId: root.id, sourceComponentId: source.id };
+  },
+);

--- a/src/plugins/tidy-doc/types.ts
+++ b/src/plugins/tidy-doc/types.ts
@@ -1,0 +1,17 @@
+/// <reference types="@figma/plugin-typings" />
+
+export type TidyDocAction = "get-context" | "document-selection";
+
+export interface GetContextResult {
+  fileKey: string | null;
+}
+
+export interface DocumentSelectionResult {
+  pageFrameId: string;
+  sourceComponentId: string;
+  sourceComponentName: string;
+}
+
+export type { DocSpec, DocStatus } from "./utils/docSpec";
+export type { DerivedFacts } from "./utils/facts";
+export type { UnresolvedRef } from "./utils/resolveReferences";

--- a/src/plugins/tidy-doc/ui.tsx
+++ b/src/plugins/tidy-doc/ui.tsx
@@ -18,9 +18,8 @@ export function TidyDocUI() {
   const [fileKey, setFileKey] = useState<string | null>(null);
   const [log, setLog] = useState<string[]>([]);
   const [building, setBuilding] = useState(false);
-  const [bridgeStatus, setBridgeStatus] = useState<BridgeStatus>(
-    getBridgeStatus(),
-  );
+  const [bridgeStatus, setBridgeStatus] =
+    useState<BridgeStatus>(getBridgeStatus());
 
   useEffect(() => {
     postToFigma({
@@ -79,9 +78,10 @@ export function TidyDocUI() {
           Bound file: <code>{fileKey ?? "unknown"}</code>
         </p>
         <p className="status-message">
-          This module is primarily driven from Claude via the MCP bridge
-          (<code>tidy_doc_read_component</code> / <code>tidy_doc_build_page</code>).
-          The button below is a facts-only fallback with no authored prose.
+          This module is primarily driven from Claude via the MCP bridge (
+          <code>tidy_doc_read_component</code> /{" "}
+          <code>tidy_doc_build_page</code>). The button below is a facts-only
+          fallback with no authored prose.
         </p>
         <button disabled={building} onClick={documentSelection}>
           {building ? "Building…" : "Document selection"}

--- a/src/plugins/tidy-doc/ui.tsx
+++ b/src/plugins/tidy-doc/ui.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+import { Card } from "@shell/components";
+import { postToFigma } from "@shared/bridge";
+import {
+  getBridgeStatus,
+  subscribeBridgeStatus,
+} from "@shared/operations/ui-bridge-startup";
+import type { BridgeStatus } from "@shared/operations/ui-bridge";
+import type { GetContextResult, DocumentSelectionResult } from "./types";
+
+const BRIDGE_STATUS_LABEL: Record<BridgeStatus, string> = {
+  open: "connected",
+  connecting: "connecting…",
+  closed: "not connected",
+};
+
+export function TidyDocUI() {
+  const [fileKey, setFileKey] = useState<string | null>(null);
+  const [log, setLog] = useState<string[]>([]);
+  const [building, setBuilding] = useState(false);
+  const [bridgeStatus, setBridgeStatus] = useState<BridgeStatus>(
+    getBridgeStatus(),
+  );
+
+  useEffect(() => {
+    postToFigma({
+      target: "tidy-doc",
+      action: "get-context",
+      payload: {},
+      requestId: "get-context",
+    });
+  }, []);
+
+  useEffect(() => subscribeBridgeStatus(setBridgeStatus), []);
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const message = event.data.pluginMessage || event.data;
+      if (!message) return;
+
+      if (message.type === "response" && message.requestId === "get-context") {
+        setFileKey((message.result as GetContextResult).fileKey);
+      } else if (
+        message.type === "response" &&
+        message.requestId === "document-selection"
+      ) {
+        const result = message.result as DocumentSelectionResult;
+        setLog((prev) => [
+          ...prev,
+          `Built Documentation Page for "${result.sourceComponentName}".`,
+        ]);
+        setBuilding(false);
+      } else if (message.type === "error") {
+        setLog((prev) => [...prev, `Error: ${message.error}`]);
+        setBuilding(false);
+      }
+    };
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
+
+  const documentSelection = () => {
+    setBuilding(true);
+    postToFigma({
+      target: "tidy-doc",
+      action: "document-selection",
+      payload: {},
+      requestId: "document-selection",
+    });
+  };
+
+  return (
+    <div className="tidy-doc">
+      <Card>
+        <p className="status-message">
+          Bridge: {BRIDGE_STATUS_LABEL[bridgeStatus]} · Session: bound
+        </p>
+        <p className="status-message">
+          Bound file: <code>{fileKey ?? "unknown"}</code>
+        </p>
+        <p className="status-message">
+          This module is primarily driven from Claude via the MCP bridge
+          (<code>tidy_doc_read_component</code> / <code>tidy_doc_build_page</code>).
+          The button below is a facts-only fallback with no authored prose.
+        </p>
+        <button disabled={building} onClick={documentSelection}>
+          {building ? "Building…" : "Document selection"}
+        </button>
+      </Card>
+      <Card>
+        <p className="status-message">Build log</p>
+        {log.length === 0 ? (
+          <p className="status-message">No builds yet.</p>
+        ) : (
+          <ul>
+            {log.map((line, i) => (
+              <li key={i}>{line}</li>
+            ))}
+          </ul>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/plugins/tidy-doc/utils/anatomy.test.ts
+++ b/src/plugins/tidy-doc/utils/anatomy.test.ts
@@ -12,11 +12,17 @@ describe("deriveWidthFact", () => {
   });
 
   it("returns the fact when only minWidth is set", () => {
-    expect(deriveWidthFact(120, null)).toEqual({ minWidth: 120, maxWidth: null });
+    expect(deriveWidthFact(120, null)).toEqual({
+      minWidth: 120,
+      maxWidth: null,
+    });
   });
 
   it("returns the fact when only maxWidth is set", () => {
-    expect(deriveWidthFact(null, 480)).toEqual({ minWidth: null, maxWidth: 480 });
+    expect(deriveWidthFact(null, 480)).toEqual({
+      minWidth: null,
+      maxWidth: 480,
+    });
   });
 
   it("returns the fact when both are set", () => {
@@ -35,7 +41,11 @@ describe("detectIconPlacement", () => {
   it("prefers a VARIANT icon-position axis over a BOOLEAN toggle", () => {
     const descriptors: PropertyDescriptor[] = [
       { name: "Has Icon", type: "BOOLEAN" },
-      { name: "Icon Position", type: "VARIANT", values: ["Leading", "Trailing", "None"] },
+      {
+        name: "Icon Position",
+        type: "VARIANT",
+        values: ["Leading", "Trailing", "None"],
+      },
     ];
     expect(detectIconPlacement(descriptors)).toEqual({
       propertyName: "Icon Position",
@@ -45,7 +55,9 @@ describe("detectIconPlacement", () => {
   });
 
   it("falls back to a BOOLEAN presence toggle when no VARIANT axis exists", () => {
-    const descriptors: PropertyDescriptor[] = [{ name: "Icon", type: "BOOLEAN" }];
+    const descriptors: PropertyDescriptor[] = [
+      { name: "Icon", type: "BOOLEAN" },
+    ];
     expect(detectIconPlacement(descriptors)).toEqual({
       propertyName: "Icon",
       propertyType: "BOOLEAN",
@@ -54,7 +66,9 @@ describe("detectIconPlacement", () => {
   });
 
   it("falls back to a bare INSTANCE_SWAP slot with no placement values", () => {
-    const descriptors: PropertyDescriptor[] = [{ name: "Icon Slot", type: "INSTANCE_SWAP" }];
+    const descriptors: PropertyDescriptor[] = [
+      { name: "Icon Slot", type: "INSTANCE_SWAP" },
+    ];
     expect(detectIconPlacement(descriptors)).toEqual({
       propertyName: "Icon Slot",
       propertyType: "INSTANCE_SWAP",
@@ -63,7 +77,9 @@ describe("detectIconPlacement", () => {
   });
 
   it("matches case-insensitively", () => {
-    const descriptors: PropertyDescriptor[] = [{ name: "ICON", type: "BOOLEAN" }];
+    const descriptors: PropertyDescriptor[] = [
+      { name: "ICON", type: "BOOLEAN" },
+    ];
     expect(detectIconPlacement(descriptors)?.propertyName).toBe("ICON");
   });
 });

--- a/src/plugins/tidy-doc/utils/anatomy.test.ts
+++ b/src/plugins/tidy-doc/utils/anatomy.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveWidthFact,
+  detectIconPlacement,
+  findMatchingVariantIndex,
+  type PropertyDescriptor,
+} from "./anatomy";
+
+describe("deriveWidthFact", () => {
+  it("returns null when neither minWidth nor maxWidth is set", () => {
+    expect(deriveWidthFact(null, null)).toBeNull();
+  });
+
+  it("returns the fact when only minWidth is set", () => {
+    expect(deriveWidthFact(120, null)).toEqual({ minWidth: 120, maxWidth: null });
+  });
+
+  it("returns the fact when only maxWidth is set", () => {
+    expect(deriveWidthFact(null, 480)).toEqual({ minWidth: null, maxWidth: 480 });
+  });
+
+  it("returns the fact when both are set", () => {
+    expect(deriveWidthFact(120, 480)).toEqual({ minWidth: 120, maxWidth: 480 });
+  });
+});
+
+describe("detectIconPlacement", () => {
+  it("returns null when no property name mentions icon", () => {
+    const descriptors: PropertyDescriptor[] = [
+      { name: "Type", type: "VARIANT", values: ["Primary", "Secondary"] },
+    ];
+    expect(detectIconPlacement(descriptors)).toBeNull();
+  });
+
+  it("prefers a VARIANT icon-position axis over a BOOLEAN toggle", () => {
+    const descriptors: PropertyDescriptor[] = [
+      { name: "Has Icon", type: "BOOLEAN" },
+      { name: "Icon Position", type: "VARIANT", values: ["Leading", "Trailing", "None"] },
+    ];
+    expect(detectIconPlacement(descriptors)).toEqual({
+      propertyName: "Icon Position",
+      propertyType: "VARIANT",
+      values: ["Leading", "Trailing", "None"],
+    });
+  });
+
+  it("falls back to a BOOLEAN presence toggle when no VARIANT axis exists", () => {
+    const descriptors: PropertyDescriptor[] = [{ name: "Icon", type: "BOOLEAN" }];
+    expect(detectIconPlacement(descriptors)).toEqual({
+      propertyName: "Icon",
+      propertyType: "BOOLEAN",
+      values: ["True", "False"],
+    });
+  });
+
+  it("falls back to a bare INSTANCE_SWAP slot with no placement values", () => {
+    const descriptors: PropertyDescriptor[] = [{ name: "Icon Slot", type: "INSTANCE_SWAP" }];
+    expect(detectIconPlacement(descriptors)).toEqual({
+      propertyName: "Icon Slot",
+      propertyType: "INSTANCE_SWAP",
+      values: [],
+    });
+  });
+
+  it("matches case-insensitively", () => {
+    const descriptors: PropertyDescriptor[] = [{ name: "ICON", type: "BOOLEAN" }];
+    expect(detectIconPlacement(descriptors)?.propertyName).toBe("ICON");
+  });
+});
+
+describe("findMatchingVariantIndex", () => {
+  const children = [
+    { variantProperties: { Size: "S", Type: "Primary", State: "Idle" } },
+    { variantProperties: { Size: "M", Type: "Primary", State: "Idle" } },
+    { variantProperties: { Size: "L", Type: "Primary", State: "Idle" } },
+    { variantProperties: null },
+  ];
+
+  it("finds the child matching every target key", () => {
+    const index = findMatchingVariantIndex(children, {
+      Size: "M",
+      Type: "Primary",
+      State: "Idle",
+    });
+    expect(index).toBe(1);
+  });
+
+  it("returns null when no child matches", () => {
+    const index = findMatchingVariantIndex(children, {
+      Size: "XL",
+      Type: "Primary",
+      State: "Idle",
+    });
+    expect(index).toBeNull();
+  });
+
+  it("returns null for a mismatched non-size key even if size matches", () => {
+    const index = findMatchingVariantIndex(children, {
+      Size: "S",
+      Type: "Secondary",
+      State: "Idle",
+    });
+    expect(index).toBeNull();
+  });
+
+  it("skips children with no variantProperties", () => {
+    const index = findMatchingVariantIndex(children, { Size: "M" });
+    expect(index).toBe(1);
+  });
+});

--- a/src/plugins/tidy-doc/utils/anatomy.ts
+++ b/src/plugins/tidy-doc/utils/anatomy.ts
@@ -81,7 +81,11 @@ export function detectIconPlacement(
 
   const swap = iconLike.find((d) => d.type === "INSTANCE_SWAP");
   if (swap) {
-    return { propertyName: swap.name, propertyType: "INSTANCE_SWAP", values: [] };
+    return {
+      propertyName: swap.name,
+      propertyType: "INSTANCE_SWAP",
+      values: [],
+    };
   }
 
   return null;

--- a/src/plugins/tidy-doc/utils/anatomy.ts
+++ b/src/plugins/tidy-doc/utils/anatomy.ts
@@ -1,0 +1,108 @@
+// Pure fact-derivation helpers for the Component Breakdown Section
+// (CONTEXT.md "Component Breakdown"): a fixed, ordered catalogue of derived
+// anatomy sub-sections (v1: Height, Width, Icon placement), each rendered
+// only when the component exposes the relevant fact. Kept Figma-independent
+// — deriveFacts.ts (Figma-touching) supplies the plain descriptors these
+// operate on, so the matching/detection logic can be unit tested without a
+// Figma runtime (mirrors categorizeAxes.ts).
+
+export interface SizeMeasurement {
+  value: string;
+  height: number;
+  verticalSizing: "FIXED" | "HUG" | "FILL";
+}
+
+export interface WidthFact {
+  minWidth: number | null;
+  maxWidth: number | null;
+}
+
+export type IconPropertyType = "VARIANT" | "BOOLEAN" | "INSTANCE_SWAP";
+
+export interface IconPlacementFact {
+  propertyName: string;
+  propertyType: IconPropertyType;
+  values: string[];
+}
+
+export interface PropertyDescriptor {
+  name: string;
+  type: "VARIANT" | "BOOLEAN" | "INSTANCE_SWAP" | "TEXT";
+  values?: string[];
+}
+
+export interface VariantChildDescriptor {
+  variantProperties: Record<string, string> | null;
+}
+
+/**
+ * Width sub-section fact: present only when the component declares at least
+ * one of minWidth/maxWidth (an auto-layout size constraint) — never both
+ * required, per the presence-only rule (ADR-0007).
+ */
+export function deriveWidthFact(
+  minWidth: number | null,
+  maxWidth: number | null,
+): WidthFact | null {
+  if (minWidth === null && maxWidth === null) return null;
+  return { minWidth, maxWidth };
+}
+
+/**
+ * Detect an icon-placement property among a component's declared
+ * properties (icon-variant detection, CONTEXT.md "Component Breakdown").
+ * Precedence: an explicit VARIANT axis naming icon positions (e.g.
+ * "Icon Position": Leading/Trailing/None) beats a BOOLEAN presence toggle,
+ * which beats a bare INSTANCE_SWAP slot with no placement values of its own.
+ */
+export function detectIconPlacement(
+  descriptors: PropertyDescriptor[],
+): IconPlacementFact | null {
+  const iconLike = descriptors.filter((d) => /icon/i.test(d.name));
+  if (iconLike.length === 0) return null;
+
+  const variant = iconLike.find((d) => d.type === "VARIANT");
+  if (variant) {
+    return {
+      propertyName: variant.name,
+      propertyType: "VARIANT",
+      values: variant.values ?? [],
+    };
+  }
+
+  const bool = iconLike.find((d) => d.type === "BOOLEAN");
+  if (bool) {
+    return {
+      propertyName: bool.name,
+      propertyType: "BOOLEAN",
+      values: ["True", "False"],
+    };
+  }
+
+  const swap = iconLike.find((d) => d.type === "INSTANCE_SWAP");
+  if (swap) {
+    return { propertyName: swap.name, propertyType: "INSTANCE_SWAP", values: [] };
+  }
+
+  return null;
+}
+
+/**
+ * Find the child variant whose variantProperties match every key in
+ * `target` (a size value plus every other axis pinned to its rest-state
+ * default). Returns null when no exact match exists rather than guessing —
+ * the Height sub-section drops that size value and logs it (skip-when-empty,
+ * one level down).
+ */
+export function findMatchingVariantIndex(
+  children: VariantChildDescriptor[],
+  target: Record<string, string>,
+): number | null {
+  const index = children.findIndex((child) => {
+    if (!child.variantProperties) return false;
+    return Object.entries(target).every(
+      ([key, value]) => child.variantProperties![key] === value,
+    );
+  });
+  return index === -1 ? null : index;
+}

--- a/src/plugins/tidy-doc/utils/buildBreakdownSection.ts
+++ b/src/plugins/tidy-doc/utils/buildBreakdownSection.ts
@@ -46,7 +46,8 @@ function createSizeSpecimenInstance(
   if (facts.familyAxis.name) {
     const familyDefault =
       source.defaultVariant.variantProperties?.[facts.familyAxis.name];
-    if (familyDefault) setVariantProps(instance, facts.familyAxis.name, familyDefault);
+    if (familyDefault)
+      setVariantProps(instance, facts.familyAxis.name, familyDefault);
   }
   if (facts.sizeAxis?.name) {
     setVariantProps(instance, facts.sizeAxis.name, sizeValue);
@@ -101,7 +102,13 @@ async function buildHeightRow(
     "#4B5563",
   );
 
-  const row = buildAutoLayoutFrame(`height-row — ${measurement.value}`, "HORIZONTAL", 0, 0, 12);
+  const row = buildAutoLayoutFrame(
+    `height-row — ${measurement.value}`,
+    "HORIZONTAL",
+    0,
+    0,
+    12,
+  );
   row.counterAxisAlignItems = "CENTER";
   row.appendChild(wrapper);
   row.appendChild(label);
@@ -114,12 +121,20 @@ async function buildHeightSubSection(
   caption?: string,
 ): Promise<FrameNode> {
   const block = buildAutoLayoutFrame("breakdown — height", "VERTICAL", 0, 0, 8);
-  block.appendChild(await createText("Height", 14, { family: "Inter", style: "Bold" }));
+  block.appendChild(
+    await createText("Height", 14, { family: "Inter", style: "Bold" }),
+  );
   if (caption) {
     block.appendChild(await createText(caption, 12, undefined, "#4B5563"));
   }
 
-  const rows = buildAutoLayoutFrame("breakdown — height — rows", "VERTICAL", 0, 0, 12);
+  const rows = buildAutoLayoutFrame(
+    "breakdown — height — rows",
+    "VERTICAL",
+    0,
+    0,
+    12,
+  );
   for (const measurement of facts.breakdown.heights) {
     rows.appendChild(await buildHeightRow(source, facts, measurement));
   }
@@ -133,7 +148,9 @@ async function buildWidthSubSection(
   caption?: string,
 ): Promise<FrameNode> {
   const block = buildAutoLayoutFrame("breakdown — width", "VERTICAL", 0, 0, 8);
-  block.appendChild(await createText("Width", 14, { family: "Inter", style: "Bold" }));
+  block.appendChild(
+    await createText("Width", 14, { family: "Inter", style: "Bold" }),
+  );
   if (caption) {
     block.appendChild(await createText(caption, 12, undefined, "#4B5563"));
   }
@@ -141,12 +158,22 @@ async function buildWidthSubSection(
   const width = facts.breakdown.width!;
   if (width.minWidth !== null) {
     block.appendChild(
-      await createText(`Min width: ${Math.round(width.minWidth)}px`, 12, undefined, "#6B7280"),
+      await createText(
+        `Min width: ${Math.round(width.minWidth)}px`,
+        12,
+        undefined,
+        "#6B7280",
+      ),
     );
   }
   if (width.maxWidth !== null) {
     block.appendChild(
-      await createText(`Max width: ${Math.round(width.maxWidth)}px`, 12, undefined, "#6B7280"),
+      await createText(
+        `Max width: ${Math.round(width.maxWidth)}px`,
+        12,
+        undefined,
+        "#6B7280",
+      ),
     );
   }
 
@@ -157,8 +184,16 @@ async function buildIconPlacementSubSection(
   facts: DerivedFacts,
   caption?: string,
 ): Promise<FrameNode> {
-  const block = buildAutoLayoutFrame("breakdown — icon-placement", "VERTICAL", 0, 0, 8);
-  block.appendChild(await createText("Icon placement", 14, { family: "Inter", style: "Bold" }));
+  const block = buildAutoLayoutFrame(
+    "breakdown — icon-placement",
+    "VERTICAL",
+    0,
+    0,
+    8,
+  );
+  block.appendChild(
+    await createText("Icon placement", 14, { family: "Inter", style: "Bold" }),
+  );
   if (caption) {
     block.appendChild(await createText(caption, 12, undefined, "#4B5563"));
   }
@@ -189,17 +224,30 @@ export async function buildBreakdownSection(
     return null;
   }
 
-  const section = buildAutoLayoutFrame("breakdown-section", "VERTICAL", 0, 0, 24);
+  const section = buildAutoLayoutFrame(
+    "breakdown-section",
+    "VERTICAL",
+    0,
+    0,
+    24,
+  );
 
   if (heights.length > 0 && source.type === "COMPONENT_SET") {
-    section.appendChild(await buildHeightSubSection(source, facts, breakdownSpec.heightCaption));
+    section.appendChild(
+      await buildHeightSubSection(source, facts, breakdownSpec.heightCaption),
+    );
   }
   if (width) {
-    section.appendChild(await buildWidthSubSection(facts, breakdownSpec.widthCaption));
+    section.appendChild(
+      await buildWidthSubSection(facts, breakdownSpec.widthCaption),
+    );
   }
   if (iconPlacement) {
     section.appendChild(
-      await buildIconPlacementSubSection(facts, breakdownSpec.iconPlacementCaption),
+      await buildIconPlacementSubSection(
+        facts,
+        breakdownSpec.iconPlacementCaption,
+      ),
     );
   }
 

--- a/src/plugins/tidy-doc/utils/buildBreakdownSection.ts
+++ b/src/plugins/tidy-doc/utils/buildBreakdownSection.ts
@@ -1,0 +1,207 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Component Breakdown Section (CONTEXT.md "Component Breakdown"): a fixed,
+// ordered catalogue of derived anatomy sub-sections — v1 ships Height,
+// Width, Icon placement (Padding/Inner-spacing are a documented fast-follow)
+// — each rendered only when the component exposes that fact
+// (skip-when-empty one level down). Measurements are re-derived from the
+// live component (deriveFacts.ts) and rendered raw; this builder never
+// invents a fact the component doesn't expose.
+
+import {
+  buildAutoLayoutFrame,
+  setVariantProps,
+} from "../../sticker-sheet-builder/utils/utilityFunctions";
+import { buildSizeMarks } from "../../tags-spacings/utils/sizeMarks";
+import { loadInterFont } from "../../tags-spacings/utils/fontLoader";
+import type { SpacingsConfig } from "../../tags-spacings/types";
+import { createText } from "./buildChrome";
+import type { DocSpec } from "./docSpec";
+import type { DerivedFacts } from "./facts";
+import type { SizeMeasurement } from "./anatomy";
+
+const SIZE_MARKS_CONFIG: SpacingsConfig = {
+  includeSize: true,
+  includePaddings: false,
+  includeItemSpacing: false,
+  units: "px",
+  rootSize: 16,
+  isShallow: true,
+};
+
+function verticalSizingLabel(sizing: "FIXED" | "HUG" | "FILL"): string {
+  return sizing.charAt(0) + sizing.slice(1).toLowerCase();
+}
+
+function createSizeSpecimenInstance(
+  source: ComponentSetNode,
+  facts: DerivedFacts,
+  sizeValue: string,
+): InstanceNode {
+  const instance = source.defaultVariant.createInstance();
+
+  for (const [axisName, value] of Object.entries(facts.pinnedDefaults)) {
+    setVariantProps(instance, axisName, value);
+  }
+  if (facts.familyAxis.name) {
+    const familyDefault =
+      source.defaultVariant.variantProperties?.[facts.familyAxis.name];
+    if (familyDefault) setVariantProps(instance, facts.familyAxis.name, familyDefault);
+  }
+  if (facts.sizeAxis?.name) {
+    setVariantProps(instance, facts.sizeAxis.name, sizeValue);
+  }
+
+  return instance;
+}
+
+// Builds one specimen + code-generated size markers (tags-spacings,
+// ADR-0006 — never Kido helper instances) inside a plain (non-auto-layout)
+// wrapper. The wrapper is built at the page origin so absolute-space marker
+// math (buildSizeMarks) and local-space reparenting agree; the wrapper's own
+// position is then free to be repositioned by the outer auto-layout flow.
+async function buildHeightRow(
+  source: ComponentSetNode,
+  facts: DerivedFacts,
+  measurement: SizeMeasurement,
+): Promise<FrameNode> {
+  const specimen = createSizeSpecimenInstance(source, facts, measurement.value);
+  specimen.x = 0;
+  specimen.y = 0;
+
+  const wrapper = figma.createFrame();
+  wrapper.name = `height-specimen — ${measurement.value}`;
+  wrapper.fills = [];
+  wrapper.clipsContent = false;
+  wrapper.x = 0;
+  wrapper.y = 0;
+  wrapper.resize(Math.max(specimen.width, 1), Math.max(specimen.height, 1));
+  wrapper.appendChild(specimen);
+
+  await loadInterFont();
+  const markers = await buildSizeMarks(specimen, SIZE_MARKS_CONFIG);
+  for (const marker of markers) wrapper.appendChild(marker);
+
+  const maxX = Math.max(
+    specimen.x + specimen.width,
+    ...markers.map((marker) => marker.x + marker.width),
+  );
+  const maxY = Math.max(
+    specimen.y + specimen.height,
+    ...markers.map((marker) => marker.y + marker.height),
+  );
+  wrapper.resize(Math.max(maxX, 1), Math.max(maxY, 1));
+
+  const label = await createText(
+    `${measurement.value} — ${Math.round(measurement.height)}px — ${verticalSizingLabel(
+      measurement.verticalSizing,
+    )}`,
+    12,
+    undefined,
+    "#4B5563",
+  );
+
+  const row = buildAutoLayoutFrame(`height-row — ${measurement.value}`, "HORIZONTAL", 0, 0, 12);
+  row.counterAxisAlignItems = "CENTER";
+  row.appendChild(wrapper);
+  row.appendChild(label);
+  return row;
+}
+
+async function buildHeightSubSection(
+  source: ComponentSetNode,
+  facts: DerivedFacts,
+  caption?: string,
+): Promise<FrameNode> {
+  const block = buildAutoLayoutFrame("breakdown — height", "VERTICAL", 0, 0, 8);
+  block.appendChild(await createText("Height", 14, { family: "Inter", style: "Bold" }));
+  if (caption) {
+    block.appendChild(await createText(caption, 12, undefined, "#4B5563"));
+  }
+
+  const rows = buildAutoLayoutFrame("breakdown — height — rows", "VERTICAL", 0, 0, 12);
+  for (const measurement of facts.breakdown.heights) {
+    rows.appendChild(await buildHeightRow(source, facts, measurement));
+  }
+  block.appendChild(rows);
+
+  return block;
+}
+
+async function buildWidthSubSection(
+  facts: DerivedFacts,
+  caption?: string,
+): Promise<FrameNode> {
+  const block = buildAutoLayoutFrame("breakdown — width", "VERTICAL", 0, 0, 8);
+  block.appendChild(await createText("Width", 14, { family: "Inter", style: "Bold" }));
+  if (caption) {
+    block.appendChild(await createText(caption, 12, undefined, "#4B5563"));
+  }
+
+  const width = facts.breakdown.width!;
+  if (width.minWidth !== null) {
+    block.appendChild(
+      await createText(`Min width: ${Math.round(width.minWidth)}px`, 12, undefined, "#6B7280"),
+    );
+  }
+  if (width.maxWidth !== null) {
+    block.appendChild(
+      await createText(`Max width: ${Math.round(width.maxWidth)}px`, 12, undefined, "#6B7280"),
+    );
+  }
+
+  return block;
+}
+
+async function buildIconPlacementSubSection(
+  facts: DerivedFacts,
+  caption?: string,
+): Promise<FrameNode> {
+  const block = buildAutoLayoutFrame("breakdown — icon-placement", "VERTICAL", 0, 0, 8);
+  block.appendChild(await createText("Icon placement", 14, { family: "Inter", style: "Bold" }));
+  if (caption) {
+    block.appendChild(await createText(caption, 12, undefined, "#4B5563"));
+  }
+
+  const icon = facts.breakdown.iconPlacement!;
+  const detail =
+    icon.values.length > 0
+      ? `${icon.propertyName} (${icon.propertyType.toLowerCase()}) — ${icon.values.join(", ")}`
+      : `${icon.propertyName} (${icon.propertyType.toLowerCase()})`;
+  block.appendChild(await createText(detail, 12, undefined, "#6B7280"));
+
+  return block;
+}
+
+export async function buildBreakdownSection(
+  source: ComponentNode | ComponentSetNode,
+  spec: DocSpec,
+  facts: DerivedFacts,
+): Promise<FrameNode | null> {
+  const breakdownSpec = spec.breakdown;
+  if (!breakdownSpec) return null;
+
+  const { heights, width, iconPlacement } = facts.breakdown;
+  if (heights.length === 0 && !width && !iconPlacement) {
+    console.warn(
+      `tidy-doc: "breakdown" key present but no derived anatomy facts for "${facts.componentName}" (${facts.componentId}); dropping the Component Breakdown Section.`,
+    );
+    return null;
+  }
+
+  const section = buildAutoLayoutFrame("breakdown-section", "VERTICAL", 0, 0, 24);
+
+  if (heights.length > 0 && source.type === "COMPONENT_SET") {
+    section.appendChild(await buildHeightSubSection(source, facts, breakdownSpec.heightCaption));
+  }
+  if (width) {
+    section.appendChild(await buildWidthSubSection(facts, breakdownSpec.widthCaption));
+  }
+  if (iconPlacement) {
+    section.appendChild(
+      await buildIconPlacementSubSection(facts, breakdownSpec.iconPlacementCaption),
+    );
+  }
+
+  return section;
+}

--- a/src/plugins/tidy-doc/utils/buildChrome.ts
+++ b/src/plugins/tidy-doc/utils/buildChrome.ts
@@ -37,12 +37,23 @@ export async function createText(
 
 async function buildStatusBadge(status: DocStatus): Promise<FrameNode> {
   const style = STATUS_BADGE[status];
-  const pill = buildAutoLayoutFrame(`status-badge — ${status}`, "HORIZONTAL", 10, 4, 6);
+  const pill = buildAutoLayoutFrame(
+    `status-badge — ${status}`,
+    "HORIZONTAL",
+    10,
+    4,
+    6,
+  );
   pill.cornerRadius = 999;
   pill.fills = [{ type: "SOLID", color: hexToRgb(style.hex), opacity: 0.16 }];
   pill.counterAxisAlignItems = "CENTER";
 
-  const label = await createText(`${style.emoji} ${status}`, 11, FONT_BOLD, style.hex);
+  const label = await createText(
+    `${style.emoji} ${status}`,
+    11,
+    FONT_BOLD,
+    style.hex,
+  );
   pill.appendChild(label);
   return pill;
 }
@@ -63,10 +74,22 @@ export async function buildSectionCard(
   card.strokeWeight = 1;
   card.cornerRadius = 12;
 
-  const header = buildAutoLayoutFrame(`${name} — header`, "HORIZONTAL", 0, 0, 12);
+  const header = buildAutoLayoutFrame(
+    `${name} — header`,
+    "HORIZONTAL",
+    0,
+    0,
+    12,
+  );
   header.counterAxisAlignItems = "CENTER";
 
-  const titleColumn = buildAutoLayoutFrame(`${name} — title`, "VERTICAL", 0, 0, 2);
+  const titleColumn = buildAutoLayoutFrame(
+    `${name} — title`,
+    "VERTICAL",
+    0,
+    0,
+    2,
+  );
   const titleText = await createText(title, 18, FONT_BOLD);
   const subtitleText = await createText(subtitle, 13, FONT_REGULAR, "#6B7280");
   titleColumn.appendChild(titleText);

--- a/src/plugins/tidy-doc/utils/buildChrome.ts
+++ b/src/plugins/tidy-doc/utils/buildChrome.ts
@@ -1,0 +1,86 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Chrome builder (ADR-0006, CONTEXT.md "Chrome"): card frame + header (icon +
+// section title + component-name subtitle + status-badge pill). Raw nodes
+// with literal hex/spacing values — no library-component linkage, ever.
+
+import { buildAutoLayoutFrame } from "../../sticker-sheet-builder/utils/utilityFunctions";
+import { STATUS_BADGE } from "./statusBadge";
+import type { DocStatus } from "./docSpec";
+
+const FONT_REGULAR: FontName = { family: "Inter", style: "Regular" };
+const FONT_BOLD: FontName = { family: "Inter", style: "Bold" };
+
+function hexToRgb(hex: string): RGB {
+  const clean = hex.replace("#", "");
+  return {
+    r: parseInt(clean.slice(0, 2), 16) / 255,
+    g: parseInt(clean.slice(2, 4), 16) / 255,
+    b: parseInt(clean.slice(4, 6), 16) / 255,
+  };
+}
+
+export async function createText(
+  content: string,
+  fontSize: number,
+  font: FontName = FONT_REGULAR,
+  hex = "#111827",
+): Promise<TextNode> {
+  await figma.loadFontAsync(font);
+  const text = figma.createText();
+  text.fontName = font;
+  text.fontSize = fontSize;
+  text.characters = content;
+  text.fills = [{ type: "SOLID", color: hexToRgb(hex) }];
+  return text;
+}
+
+async function buildStatusBadge(status: DocStatus): Promise<FrameNode> {
+  const style = STATUS_BADGE[status];
+  const pill = buildAutoLayoutFrame(`status-badge — ${status}`, "HORIZONTAL", 10, 4, 6);
+  pill.cornerRadius = 999;
+  pill.fills = [{ type: "SOLID", color: hexToRgb(style.hex), opacity: 0.16 }];
+  pill.counterAxisAlignItems = "CENTER";
+
+  const label = await createText(`${style.emoji} ${status}`, 11, FONT_BOLD, style.hex);
+  pill.appendChild(label);
+  return pill;
+}
+
+/**
+ * One Section's Chrome: a card frame with a header row (title + component
+ * subtitle + status badge) ready to receive Section-specific content.
+ */
+export async function buildSectionCard(
+  name: string,
+  title: string,
+  subtitle: string,
+  status: DocStatus,
+): Promise<{ card: FrameNode; body: FrameNode }> {
+  const card = buildAutoLayoutFrame(name, "VERTICAL", 24, 24, 16);
+  card.fills = [{ type: "SOLID", color: hexToRgb("#FFFFFF") }];
+  card.strokes = [{ type: "SOLID", color: hexToRgb("#E5E7EB") }];
+  card.strokeWeight = 1;
+  card.cornerRadius = 12;
+
+  const header = buildAutoLayoutFrame(`${name} — header`, "HORIZONTAL", 0, 0, 12);
+  header.counterAxisAlignItems = "CENTER";
+
+  const titleColumn = buildAutoLayoutFrame(`${name} — title`, "VERTICAL", 0, 0, 2);
+  const titleText = await createText(title, 18, FONT_BOLD);
+  const subtitleText = await createText(subtitle, 13, FONT_REGULAR, "#6B7280");
+  titleColumn.appendChild(titleText);
+  titleColumn.appendChild(subtitleText);
+
+  const badge = await buildStatusBadge(status);
+
+  header.appendChild(titleColumn);
+  header.appendChild(badge);
+
+  const body = buildAutoLayoutFrame(`${name} — body`, "VERTICAL", 0, 0, 20);
+
+  card.appendChild(header);
+  card.appendChild(body);
+
+  return { card, body };
+}

--- a/src/plugins/tidy-doc/utils/buildDocPage.ts
+++ b/src/plugins/tidy-doc/utils/buildDocPage.ts
@@ -118,12 +118,13 @@ export async function buildDocPage(
 
   const guidelinesSection = await buildGuidelinesSection(source, spec, facts);
   if (guidelinesSection) {
-    const { card: guidelinesCard, body: guidelinesBody } = await buildSectionCard(
-      "guidelines",
-      "Usage Guidelines",
-      source.name,
-      spec.status,
-    );
+    const { card: guidelinesCard, body: guidelinesBody } =
+      await buildSectionCard(
+        "guidelines",
+        "Usage Guidelines",
+        source.name,
+        spec.status,
+      );
     guidelinesBody.appendChild(guidelinesSection);
     root.appendChild(guidelinesCard);
   }

--- a/src/plugins/tidy-doc/utils/buildDocPage.ts
+++ b/src/plugins/tidy-doc/utils/buildDocPage.ts
@@ -10,6 +10,7 @@ import { deriveFacts } from "./deriveFacts";
 import { resolveDocSpecReferences } from "./resolveReferences";
 import { buildSectionCard } from "./buildChrome";
 import { buildVariantsSection } from "./buildVariantsSection";
+import { buildRelatedSection } from "./buildRelatedSection";
 import type { DocSpec } from "./docSpec";
 
 const PLUGIN_DATA_KEY = "tidy:doc-page";
@@ -47,7 +48,7 @@ export async function buildDocPage(
   source: ComponentNode | ComponentSetNode,
   spec: DocSpec,
 ): Promise<FrameNode> {
-  const facts = deriveFacts(source);
+  const facts = await deriveFacts(source);
 
   const { unresolved } = resolveDocSpecReferences(spec, facts);
   if (unresolved.length > 0) {
@@ -86,6 +87,8 @@ export async function buildDocPage(
   );
   const variantsSection = await buildVariantsSection(source, spec, facts);
   if (variantsSection) body.appendChild(variantsSection);
+  const relatedSection = await buildRelatedSection(spec, facts);
+  if (relatedSection) body.appendChild(relatedSection);
   root.appendChild(card);
 
   page.appendChild(root);

--- a/src/plugins/tidy-doc/utils/buildDocPage.ts
+++ b/src/plugins/tidy-doc/utils/buildDocPage.ts
@@ -11,6 +11,7 @@ import { resolveDocSpecReferences } from "./resolveReferences";
 import { buildSectionCard } from "./buildChrome";
 import { buildVariantsSection } from "./buildVariantsSection";
 import { buildBreakdownSection } from "./buildBreakdownSection";
+import { buildModeSection } from "./buildModeSection";
 import { buildGuidelinesSection } from "./buildGuidelinesSection";
 import { buildRelatedSection } from "./buildRelatedSection";
 import type { DocSpec } from "./docSpec";
@@ -101,6 +102,18 @@ export async function buildDocPage(
     );
     breakdownBody.appendChild(breakdownSection);
     root.appendChild(breakdownCard);
+  }
+
+  const modeSection = await buildModeSection(source, spec, facts);
+  if (modeSection) {
+    const { card: modeCard, body: modeBody } = await buildSectionCard(
+      "mode",
+      "Mode",
+      source.name,
+      spec.status,
+    );
+    modeBody.appendChild(modeSection);
+    root.appendChild(modeCard);
   }
 
   const guidelinesSection = await buildGuidelinesSection(source, spec, facts);

--- a/src/plugins/tidy-doc/utils/buildDocPage.ts
+++ b/src/plugins/tidy-doc/utils/buildDocPage.ts
@@ -1,0 +1,107 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Orchestrator: derive facts, resolve references, replace-wholesale rebuild,
+// render Chrome + Variants. Not unit tested (Figma-API adapter) — validated
+// by manual round-trip in Figma per the plan's verification section.
+
+import { ErrorCode, OperationError } from "../../../shared/operations/errors";
+import { buildAutoLayoutFrame } from "../../sticker-sheet-builder/utils/utilityFunctions";
+import { deriveFacts } from "./deriveFacts";
+import { resolveDocSpecReferences } from "./resolveReferences";
+import { buildSectionCard } from "./buildChrome";
+import { buildVariantsSection } from "./buildVariantsSection";
+import type { DocSpec } from "./docSpec";
+
+const PLUGIN_DATA_KEY = "tidy:doc-page";
+
+interface DocPageStamp {
+  version: number;
+  sourceComponentId: string;
+  builtAt: number;
+}
+
+// Scans every page (not just the current one) and every depth (not just
+// top-level children), since re-runs must find a stamped page regardless of
+// which page or frame a designer moved it into between runs (#52 ACR).
+async function findExistingDocPages(
+  sourceComponentId: string,
+): Promise<FrameNode[]> {
+  await figma.loadAllPagesAsync();
+  const matches: FrameNode[] = [];
+  for (const frame of figma.root.findAllWithCriteria({ types: ["FRAME"] })) {
+    const raw = frame.getPluginData(PLUGIN_DATA_KEY);
+    if (!raw) continue;
+    try {
+      const stamp = JSON.parse(raw) as DocPageStamp;
+      if (stamp.sourceComponentId === sourceComponentId) {
+        matches.push(frame);
+      }
+    } catch {
+      // Not a doc-page stamp we understand — ignore.
+    }
+  }
+  return matches;
+}
+
+export async function buildDocPage(
+  source: ComponentNode | ComponentSetNode,
+  spec: DocSpec,
+): Promise<FrameNode> {
+  const facts = deriveFacts(source);
+
+  const { unresolved } = resolveDocSpecReferences(spec, facts);
+  if (unresolved.length > 0) {
+    throw new OperationError(
+      ErrorCode.INVALID_PARAMS,
+      `${unresolved.length} Doc Spec reference(s) did not resolve`,
+      true,
+      { unresolved },
+    );
+  }
+
+  const page = figma.currentPage;
+  const existing = await findExistingDocPages(source.id);
+  if (existing.length > 0) {
+    if (existing.length > 1) {
+      console.warn(
+        `tidy-doc: found ${existing.length} existing doc pages for ${source.id}; deleting all before rebuild`,
+      );
+    }
+    for (const frame of existing) frame.remove();
+  }
+
+  const root = buildAutoLayoutFrame(
+    `Documentation — ${source.name}`,
+    "VERTICAL",
+    0,
+    0,
+    0,
+  );
+
+  const { card, body } = await buildSectionCard(
+    "variants",
+    "Variants",
+    source.name,
+    spec.status,
+  );
+  const variantsSection = await buildVariantsSection(source, spec, facts);
+  if (variantsSection) body.appendChild(variantsSection);
+  root.appendChild(card);
+
+  page.appendChild(root);
+  root.x = source.x + source.width + 200;
+  root.y = source.y;
+
+  root.setPluginData(
+    PLUGIN_DATA_KEY,
+    JSON.stringify({
+      version: 1,
+      sourceComponentId: source.id,
+      builtAt: Date.now(),
+    } satisfies DocPageStamp),
+  );
+
+  figma.viewport.scrollAndZoomIntoView([root]);
+
+  return root;
+}

--- a/src/plugins/tidy-doc/utils/buildDocPage.ts
+++ b/src/plugins/tidy-doc/utils/buildDocPage.ts
@@ -10,6 +10,7 @@ import { deriveFacts } from "./deriveFacts";
 import { resolveDocSpecReferences } from "./resolveReferences";
 import { buildSectionCard } from "./buildChrome";
 import { buildVariantsSection } from "./buildVariantsSection";
+import { buildGuidelinesSection } from "./buildGuidelinesSection";
 import type { DocSpec } from "./docSpec";
 
 const PLUGIN_DATA_KEY = "tidy:doc-page";
@@ -87,6 +88,18 @@ export async function buildDocPage(
   const variantsSection = await buildVariantsSection(source, spec, facts);
   if (variantsSection) body.appendChild(variantsSection);
   root.appendChild(card);
+
+  const guidelinesSection = await buildGuidelinesSection(source, spec, facts);
+  if (guidelinesSection) {
+    const { card: guidelinesCard, body: guidelinesBody } = await buildSectionCard(
+      "guidelines",
+      "Usage Guidelines",
+      source.name,
+      spec.status,
+    );
+    guidelinesBody.appendChild(guidelinesSection);
+    root.appendChild(guidelinesCard);
+  }
 
   page.appendChild(root);
   root.x = source.x + source.width + 200;

--- a/src/plugins/tidy-doc/utils/buildDocPage.ts
+++ b/src/plugins/tidy-doc/utils/buildDocPage.ts
@@ -10,6 +10,7 @@ import { deriveFacts } from "./deriveFacts";
 import { resolveDocSpecReferences } from "./resolveReferences";
 import { buildSectionCard } from "./buildChrome";
 import { buildVariantsSection } from "./buildVariantsSection";
+import { buildBreakdownSection } from "./buildBreakdownSection";
 import type { DocSpec } from "./docSpec";
 
 const PLUGIN_DATA_KEY = "tidy:doc-page";
@@ -87,6 +88,18 @@ export async function buildDocPage(
   const variantsSection = await buildVariantsSection(source, spec, facts);
   if (variantsSection) body.appendChild(variantsSection);
   root.appendChild(card);
+
+  const breakdownSection = await buildBreakdownSection(source, spec, facts);
+  if (breakdownSection) {
+    const { card: breakdownCard, body: breakdownBody } = await buildSectionCard(
+      "breakdown",
+      "Component Breakdown",
+      source.name,
+      spec.status,
+    );
+    breakdownBody.appendChild(breakdownSection);
+    root.appendChild(breakdownCard);
+  }
 
   page.appendChild(root);
   root.x = source.x + source.width + 200;

--- a/src/plugins/tidy-doc/utils/buildGuidelinesSection.ts
+++ b/src/plugins/tidy-doc/utils/buildGuidelinesSection.ts
@@ -1,0 +1,163 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Usage Guidelines Section (CONTEXT.md "Section", "Specimen Scene"):
+// authored whenToUse/whenNotToUse/general bullet lists plus Do/Don't
+// specimen pairs. Each pair renders a good and a bad SpecimenScene — 1–4
+// live source-component instances in a row/stack, each with a verdict icon
+// (code-generated glyph, no library linkage, per ADR-0006).
+
+import {
+  buildAutoLayoutFrame,
+  setVariantProps,
+} from "../../sticker-sheet-builder/utils/utilityFunctions";
+import { createText } from "./buildChrome";
+import type { DocSpec, DoDontPair, SpecimenScene } from "./docSpec";
+import type { DerivedFacts } from "./facts";
+
+async function buildBulletList(
+  name: string,
+  title: string,
+  items: string[],
+): Promise<FrameNode> {
+  const list = buildAutoLayoutFrame(name, "VERTICAL", 0, 0, 6);
+  const heading = await createText(title, 13, { family: "Inter", style: "Bold" });
+  list.appendChild(heading);
+  for (const item of items) {
+    const bullet = await createText(`• ${item}`, 12, undefined, "#4B5563");
+    list.appendChild(bullet);
+  }
+  return list;
+}
+
+function createSceneInstance(
+  source: ComponentNode | ComponentSetNode,
+  props: Record<string, string>,
+  facts: DerivedFacts,
+): InstanceNode {
+  const base = source.type === "COMPONENT_SET" ? source.defaultVariant : source;
+  const instance = base.createInstance();
+
+  if (source.type === "COMPONENT_SET") {
+    for (const [axisName, value] of Object.entries(facts.pinnedDefaults)) {
+      setVariantProps(instance, axisName, value);
+    }
+    for (const [axisName, value] of Object.entries(props)) {
+      setVariantProps(instance, axisName, value);
+    }
+  }
+
+  return instance;
+}
+
+async function buildScene(
+  source: ComponentNode | ComponentSetNode,
+  scene: SpecimenScene,
+  facts: DerivedFacts,
+  name: string,
+): Promise<FrameNode> {
+  const frame = buildAutoLayoutFrame(
+    name,
+    scene.layout === "stack" ? "VERTICAL" : "HORIZONTAL",
+    0,
+    0,
+    12,
+  );
+  frame.counterAxisAlignItems = "CENTER";
+
+  for (const instanceSpec of scene.instances) {
+    const instance = createSceneInstance(source, instanceSpec.props, facts);
+    frame.appendChild(instance);
+    if (instanceSpec.labelOverride) {
+      const label = await createText(instanceSpec.labelOverride, 11, undefined, "#6B7280");
+      frame.appendChild(label);
+    }
+  }
+
+  return frame;
+}
+
+async function buildVerdictIcon(verdict: "good" | "bad"): Promise<TextNode> {
+  return verdict === "good"
+    ? createText("✓", 16, { family: "Inter", style: "Bold" }, "#16A34A")
+    : createText("✗", 16, { family: "Inter", style: "Bold" }, "#DC2626");
+}
+
+async function buildVerdictRow(
+  source: ComponentNode | ComponentSetNode,
+  verdict: "good" | "bad",
+  scene: SpecimenScene,
+  facts: DerivedFacts,
+  name: string,
+): Promise<FrameNode> {
+  const row = buildAutoLayoutFrame(name, "HORIZONTAL", 0, 0, 8);
+  row.counterAxisAlignItems = "CENTER";
+  row.appendChild(await buildVerdictIcon(verdict));
+  row.appendChild(await buildScene(source, scene, facts, `${name} — scene`));
+  return row;
+}
+
+async function buildDoDontPair(
+  source: ComponentNode | ComponentSetNode,
+  pair: DoDontPair,
+  facts: DerivedFacts,
+  index: number,
+): Promise<FrameNode> {
+  const name = `do/dont — ${index}`;
+  const block = buildAutoLayoutFrame(name, "VERTICAL", 0, 0, 8);
+  block.appendChild(await createText(pair.description, 12, undefined, "#111827"));
+  block.appendChild(
+    await buildVerdictRow(source, "good", pair.good, facts, `${name} — good`),
+  );
+  block.appendChild(
+    await buildVerdictRow(source, "bad", pair.bad, facts, `${name} — bad`),
+  );
+  return block;
+}
+
+export async function buildGuidelinesSection(
+  source: ComponentNode | ComponentSetNode,
+  spec: DocSpec,
+  facts: DerivedFacts,
+): Promise<FrameNode | null> {
+  const guidelines = spec.guidelines;
+  if (!guidelines) return null;
+
+  const hasContent =
+    (guidelines.whenToUse?.length ?? 0) > 0 ||
+    (guidelines.whenNotToUse?.length ?? 0) > 0 ||
+    (guidelines.general?.length ?? 0) > 0 ||
+    (guidelines.doDonts?.length ?? 0) > 0;
+  if (!hasContent) return null;
+
+  const section = buildAutoLayoutFrame("guidelines-section", "VERTICAL", 0, 0, 16);
+
+  if (guidelines.whenToUse?.length) {
+    section.appendChild(
+      await buildBulletList("guidelines — when to use", "When to use", guidelines.whenToUse),
+    );
+  }
+  if (guidelines.whenNotToUse?.length) {
+    section.appendChild(
+      await buildBulletList(
+        "guidelines — when not to use",
+        "When not to use",
+        guidelines.whenNotToUse,
+      ),
+    );
+  }
+  if (guidelines.general?.length) {
+    section.appendChild(
+      await buildBulletList("guidelines — general", "General", guidelines.general),
+    );
+  }
+
+  if (guidelines.doDonts?.length) {
+    const doDonts = buildAutoLayoutFrame("guidelines — do/dont", "VERTICAL", 0, 0, 20);
+    for (let i = 0; i < guidelines.doDonts.length; i++) {
+      doDonts.appendChild(await buildDoDontPair(source, guidelines.doDonts[i], facts, i));
+    }
+    section.appendChild(doDonts);
+  }
+
+  return section;
+}

--- a/src/plugins/tidy-doc/utils/buildGuidelinesSection.ts
+++ b/src/plugins/tidy-doc/utils/buildGuidelinesSection.ts
@@ -20,7 +20,10 @@ async function buildBulletList(
   items: string[],
 ): Promise<FrameNode> {
   const list = buildAutoLayoutFrame(name, "VERTICAL", 0, 0, 6);
-  const heading = await createText(title, 13, { family: "Inter", style: "Bold" });
+  const heading = await createText(title, 13, {
+    family: "Inter",
+    style: "Bold",
+  });
   list.appendChild(heading);
   for (const item of items) {
     const bullet = await createText(`• ${item}`, 12, undefined, "#4B5563");
@@ -68,7 +71,12 @@ async function buildScene(
     const instance = createSceneInstance(source, instanceSpec.props, facts);
     frame.appendChild(instance);
     if (instanceSpec.labelOverride) {
-      const label = await createText(instanceSpec.labelOverride, 11, undefined, "#6B7280");
+      const label = await createText(
+        instanceSpec.labelOverride,
+        11,
+        undefined,
+        "#6B7280",
+      );
       frame.appendChild(label);
     }
   }
@@ -104,7 +112,9 @@ async function buildDoDontPair(
 ): Promise<FrameNode> {
   const name = `do/dont — ${index}`;
   const block = buildAutoLayoutFrame(name, "VERTICAL", 0, 0, 8);
-  block.appendChild(await createText(pair.description, 12, undefined, "#111827"));
+  block.appendChild(
+    await createText(pair.description, 12, undefined, "#111827"),
+  );
   block.appendChild(
     await buildVerdictRow(source, "good", pair.good, facts, `${name} — good`),
   );
@@ -129,11 +139,21 @@ export async function buildGuidelinesSection(
     (guidelines.doDonts?.length ?? 0) > 0;
   if (!hasContent) return null;
 
-  const section = buildAutoLayoutFrame("guidelines-section", "VERTICAL", 0, 0, 16);
+  const section = buildAutoLayoutFrame(
+    "guidelines-section",
+    "VERTICAL",
+    0,
+    0,
+    16,
+  );
 
   if (guidelines.whenToUse?.length) {
     section.appendChild(
-      await buildBulletList("guidelines — when to use", "When to use", guidelines.whenToUse),
+      await buildBulletList(
+        "guidelines — when to use",
+        "When to use",
+        guidelines.whenToUse,
+      ),
     );
   }
   if (guidelines.whenNotToUse?.length) {
@@ -147,14 +167,26 @@ export async function buildGuidelinesSection(
   }
   if (guidelines.general?.length) {
     section.appendChild(
-      await buildBulletList("guidelines — general", "General", guidelines.general),
+      await buildBulletList(
+        "guidelines — general",
+        "General",
+        guidelines.general,
+      ),
     );
   }
 
   if (guidelines.doDonts?.length) {
-    const doDonts = buildAutoLayoutFrame("guidelines — do/dont", "VERTICAL", 0, 0, 20);
+    const doDonts = buildAutoLayoutFrame(
+      "guidelines — do/dont",
+      "VERTICAL",
+      0,
+      0,
+      20,
+    );
     for (let i = 0; i < guidelines.doDonts.length; i++) {
-      doDonts.appendChild(await buildDoDontPair(source, guidelines.doDonts[i], facts, i));
+      doDonts.appendChild(
+        await buildDoDontPair(source, guidelines.doDonts[i], facts, i),
+      );
     }
     section.appendChild(doDonts);
   }

--- a/src/plugins/tidy-doc/utils/buildModeSection.ts
+++ b/src/plugins/tidy-doc/utils/buildModeSection.ts
@@ -1,0 +1,96 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Mode Section (#55): automatic, crossed, capped theming showcases. The
+// source component's bound-variable collections are derived in deriveFacts;
+// this builder re-resolves the live VariableCollection objects so it can pin
+// each showcase container with setExplicitVariableModeForCollection(collection,
+// modeId) using the dynamic-page-safe overload.
+
+import { buildAutoLayoutFrame } from "../../sticker-sheet-builder/utils/utilityFunctions";
+import { createText } from "./buildChrome";
+import type { DocSpec } from "./docSpec";
+import type { DerivedFacts } from "./facts";
+import { buildModeCrossProduct, modeShowcaseLabel } from "./modes";
+
+const MAX_MODE_SHOWCASES = 8;
+
+function createSpecimenInstance(
+  source: ComponentNode | ComponentSetNode,
+): InstanceNode {
+  const base = source.type === "COMPONENT_SET" ? source.defaultVariant : source;
+  return base.createInstance();
+}
+
+async function resolveCollections(
+  collectionIds: string[],
+): Promise<Map<string, VariableCollection>> {
+  const result = new Map<string, VariableCollection>();
+  for (const id of collectionIds) {
+    const collection = await figma.variables.getVariableCollectionByIdAsync(id);
+    if (collection) result.set(id, collection);
+  }
+  return result;
+}
+
+export async function buildModeSection(
+  source: ComponentNode | ComponentSetNode,
+  spec: DocSpec,
+  facts: DerivedFacts,
+): Promise<FrameNode | null> {
+  if (!spec.mode) return null;
+  if (facts.modeCollections.length === 0) return null;
+
+  const { showcases, dropped } = buildModeCrossProduct(
+    facts.modeCollections,
+    MAX_MODE_SHOWCASES,
+  );
+  if (showcases.length === 0) return null;
+  if (dropped > 0) {
+    console.warn(
+      `tidy-doc: Mode Section capped at ${MAX_MODE_SHOWCASES} showcases; dropped ${dropped} additional mode combination(s)`,
+    );
+  }
+
+  const section = buildAutoLayoutFrame("mode-section", "VERTICAL", 0, 0, 16);
+
+  if (spec.mode.caption) {
+    section.appendChild(await createText(spec.mode.caption, 12, undefined, "#4B5563"));
+  }
+
+  const collectionIds = facts.modeCollections.map((collection) => collection.id);
+  const collectionsById = await resolveCollections(collectionIds);
+
+  for (const showcase of showcases) {
+    const block = buildAutoLayoutFrame("mode-showcase", "VERTICAL", 0, 0, 8);
+    block.appendChild(
+      await createText(modeShowcaseLabel(showcase), 13, { family: "Inter", style: "Bold" }),
+    );
+
+    const container = buildAutoLayoutFrame(
+      `mode-showcase — ${modeShowcaseLabel(showcase)}`,
+      "VERTICAL",
+      16,
+      16,
+      8,
+    );
+    container.fills = [{ type: "SOLID", color: { r: 0.98, g: 0.98, b: 0.98 } }];
+    container.cornerRadius = 8;
+
+    for (const selection of showcase.selections) {
+      const collection = collectionsById.get(selection.collectionId);
+      if (!collection) {
+        console.warn(
+          `tidy-doc: mode collection ${selection.collectionId} no longer resolved; skipping explicit mode pin for ${selection.modeId}`,
+        );
+        continue;
+      }
+      container.setExplicitVariableModeForCollection(collection, selection.modeId);
+    }
+
+    container.appendChild(createSpecimenInstance(source));
+    block.appendChild(container);
+    section.appendChild(block);
+  }
+
+  return section;
+}

--- a/src/plugins/tidy-doc/utils/buildModeSection.ts
+++ b/src/plugins/tidy-doc/utils/buildModeSection.ts
@@ -25,9 +25,11 @@ async function resolveCollections(
   collectionIds: string[],
 ): Promise<Map<string, VariableCollection>> {
   const result = new Map<string, VariableCollection>();
-  for (const id of collectionIds) {
-    const collection = await figma.variables.getVariableCollectionByIdAsync(id);
-    if (collection) result.set(id, collection);
+  const fetched = await Promise.all(
+    collectionIds.map((id) => figma.variables.getVariableCollectionByIdAsync(id)),
+  );
+  for (const collection of fetched) {
+    if (collection) result.set(collection.id, collection);
   }
   return result;
 }

--- a/src/plugins/tidy-doc/utils/buildModeSection.ts
+++ b/src/plugins/tidy-doc/utils/buildModeSection.ts
@@ -26,7 +26,9 @@ async function resolveCollections(
 ): Promise<Map<string, VariableCollection>> {
   const result = new Map<string, VariableCollection>();
   const fetched = await Promise.all(
-    collectionIds.map((id) => figma.variables.getVariableCollectionByIdAsync(id)),
+    collectionIds.map((id) =>
+      figma.variables.getVariableCollectionByIdAsync(id),
+    ),
   );
   for (const collection of fetched) {
     if (collection) result.set(collection.id, collection);
@@ -56,16 +58,23 @@ export async function buildModeSection(
   const section = buildAutoLayoutFrame("mode-section", "VERTICAL", 0, 0, 16);
 
   if (spec.mode.caption) {
-    section.appendChild(await createText(spec.mode.caption, 12, undefined, "#4B5563"));
+    section.appendChild(
+      await createText(spec.mode.caption, 12, undefined, "#4B5563"),
+    );
   }
 
-  const collectionIds = facts.modeCollections.map((collection) => collection.id);
+  const collectionIds = facts.modeCollections.map(
+    (collection) => collection.id,
+  );
   const collectionsById = await resolveCollections(collectionIds);
 
   for (const showcase of showcases) {
     const block = buildAutoLayoutFrame("mode-showcase", "VERTICAL", 0, 0, 8);
     block.appendChild(
-      await createText(modeShowcaseLabel(showcase), 13, { family: "Inter", style: "Bold" }),
+      await createText(modeShowcaseLabel(showcase), 13, {
+        family: "Inter",
+        style: "Bold",
+      }),
     );
 
     const container = buildAutoLayoutFrame(
@@ -86,7 +95,10 @@ export async function buildModeSection(
         );
         continue;
       }
-      container.setExplicitVariableModeForCollection(collection, selection.modeId);
+      container.setExplicitVariableModeForCollection(
+        collection,
+        selection.modeId,
+      );
     }
 
     container.appendChild(createSpecimenInstance(source));

--- a/src/plugins/tidy-doc/utils/buildRelatedSection.ts
+++ b/src/plugins/tidy-doc/utils/buildRelatedSection.ts
@@ -6,33 +6,44 @@
 // order (facts.relatedCandidates — resolveReferences already rejected any
 // key that isn't a real candidate before this runs).
 
-import { buildAutoLayoutFrame } from "../../sticker-sheet-builder/utils/utilityFunctions";
+import { buildAutoLayoutFrame, setVariantProps } from "../../sticker-sheet-builder/utils/utilityFunctions";
 import { createText } from "./buildChrome";
 import { ErrorCode, OperationError } from "../../../shared/operations/errors";
 import type { DocSpec } from "./docSpec";
 import type { DerivedFacts } from "./facts";
 
-async function findSiblingByName(
-  name: string,
-): Promise<ComponentNode | ComponentSetNode> {
+/**
+ * One-shot file-wide scan to resolve all authored sibling names at once,
+ * rather than re-running loadAllPagesAsync + findAllWithCriteria per key
+ * (N related entries → N+1 full-tree traversals).
+ */
+async function resolveAllSiblings(
+  names: string[],
+): Promise<Map<string, ComponentNode | ComponentSetNode>> {
   await figma.loadAllPagesAsync();
-  const match = figma.root
-    .findAllWithCriteria({ types: ["COMPONENT_SET", "COMPONENT"] })
-    .find((node) => node.name === name);
-  if (!match) {
-    throw new OperationError(
-      ErrorCode.NOT_FOUND,
-      `related sibling "${name}" resolved against derived facts but no longer exists in the file`,
-      true,
-      { name },
-    );
+  const result = new Map<string, ComponentNode | ComponentSetNode>();
+  for (const node of figma.root.findAllWithCriteria({ types: ["COMPONENT_SET", "COMPONENT"] })) {
+    // Skip variant children of component sets — only top-level peers
+    // are valid resolved siblings.
+    if (node.parent?.type === "COMPONENT_SET") continue;
+    if (names.includes(node.name)) {
+      result.set(node.name, node);
+    }
   }
-  return match;
+  return result;
 }
 
 function createSpecimenInstance(sibling: ComponentNode | ComponentSetNode): InstanceNode {
   const base = sibling.type === "COMPONENT_SET" ? sibling.defaultVariant : sibling;
-  return base.createInstance();
+  const instance = base.createInstance();
+  // Pin the sibling to its own default-variant state, giving a neutral
+  // designer-intended appearance rather than un-pinned/arbitrary defaults.
+  if (sibling.type === "COMPONENT_SET" && sibling.defaultVariant?.variantProperties) {
+    for (const [axis, value] of Object.entries(sibling.defaultVariant.variantProperties)) {
+      setVariantProps(instance, axis, value);
+    }
+  }
+  return instance;
 }
 
 export async function buildRelatedSection(
@@ -48,6 +59,8 @@ export async function buildRelatedSection(
     .map((candidate) => candidate.name)
     .filter((name) => Object.prototype.hasOwnProperty.call(related, name));
 
+  const siblingsByName = await resolveAllSiblings(orderedNames);
+
   for (const name of orderedNames) {
     const content = related[name];
     const block = buildAutoLayoutFrame(`related — ${name}`, "VERTICAL", 0, 0, 8);
@@ -57,7 +70,15 @@ export async function buildRelatedSection(
     block.appendChild(title);
     block.appendChild(guidance);
 
-    const sibling = await findSiblingByName(name);
+    const sibling = siblingsByName.get(name);
+    if (!sibling) {
+      throw new OperationError(
+        ErrorCode.NOT_FOUND,
+        `related sibling "${name}" resolved against derived facts but no longer exists in the file`,
+        true,
+        { name },
+      );
+    }
     const specimen = createSpecimenInstance(sibling);
     block.appendChild(specimen);
 

--- a/src/plugins/tidy-doc/utils/buildRelatedSection.ts
+++ b/src/plugins/tidy-doc/utils/buildRelatedSection.ts
@@ -6,7 +6,10 @@
 // order (facts.relatedCandidates — resolveReferences already rejected any
 // key that isn't a real candidate before this runs).
 
-import { buildAutoLayoutFrame, setVariantProps } from "../../sticker-sheet-builder/utils/utilityFunctions";
+import {
+  buildAutoLayoutFrame,
+  setVariantProps,
+} from "../../sticker-sheet-builder/utils/utilityFunctions";
 import { createText } from "./buildChrome";
 import { ErrorCode, OperationError } from "../../../shared/operations/errors";
 import type { DocSpec } from "./docSpec";
@@ -22,7 +25,9 @@ async function resolveAllSiblings(
 ): Promise<Map<string, ComponentNode | ComponentSetNode>> {
   await figma.loadAllPagesAsync();
   const result = new Map<string, ComponentNode | ComponentSetNode>();
-  for (const node of figma.root.findAllWithCriteria({ types: ["COMPONENT_SET", "COMPONENT"] })) {
+  for (const node of figma.root.findAllWithCriteria({
+    types: ["COMPONENT_SET", "COMPONENT"],
+  })) {
     // Skip variant children of component sets — only top-level peers
     // are valid resolved siblings.
     if (node.parent?.type === "COMPONENT_SET") continue;
@@ -33,13 +38,21 @@ async function resolveAllSiblings(
   return result;
 }
 
-function createSpecimenInstance(sibling: ComponentNode | ComponentSetNode): InstanceNode {
-  const base = sibling.type === "COMPONENT_SET" ? sibling.defaultVariant : sibling;
+function createSpecimenInstance(
+  sibling: ComponentNode | ComponentSetNode,
+): InstanceNode {
+  const base =
+    sibling.type === "COMPONENT_SET" ? sibling.defaultVariant : sibling;
   const instance = base.createInstance();
   // Pin the sibling to its own default-variant state, giving a neutral
   // designer-intended appearance rather than un-pinned/arbitrary defaults.
-  if (sibling.type === "COMPONENT_SET" && sibling.defaultVariant?.variantProperties) {
-    for (const [axis, value] of Object.entries(sibling.defaultVariant.variantProperties)) {
+  if (
+    sibling.type === "COMPONENT_SET" &&
+    sibling.defaultVariant?.variantProperties
+  ) {
+    for (const [axis, value] of Object.entries(
+      sibling.defaultVariant.variantProperties,
+    )) {
       setVariantProps(instance, axis, value);
     }
   }
@@ -63,10 +76,24 @@ export async function buildRelatedSection(
 
   for (const name of orderedNames) {
     const content = related[name];
-    const block = buildAutoLayoutFrame(`related — ${name}`, "VERTICAL", 0, 0, 8);
+    const block = buildAutoLayoutFrame(
+      `related — ${name}`,
+      "VERTICAL",
+      0,
+      0,
+      8,
+    );
 
-    const title = await createText(name, 14, { family: "Inter", style: "Bold" });
-    const guidance = await createText(content.guidance, 12, undefined, "#4B5563");
+    const title = await createText(name, 14, {
+      family: "Inter",
+      style: "Bold",
+    });
+    const guidance = await createText(
+      content.guidance,
+      12,
+      undefined,
+      "#4B5563",
+    );
     block.appendChild(title);
     block.appendChild(guidance);
 

--- a/src/plugins/tidy-doc/utils/buildRelatedSection.ts
+++ b/src/plugins/tidy-doc/utils/buildRelatedSection.ts
@@ -1,0 +1,68 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Related Components Section (CONTEXT.md "Related-component candidates…"):
+// one block per authored `related` key, each with authored guidance and a
+// live specimen instance of the resolved sibling, rendered in candidate-rank
+// order (facts.relatedCandidates — resolveReferences already rejected any
+// key that isn't a real candidate before this runs).
+
+import { buildAutoLayoutFrame } from "../../sticker-sheet-builder/utils/utilityFunctions";
+import { createText } from "./buildChrome";
+import { ErrorCode, OperationError } from "../../../shared/operations/errors";
+import type { DocSpec } from "./docSpec";
+import type { DerivedFacts } from "./facts";
+
+async function findSiblingByName(
+  name: string,
+): Promise<ComponentNode | ComponentSetNode> {
+  await figma.loadAllPagesAsync();
+  const match = figma.root
+    .findAllWithCriteria({ types: ["COMPONENT_SET", "COMPONENT"] })
+    .find((node) => node.name === name);
+  if (!match) {
+    throw new OperationError(
+      ErrorCode.NOT_FOUND,
+      `related sibling "${name}" resolved against derived facts but no longer exists in the file`,
+      true,
+      { name },
+    );
+  }
+  return match;
+}
+
+function createSpecimenInstance(sibling: ComponentNode | ComponentSetNode): InstanceNode {
+  const base = sibling.type === "COMPONENT_SET" ? sibling.defaultVariant : sibling;
+  return base.createInstance();
+}
+
+export async function buildRelatedSection(
+  spec: DocSpec,
+  facts: DerivedFacts,
+): Promise<FrameNode | null> {
+  const related = spec.related;
+  if (!related || Object.keys(related).length === 0) return null;
+
+  const section = buildAutoLayoutFrame("related-section", "VERTICAL", 0, 0, 24);
+
+  const orderedNames = facts.relatedCandidates
+    .map((candidate) => candidate.name)
+    .filter((name) => Object.prototype.hasOwnProperty.call(related, name));
+
+  for (const name of orderedNames) {
+    const content = related[name];
+    const block = buildAutoLayoutFrame(`related — ${name}`, "VERTICAL", 0, 0, 8);
+
+    const title = await createText(name, 14, { family: "Inter", style: "Bold" });
+    const guidance = await createText(content.guidance, 12, undefined, "#4B5563");
+    block.appendChild(title);
+    block.appendChild(guidance);
+
+    const sibling = await findSiblingByName(name);
+    const specimen = createSpecimenInstance(sibling);
+    block.appendChild(specimen);
+
+    section.appendChild(block);
+  }
+
+  return section;
+}

--- a/src/plugins/tidy-doc/utils/buildVariantsSection.ts
+++ b/src/plugins/tidy-doc/utils/buildVariantsSection.ts
@@ -29,11 +29,36 @@ function createSpecimenInstance(
   if (source.type === "COMPONENT_SET" && facts.familyAxis.name) {
     setVariantProps(instance, facts.familyAxis.name, familyValue);
   }
+
+  // Pin non-spanned axes to rest-state defaults — but exclude the state
+  // axis when a per-cell stateValue is provided, so the state override
+  // below sets the correct cell state rather than being reverted to the
+  // rest-state default.
+  const pinning: Record<string, string> = {};
   for (const [axisName, value] of Object.entries(facts.pinnedDefaults)) {
+    if (facts.stateAxis?.name && stateValue && axisName === facts.stateAxis.name) {
+      continue;
+    }
+    pinning[axisName] = value;
+  }
+  for (const [axisName, value] of Object.entries(pinning)) {
     setVariantProps(instance, axisName, value);
   }
+
+  // State override: match the exact property name rather than relying on
+  // setVariantProps's substring matching, which can collide with other
+  // axes (e.g. a "Loading State" axis would match a substring search for
+  // "State").
   if (facts.stateAxis?.name && stateValue) {
-    setVariantProps(instance, facts.stateAxis.name, stateValue);
+    for (const property in instance.componentProperties) {
+      if (
+        instance.componentProperties[property].type === "VARIANT" &&
+        property === facts.stateAxis.name
+      ) {
+        instance.setProperties({ [property]: stateValue });
+        break;
+      }
+    }
   }
 
   return instance;

--- a/src/plugins/tidy-doc/utils/buildVariantsSection.ts
+++ b/src/plugins/tidy-doc/utils/buildVariantsSection.ts
@@ -1,0 +1,89 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Minimal Variants Section (CONTEXT.md "Variant Family"): one block per
+// keyed family value, each with an authored description and a single live
+// specimen instance pinned to that family value plus every other axis's
+// pinned rest-state default. State-spanning rows are deferred to the
+// Variants-complete slice (see issue #52 body).
+
+import {
+  buildAutoLayoutFrame,
+  setVariantProps,
+} from "../../sticker-sheet-builder/utils/utilityFunctions";
+import { createText } from "./buildChrome";
+import type { DocSpec } from "./docSpec";
+import type { DerivedFacts } from "./facts";
+
+function createSpecimenInstance(
+  source: ComponentNode | ComponentSetNode,
+  familyValue: string,
+  facts: DerivedFacts,
+): InstanceNode {
+  const base =
+    source.type === "COMPONENT_SET" ? source.defaultVariant : source;
+  const instance = base.createInstance();
+
+  if (source.type === "COMPONENT_SET" && facts.familyAxis.name) {
+    setVariantProps(instance, facts.familyAxis.name, familyValue);
+  }
+  for (const [axisName, value] of Object.entries(facts.pinnedDefaults)) {
+    setVariantProps(instance, axisName, value);
+  }
+
+  return instance;
+}
+
+export async function buildVariantsSection(
+  source: ComponentNode | ComponentSetNode,
+  spec: DocSpec,
+  facts: DerivedFacts,
+): Promise<FrameNode | null> {
+  const variants = spec.variants;
+  if (!variants || Object.keys(variants).length === 0) return null;
+
+  const section = buildAutoLayoutFrame("variants-section", "VERTICAL", 0, 0, 24);
+
+  for (const [familyValue, content] of Object.entries(variants)) {
+    const block = buildAutoLayoutFrame(
+      `variant — ${familyValue}`,
+      "VERTICAL",
+      0,
+      0,
+      8,
+    );
+
+    // The reserved key "default" (single-unnamed-family fallback, per
+    // CONTEXT.md) is a DocSpec/reference-resolution implementation detail —
+    // shown to the author as the source component's own name instead of the
+    // literal word "default".
+    const displayTitle =
+      facts.familyAxis.name === null ? source.name : familyValue;
+    const title = await createText(displayTitle, 14, { family: "Inter", style: "Bold" });
+    const description = await createText(content.description, 12, undefined, "#4B5563");
+
+    block.appendChild(title);
+    block.appendChild(description);
+
+    if (content.whenToUse?.length) {
+      const list = buildAutoLayoutFrame(
+        `variant — ${familyValue} — when to use`,
+        "VERTICAL",
+        0,
+        0,
+        4,
+      );
+      for (const item of content.whenToUse) {
+        const bullet = await createText(`• ${item}`, 12, undefined, "#6B7280");
+        list.appendChild(bullet);
+      }
+      block.appendChild(list);
+    }
+
+    const specimen = createSpecimenInstance(source, familyValue, facts);
+    block.appendChild(specimen);
+
+    section.appendChild(block);
+  }
+
+  return section;
+}

--- a/src/plugins/tidy-doc/utils/buildVariantsSection.ts
+++ b/src/plugins/tidy-doc/utils/buildVariantsSection.ts
@@ -1,10 +1,12 @@
 /// <reference types="@figma/plugin-typings" />
 
-// Minimal Variants Section (CONTEXT.md "Variant Family"): one block per
-// keyed family value, each with an authored description and a single live
-// specimen instance pinned to that family value plus every other axis's
-// pinned rest-state default. State-spanning rows are deferred to the
-// Variants-complete slice (see issue #52 body).
+// Complete Variants Section (CONTEXT.md "Variant Family"): one block per
+// keyed family value, each with an authored description, an authored
+// "when to use" bullet list, and a Specimen Scene spanning the full state
+// axis (one specimen cell per state value, in the component's own option
+// order). Every non-spanned axis (size, a demoted type-like axis, any
+// incidental axis) is pinned to its derived rest-state default in every
+// cell — the scene never expands into a state×axis grid.
 
 import {
   buildAutoLayoutFrame,
@@ -18,6 +20,7 @@ function createSpecimenInstance(
   source: ComponentNode | ComponentSetNode,
   familyValue: string,
   facts: DerivedFacts,
+  stateValue?: string,
 ): InstanceNode {
   const base =
     source.type === "COMPONENT_SET" ? source.defaultVariant : source;
@@ -29,8 +32,53 @@ function createSpecimenInstance(
   for (const [axisName, value] of Object.entries(facts.pinnedDefaults)) {
     setVariantProps(instance, axisName, value);
   }
+  if (facts.stateAxis?.name && stateValue) {
+    setVariantProps(instance, facts.stateAxis.name, stateValue);
+  }
 
   return instance;
+}
+
+/**
+ * A family's Specimen Scene: one cell per state-axis value when the
+ * component exposes a state axis, else a single pinned-default specimen.
+ */
+async function createSpecimenScene(
+  source: ComponentNode | ComponentSetNode,
+  familyValue: string,
+  facts: DerivedFacts,
+): Promise<FrameNode | InstanceNode> {
+  if (!facts.stateAxis) {
+    return createSpecimenInstance(source, familyValue, facts);
+  }
+
+  const row = buildAutoLayoutFrame(
+    `variant — ${familyValue} — states`,
+    "HORIZONTAL",
+    0,
+    0,
+    24,
+  );
+
+  for (const stateValue of facts.stateAxis.values) {
+    const cell = buildAutoLayoutFrame(
+      `variant — ${familyValue} — state — ${stateValue}`,
+      "VERTICAL",
+      0,
+      0,
+      8,
+    );
+    cell.counterAxisAlignItems = "CENTER";
+
+    const instance = createSpecimenInstance(source, familyValue, facts, stateValue);
+    const label = await createText(stateValue, 10, undefined, "#6B7280");
+
+    cell.appendChild(instance);
+    cell.appendChild(label);
+    row.appendChild(cell);
+  }
+
+  return row;
 }
 
 export async function buildVariantsSection(
@@ -79,7 +127,7 @@ export async function buildVariantsSection(
       block.appendChild(list);
     }
 
-    const specimen = createSpecimenInstance(source, familyValue, facts);
+    const specimen = await createSpecimenScene(source, familyValue, facts);
     block.appendChild(specimen);
 
     section.appendChild(block);

--- a/src/plugins/tidy-doc/utils/buildVariantsSection.ts
+++ b/src/plugins/tidy-doc/utils/buildVariantsSection.ts
@@ -22,8 +22,7 @@ function createSpecimenInstance(
   facts: DerivedFacts,
   stateValue?: string,
 ): InstanceNode {
-  const base =
-    source.type === "COMPONENT_SET" ? source.defaultVariant : source;
+  const base = source.type === "COMPONENT_SET" ? source.defaultVariant : source;
   const instance = base.createInstance();
 
   if (source.type === "COMPONENT_SET" && facts.familyAxis.name) {
@@ -36,7 +35,11 @@ function createSpecimenInstance(
   // rest-state default.
   const pinning: Record<string, string> = {};
   for (const [axisName, value] of Object.entries(facts.pinnedDefaults)) {
-    if (facts.stateAxis?.name && stateValue && axisName === facts.stateAxis.name) {
+    if (
+      facts.stateAxis?.name &&
+      stateValue &&
+      axisName === facts.stateAxis.name
+    ) {
       continue;
     }
     pinning[axisName] = value;
@@ -95,7 +98,12 @@ async function createSpecimenScene(
     );
     cell.counterAxisAlignItems = "CENTER";
 
-    const instance = createSpecimenInstance(source, familyValue, facts, stateValue);
+    const instance = createSpecimenInstance(
+      source,
+      familyValue,
+      facts,
+      stateValue,
+    );
     const label = await createText(stateValue, 10, undefined, "#6B7280");
 
     cell.appendChild(instance);
@@ -114,7 +122,13 @@ export async function buildVariantsSection(
   const variants = spec.variants;
   if (!variants || Object.keys(variants).length === 0) return null;
 
-  const section = buildAutoLayoutFrame("variants-section", "VERTICAL", 0, 0, 24);
+  const section = buildAutoLayoutFrame(
+    "variants-section",
+    "VERTICAL",
+    0,
+    0,
+    24,
+  );
 
   for (const [familyValue, content] of Object.entries(variants)) {
     const block = buildAutoLayoutFrame(
@@ -131,8 +145,16 @@ export async function buildVariantsSection(
     // literal word "default".
     const displayTitle =
       facts.familyAxis.name === null ? source.name : familyValue;
-    const title = await createText(displayTitle, 14, { family: "Inter", style: "Bold" });
-    const description = await createText(content.description, 12, undefined, "#4B5563");
+    const title = await createText(displayTitle, 14, {
+      family: "Inter",
+      style: "Bold",
+    });
+    const description = await createText(
+      content.description,
+      12,
+      undefined,
+      "#4B5563",
+    );
 
     block.appendChild(title);
     block.appendChild(description);

--- a/src/plugins/tidy-doc/utils/categorizeAxes.test.ts
+++ b/src/plugins/tidy-doc/utils/categorizeAxes.test.ts
@@ -67,7 +67,11 @@ describe("categorizeAxes", () => {
 
   it("excludes size from family candidates", () => {
     const descriptors: AxisDescriptor[] = [
-      { name: "Size", values: ["Small", "Medium", "Large"], defaultValue: "Medium" },
+      {
+        name: "Size",
+        values: ["Small", "Medium", "Large"],
+        defaultValue: "Medium",
+      },
       { name: "Type", values: ["Primary", "Secondary"] },
     ];
     const result = categorizeAxes(descriptors);

--- a/src/plugins/tidy-doc/utils/categorizeAxes.test.ts
+++ b/src/plugins/tidy-doc/utils/categorizeAxes.test.ts
@@ -34,14 +34,26 @@ describe("categorizeAxes", () => {
     expect(result.demoted).toEqual([]);
   });
 
-  it("picks the first-declared axis by declaration order when multiple axes are ambiguous and none match by name", () => {
+  it("picks the first-declared axis by declaration order when multiple axes are type-like by value but neither name matches the precedence list", () => {
     const descriptors: AxisDescriptor[] = [
-      { name: "Emphasis", values: ["Bold", "Subtle"] },
+      { name: "Style", values: ["Filled", "Outline"] },
+      { name: "Look", values: ["Solid", "Ghost"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.familyAxis.name).toBe("Style");
+    expect(result.demoted).toEqual(["Look"]);
+  });
+
+  it("collapses to a single unnamed family when several axes remain but none categorise as type-like by name or value", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "Emphasis", values: ["Strong", "Weak"] },
       { name: "Flavor", values: ["Sweet", "Sour"] },
     ];
     const result = categorizeAxes(descriptors);
-    expect(result.familyAxis.name).toBe("Emphasis");
-    expect(result.demoted).toEqual(["Flavor"]);
+    expect(result.familyAxis).toEqual({ name: null, values: ["default"] });
+    expect(result.demoted).toEqual([]);
+    expect(result.pinnedDefaults.Emphasis).toBe("Strong");
+    expect(result.pinnedDefaults.Flavor).toBe("Sweet");
   });
 
   it("falls back to a single unnamed family when no type-like axis exists", () => {
@@ -71,6 +83,16 @@ describe("categorizeAxes", () => {
     ];
     const result = categorizeAxes(descriptors);
     expect(result.stateAxis?.name).toBe("Interaction");
+  });
+
+  it("recognises 'Regular/Hover/Pressed' values as state even on an unnamed axis", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "Interaction", values: ["Regular", "Hover", "Pressed"] },
+      { name: "Kind", values: ["Ghost", "Outline"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.stateAxis?.name).toBe("Interaction");
+    expect(result.familyAxis.name).toBe("Kind");
   });
 
   it("pins non-family axes to defaultValue when present", () => {

--- a/src/plugins/tidy-doc/utils/categorizeAxes.test.ts
+++ b/src/plugins/tidy-doc/utils/categorizeAxes.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { categorizeAxes, type AxisDescriptor } from "./categorizeAxes";
+
+describe("categorizeAxes", () => {
+  it("picks the axis named 'Type' as family over 'Kind'/'Variant'", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "Kind", values: ["Ghost", "Outline"] },
+      { name: "Type", values: ["Primary", "Secondary"] },
+      { name: "Variant", values: ["A", "B"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.familyAxis.name).toBe("Type");
+    expect(result.familyAxis.values).toEqual(["Primary", "Secondary"]);
+    expect(result.demoted.sort()).toEqual(["Kind", "Variant"]);
+  });
+
+  it("falls back to 'Kind' when no 'Type' axis is present", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "Kind", values: ["Ghost", "Outline"] },
+      { name: "Variant", values: ["A", "B"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.familyAxis.name).toBe("Kind");
+    expect(result.demoted).toEqual(["Variant"]);
+  });
+
+  it("promotes the single remaining axis when none match the name precedence", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "Emphasis", values: ["Bold", "Subtle"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.familyAxis.name).toBe("Emphasis");
+    expect(result.familyAxis.values).toEqual(["Bold", "Subtle"]);
+    expect(result.demoted).toEqual([]);
+  });
+
+  it("picks the first-declared axis by declaration order when multiple axes are ambiguous and none match by name", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "Emphasis", values: ["Bold", "Subtle"] },
+      { name: "Flavor", values: ["Sweet", "Sour"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.familyAxis.name).toBe("Emphasis");
+    expect(result.demoted).toEqual(["Flavor"]);
+  });
+
+  it("falls back to a single unnamed family when no type-like axis exists", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "State", values: ["Hover", "Idle", "Pressed"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.familyAxis).toEqual({ name: null, values: ["default"] });
+    expect(result.stateAxis?.name).toBe("State");
+  });
+
+  it("excludes size from family candidates", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "Size", values: ["Small", "Medium", "Large"], defaultValue: "Medium" },
+      { name: "Type", values: ["Primary", "Secondary"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.familyAxis.name).toBe("Type");
+    expect(result.sizeAxis?.name).toBe("Size");
+    expect(result.pinnedDefaults.Size).toBe("Medium");
+  });
+
+  it("detects state by value overlap even when the axis isn't named 'State'", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "Interaction", values: ["Hover", "Pressed", "Rest"] },
+      { name: "Type", values: ["Primary", "Secondary"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.stateAxis?.name).toBe("Interaction");
+  });
+
+  it("pins non-family axes to defaultValue when present", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "State", values: ["Hover", "Idle"], defaultValue: "Idle" },
+      { name: "Type", values: ["Primary", "Secondary"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.pinnedDefaults.State).toBe("Idle");
+  });
+
+  it("pins non-family axes to the first option when no defaultValue is given", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "State", values: ["Hover", "Idle"] },
+      { name: "Type", values: ["Primary", "Secondary"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.pinnedDefaults.State).toBe("Hover");
+  });
+
+  it("ignores a defaultValue that isn't among the axis's own values", () => {
+    const descriptors: AxisDescriptor[] = [
+      { name: "State", values: ["Hover", "Idle"], defaultValue: "Bogus" },
+      { name: "Type", values: ["Primary", "Secondary"] },
+    ];
+    const result = categorizeAxes(descriptors);
+    expect(result.pinnedDefaults.State).toBe("Hover");
+  });
+});

--- a/src/plugins/tidy-doc/utils/categorizeAxes.ts
+++ b/src/plugins/tidy-doc/utils/categorizeAxes.ts
@@ -40,6 +40,33 @@ const STATE_VALUE_VOCAB = new Set([
   "default",
   "rest",
   "error",
+  "regular",
+]);
+
+// Widened from sticker-sheet-builder's getProps() (utils/getAllVariantProps.ts
+// `typeOptions = ["primary", "secondary"]`) so a "Kind"/"Style"/… axis is
+// recognised as type-like by its values, not only by its name.
+const TYPE_VALUE_VOCAB = new Set([
+  "primary",
+  "secondary",
+  "tertiary",
+  "ghost",
+  "outline",
+  "outlined",
+  "filled",
+  "solid",
+  "subtle",
+  "link",
+  "text",
+  "danger",
+  "warning",
+  "success",
+  "info",
+  "neutral",
+  "brand",
+  "accent",
+  "destructive",
+  "critical",
 ]);
 
 const FAMILY_NAME_PRECEDENCE = ["type", "kind", "variant"];
@@ -51,6 +78,13 @@ function lower(values: string[]): string[] {
 function looksLikeState(descriptor: AxisDescriptor): boolean {
   if (descriptor.name.toLowerCase() === "state") return true;
   return lower(descriptor.values).some((v) => STATE_VALUE_VOCAB.has(v));
+}
+
+function looksLikeType(descriptor: AxisDescriptor): boolean {
+  if (FAMILY_NAME_PRECEDENCE.includes(descriptor.name.toLowerCase())) {
+    return true;
+  }
+  return lower(descriptor.values).some((v) => TYPE_VALUE_VOCAB.has(v));
 }
 
 function pinnedDefaultFor(descriptor: AxisDescriptor): string {
@@ -86,19 +120,32 @@ export function categorizeAxes(
   if (remaining.length === 0) {
     familyAxis = { name: null, values: ["default"] };
   } else if (remaining.length === 1) {
+    // By elimination the sole non-size/non-state axis is the family axis —
+    // there is no other candidate to compare it against.
     const [only] = remaining;
     familyAxis = { name: only.name, values: only.values };
   } else {
-    const byPrecedence = FAMILY_NAME_PRECEDENCE.map((wanted) =>
-      remaining.find((d) => d.name.toLowerCase() === wanted),
-    ).find((d): d is AxisDescriptor => Boolean(d));
-    const chosen = byPrecedence ?? remaining[0];
-    familyAxis = { name: chosen.name, values: chosen.values };
+    const typeCandidates = remaining.filter(looksLikeType);
 
-    for (const d of remaining) {
-      if (d !== chosen) {
-        demoted.push(d.name);
+    if (typeCandidates.length === 0) {
+      // No axis categorises as type-like by name or value: never promote an
+      // arbitrary axis to family. Every remaining axis is pinned instead.
+      familyAxis = { name: null, values: ["default"] };
+      for (const d of remaining) {
         pinnedDefaults[d.name] = pinnedDefaultFor(d);
+      }
+    } else {
+      const byPrecedence = FAMILY_NAME_PRECEDENCE.map((wanted) =>
+        typeCandidates.find((d) => d.name.toLowerCase() === wanted),
+      ).find((d): d is AxisDescriptor => Boolean(d));
+      const chosen = byPrecedence ?? typeCandidates[0];
+      familyAxis = { name: chosen.name, values: chosen.values };
+
+      for (const d of remaining) {
+        if (d !== chosen) {
+          demoted.push(d.name);
+          pinnedDefaults[d.name] = pinnedDefaultFor(d);
+        }
       }
     }
   }

--- a/src/plugins/tidy-doc/utils/categorizeAxes.ts
+++ b/src/plugins/tidy-doc/utils/categorizeAxes.ts
@@ -1,0 +1,124 @@
+// Pure axis-categorisation logic for tidy-doc. No Figma types — operates on
+// plain variant-prop descriptors so it can be unit tested without a Figma
+// runtime (mirrors src/plugins/color-finder/utils/categorize.ts).
+//
+// Widens sticker-sheet-builder's getProps() (utils/getAllVariantProps.ts)
+// value-bucketing into a dedicated categoriser for tidy-doc's Variant Family
+// concept (CONTEXT.md). Family/state axes are recognised by the *values*
+// they contain, not just the axis name; ambiguity among type-like axes is
+// resolved by a fixed name precedence (Type > Kind > Variant), then
+// declaration order.
+
+export interface AxisDescriptor {
+  name: string;
+  values: string[];
+  defaultValue?: string;
+}
+
+export interface Axis {
+  name: string | null;
+  values: string[];
+}
+
+export interface CategorizationResult {
+  familyAxis: Axis;
+  stateAxis: Axis | null;
+  sizeAxis: Axis | null;
+  demoted: string[];
+  pinnedDefaults: Record<string, string>;
+}
+
+const STATE_VALUE_VOCAB = new Set([
+  "hover",
+  "idle",
+  "pressed",
+  "active",
+  "focus",
+  "focused",
+  "disabled",
+  "selected",
+  "default",
+  "rest",
+  "error",
+]);
+
+const FAMILY_NAME_PRECEDENCE = ["type", "kind", "variant"];
+
+function lower(values: string[]): string[] {
+  return values.map((v) => v.toLowerCase());
+}
+
+function looksLikeState(descriptor: AxisDescriptor): boolean {
+  if (descriptor.name.toLowerCase() === "state") return true;
+  return lower(descriptor.values).some((v) => STATE_VALUE_VOCAB.has(v));
+}
+
+function pinnedDefaultFor(descriptor: AxisDescriptor): string {
+  if (descriptor.defaultValue && descriptor.values.includes(descriptor.defaultValue)) {
+    return descriptor.defaultValue;
+  }
+  return descriptor.values[0];
+}
+
+/**
+ * Categorise a component's variant axes into family/state/size buckets.
+ * Rest-state (non-spanned) axes are pinned to a single value each, since
+ * v1 renders one specimen per family value with no state-spanning row.
+ */
+export function categorizeAxes(
+  descriptors: AxisDescriptor[],
+): CategorizationResult {
+  const sizeDescriptor = descriptors.find(
+    (d) => d.name.toLowerCase() === "size",
+  );
+  const stateDescriptor = descriptors.find(
+    (d) => d !== sizeDescriptor && looksLikeState(d),
+  );
+
+  const remaining = descriptors.filter(
+    (d) => d !== sizeDescriptor && d !== stateDescriptor,
+  );
+
+  const pinnedDefaults: Record<string, string> = {};
+  const demoted: string[] = [];
+  let familyAxis: Axis;
+
+  if (remaining.length === 0) {
+    familyAxis = { name: null, values: ["default"] };
+  } else if (remaining.length === 1) {
+    const [only] = remaining;
+    familyAxis = { name: only.name, values: only.values };
+  } else {
+    const byPrecedence = FAMILY_NAME_PRECEDENCE.map((wanted) =>
+      remaining.find((d) => d.name.toLowerCase() === wanted),
+    ).find((d): d is AxisDescriptor => Boolean(d));
+    const chosen = byPrecedence ?? remaining[0];
+    familyAxis = { name: chosen.name, values: chosen.values };
+
+    for (const d of remaining) {
+      if (d !== chosen) {
+        demoted.push(d.name);
+        pinnedDefaults[d.name] = pinnedDefaultFor(d);
+      }
+    }
+  }
+
+  if (stateDescriptor) {
+    pinnedDefaults[stateDescriptor.name] = pinnedDefaultFor(stateDescriptor);
+  }
+  if (sizeDescriptor) {
+    pinnedDefaults[sizeDescriptor.name] = pinnedDefaultFor(sizeDescriptor);
+  }
+
+  return {
+    familyAxis,
+    stateAxis: stateDescriptor
+      ? { name: stateDescriptor.name, values: stateDescriptor.values }
+      : null,
+    sizeAxis: sizeDescriptor
+      ? { name: sizeDescriptor.name, values: sizeDescriptor.values }
+      : null,
+    demoted,
+    pinnedDefaults,
+  };
+}

--- a/src/plugins/tidy-doc/utils/categorizeAxes.ts
+++ b/src/plugins/tidy-doc/utils/categorizeAxes.ts
@@ -90,7 +90,10 @@ function looksLikeType(descriptor: AxisDescriptor): boolean {
 }
 
 function pinnedDefaultFor(descriptor: AxisDescriptor): string {
-  if (descriptor.defaultValue && descriptor.values.includes(descriptor.defaultValue)) {
+  if (
+    descriptor.defaultValue &&
+    descriptor.values.includes(descriptor.defaultValue)
+  ) {
     return descriptor.defaultValue;
   }
   return descriptor.values[0];

--- a/src/plugins/tidy-doc/utils/categorizeAxes.ts
+++ b/src/plugins/tidy-doc/utils/categorizeAxes.ts
@@ -25,6 +25,8 @@ export interface CategorizationResult {
   stateAxis: Axis | null;
   sizeAxis: Axis | null;
   demoted: string[];
+  /** Full value lists for every demoted axis (needed for Do/Don't SpecimenScene validation). */
+  demotedAxisValues: Record<string, string[]>;
   pinnedDefaults: Record<string, string>;
 }
 
@@ -115,6 +117,7 @@ export function categorizeAxes(
 
   const pinnedDefaults: Record<string, string> = {};
   const demoted: string[] = [];
+  const demotedAxisValues: Record<string, string[]> = {};
   let familyAxis: Axis;
 
   if (remaining.length === 0) {
@@ -133,6 +136,7 @@ export function categorizeAxes(
       familyAxis = { name: null, values: ["default"] };
       for (const d of remaining) {
         pinnedDefaults[d.name] = pinnedDefaultFor(d);
+        demotedAxisValues[d.name] = d.values;
       }
     } else {
       const byPrecedence = FAMILY_NAME_PRECEDENCE.map((wanted) =>
@@ -145,6 +149,7 @@ export function categorizeAxes(
         if (d !== chosen) {
           demoted.push(d.name);
           pinnedDefaults[d.name] = pinnedDefaultFor(d);
+          demotedAxisValues[d.name] = d.values;
         }
       }
     }
@@ -166,6 +171,7 @@ export function categorizeAxes(
       ? { name: sizeDescriptor.name, values: sizeDescriptor.values }
       : null,
     demoted,
+    demotedAxisValues,
     pinnedDefaults,
   };
 }

--- a/src/plugins/tidy-doc/utils/deriveFacts.ts
+++ b/src/plugins/tidy-doc/utils/deriveFacts.ts
@@ -6,32 +6,100 @@
 // treat the Figma-API adapter as validated by manual/plugin verification.
 
 import { categorizeAxes, type AxisDescriptor } from "./categorizeAxes";
+import {
+  deriveWidthFact,
+  detectIconPlacement,
+  findMatchingVariantIndex,
+  type PropertyDescriptor,
+  type SizeMeasurement,
+} from "./anatomy";
 import type { DerivedFacts } from "./facts";
+
+function deriveHeights(
+  node: ComponentSetNode,
+  categorization: ReturnType<typeof categorizeAxes>,
+  defaults: Record<string, string>,
+): SizeMeasurement[] {
+  if (!categorization.sizeAxis) return [];
+  const sizeAxisName = categorization.sizeAxis.name!;
+
+  const pinMap: Record<string, string> = { ...categorization.pinnedDefaults };
+  if (categorization.familyAxis.name) {
+    const familyDefault = defaults[categorization.familyAxis.name];
+    if (familyDefault) pinMap[categorization.familyAxis.name] = familyDefault;
+  }
+
+  const childDescriptors = node.children.map((child) => ({
+    variantProperties: child.type === "COMPONENT" ? child.variantProperties : null,
+  }));
+
+  const heights: SizeMeasurement[] = [];
+  for (const value of categorization.sizeAxis.values) {
+    const target = { ...pinMap, [sizeAxisName]: value };
+    const index = findMatchingVariantIndex(childDescriptors, target);
+    if (index === null) {
+      console.warn(
+        `tidy-doc: no variant of "${node.name}" matched size "${value}" under its pinned rest-state defaults; dropping from the Height sub-section`,
+      );
+      continue;
+    }
+    const child = node.children[index] as ComponentNode;
+    heights.push({
+      value,
+      height: child.height,
+      verticalSizing: child.layoutSizingVertical,
+    });
+  }
+  return heights;
+}
 
 export function deriveFacts(
   node: ComponentNode | ComponentSetNode,
 ): DerivedFacts {
   const descriptors: AxisDescriptor[] = [];
+  const propertyDescriptors: PropertyDescriptor[] = [];
+  let defaults: Record<string, string> = {};
 
   if (node.type === "COMPONENT_SET") {
-    const defaults = node.defaultVariant?.variantProperties ?? {};
+    defaults = node.defaultVariant?.variantProperties ?? {};
     for (const [name, def] of Object.entries(
       node.componentPropertyDefinitions,
     )) {
-      if (def.type !== "VARIANT") continue;
-      descriptors.push({
-        name,
-        values: def.variantOptions ?? [],
-        defaultValue: defaults[name],
-      });
+      if (def.type === "VARIANT") {
+        descriptors.push({
+          name,
+          values: def.variantOptions ?? [],
+          defaultValue: defaults[name],
+        });
+        propertyDescriptors.push({
+          name,
+          type: "VARIANT",
+          values: def.variantOptions ?? [],
+        });
+      } else {
+        propertyDescriptors.push({ name, type: def.type });
+      }
+    }
+  } else {
+    for (const [name, def] of Object.entries(
+      node.componentPropertyDefinitions,
+    )) {
+      propertyDescriptors.push({ name, type: def.type });
     }
   }
 
   const categorization = categorizeAxes(descriptors);
 
+  const widthSource = node.type === "COMPONENT_SET" ? node.defaultVariant ?? node : node;
+  const width = deriveWidthFact(widthSource.minWidth ?? null, widthSource.maxWidth ?? null);
+  const iconPlacement = detectIconPlacement(propertyDescriptors);
+  const heights =
+    node.type === "COMPONENT_SET" ? deriveHeights(node, categorization, defaults) : [];
+
   return {
     componentId: node.id,
     componentName: node.name,
     ...categorization,
+    breakdown: { heights, width, iconPlacement },
   };
 }

--- a/src/plugins/tidy-doc/utils/deriveFacts.ts
+++ b/src/plugins/tidy-doc/utils/deriveFacts.ts
@@ -15,6 +15,83 @@ import {
 } from "./anatomy";
 import { findRelatedCandidates } from "./findRelatedCandidates";
 import type { DerivedFacts } from "./facts";
+import type { ModeCollectionFact } from "./modes";
+
+function collectVariableAliasIds(value: unknown, ids: Set<string>): void {
+  if (value === null || typeof value !== "object") return;
+
+  const maybeAlias = value as { type?: unknown; id?: unknown };
+  if (maybeAlias.type === "VARIABLE_ALIAS" && typeof maybeAlias.id === "string") {
+    ids.add(maybeAlias.id);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) collectVariableAliasIds(item, ids);
+    return;
+  }
+
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    collectVariableAliasIds(child, ids);
+  }
+}
+
+function collectNodeBoundVariableIds(node: SceneNode, ids: Set<string>): void {
+  const candidate = node as unknown as {
+    boundVariables?: unknown;
+    fills?: unknown;
+    strokes?: unknown;
+    effects?: unknown;
+    layoutGrids?: unknown;
+    children?: readonly SceneNode[];
+  };
+
+  collectVariableAliasIds(candidate.boundVariables, ids);
+  collectVariableAliasIds(candidate.fills, ids);
+  collectVariableAliasIds(candidate.strokes, ids);
+  collectVariableAliasIds(candidate.effects, ids);
+  collectVariableAliasIds(candidate.layoutGrids, ids);
+
+  for (const child of candidate.children ?? []) {
+    collectNodeBoundVariableIds(child, ids);
+  }
+}
+
+async function deriveModeCollections(
+  node: ComponentNode | ComponentSetNode,
+): Promise<ModeCollectionFact[]> {
+  const aliasIds = new Set<string>();
+  collectNodeBoundVariableIds(node, aliasIds);
+  if (aliasIds.size === 0) return [];
+
+  const localCollections = await figma.variables.getLocalVariableCollectionsAsync();
+  const localById = new Map(localCollections.map((collection) => [collection.id, collection]));
+  const collectionIds = new Set<string>();
+
+  for (const variableId of aliasIds) {
+    const variable = await figma.variables.getVariableByIdAsync(variableId);
+    if (variable) collectionIds.add(variable.variableCollectionId);
+  }
+
+  const collections: ModeCollectionFact[] = [];
+  for (const collectionId of collectionIds) {
+    const collection =
+      localById.get(collectionId) ??
+      (await figma.variables.getVariableCollectionByIdAsync(collectionId));
+    if (!collection || collection.modes.length <= 1) continue;
+    collections.push({
+      id: collection.id,
+      name: collection.name,
+      defaultModeId: collection.defaultModeId,
+      modes: collection.modes.map((mode) => ({
+        modeId: mode.modeId,
+        name: mode.name,
+      })),
+    });
+  }
+
+  return collections;
+}
 
 function deriveHeights(
   node: ComponentSetNode,
@@ -90,6 +167,7 @@ export async function deriveFacts(
   }
 
   const categorization = categorizeAxes(descriptors);
+  const modeCollections = await deriveModeCollections(node);
   const relatedCandidates = await findRelatedCandidates(node);
 
   const widthSource = node.type === "COMPONENT_SET" ? node.defaultVariant ?? node : node;
@@ -103,6 +181,7 @@ export async function deriveFacts(
     componentName: node.name,
     ...categorization,
     breakdown: { heights, width, iconPlacement },
+    modeCollections,
     relatedCandidates,
   };
 }

--- a/src/plugins/tidy-doc/utils/deriveFacts.ts
+++ b/src/plugins/tidy-doc/utils/deriveFacts.ts
@@ -66,18 +66,30 @@ async function deriveModeCollections(
 
   const localCollections = await figma.variables.getLocalVariableCollectionsAsync();
   const localById = new Map(localCollections.map((collection) => [collection.id, collection]));
-  const collectionIds = new Set<string>();
 
-  for (const variableId of aliasIds) {
-    const variable = await figma.variables.getVariableByIdAsync(variableId);
+  // Fetch all bound variables in one parallel batch (was N sequential awaits).
+  const variableIds = [...aliasIds];
+  const variables = await Promise.all(
+    variableIds.map((id) => figma.variables.getVariableByIdAsync(id)),
+  );
+  const collectionIds = new Set<string>();
+  for (const variable of variables) {
     if (variable) collectionIds.add(variable.variableCollectionId);
+  }
+
+  // Fetch any non-local collections in parallel (was N sequential awaits).
+  const remoteIds = [...collectionIds].filter((id) => !localById.has(id));
+  const remoteCollections = await Promise.all(
+    remoteIds.map((id) => figma.variables.getVariableCollectionByIdAsync(id)),
+  );
+  const allById = new Map(localCollections.map((c) => [c.id, c]));
+  for (const c of remoteCollections) {
+    if (c) allById.set(c.id, c);
   }
 
   const collections: ModeCollectionFact[] = [];
   for (const collectionId of collectionIds) {
-    const collection =
-      localById.get(collectionId) ??
-      (await figma.variables.getVariableCollectionByIdAsync(collectionId));
+    const collection = allById.get(collectionId);
     if (!collection || collection.modes.length <= 1) continue;
     collections.push({
       id: collection.id,

--- a/src/plugins/tidy-doc/utils/deriveFacts.ts
+++ b/src/plugins/tidy-doc/utils/deriveFacts.ts
@@ -1,0 +1,37 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Figma-touching adapter: reads a component (set)'s live variant properties
+// and feeds them into the pure categoriser. Not unit tested — the repo's
+// convention is to test the pure core only (categorizeAxes.test.ts) and
+// treat the Figma-API adapter as validated by manual/plugin verification.
+
+import { categorizeAxes, type AxisDescriptor } from "./categorizeAxes";
+import type { DerivedFacts } from "./facts";
+
+export function deriveFacts(
+  node: ComponentNode | ComponentSetNode,
+): DerivedFacts {
+  const descriptors: AxisDescriptor[] = [];
+
+  if (node.type === "COMPONENT_SET") {
+    const defaults = node.defaultVariant?.variantProperties ?? {};
+    for (const [name, def] of Object.entries(
+      node.componentPropertyDefinitions,
+    )) {
+      if (def.type !== "VARIANT") continue;
+      descriptors.push({
+        name,
+        values: def.variantOptions ?? [],
+        defaultValue: defaults[name],
+      });
+    }
+  }
+
+  const categorization = categorizeAxes(descriptors);
+
+  return {
+    componentId: node.id,
+    componentName: node.name,
+    ...categorization,
+  };
+}

--- a/src/plugins/tidy-doc/utils/deriveFacts.ts
+++ b/src/plugins/tidy-doc/utils/deriveFacts.ts
@@ -21,7 +21,10 @@ function collectVariableAliasIds(value: unknown, ids: Set<string>): void {
   if (value === null || typeof value !== "object") return;
 
   const maybeAlias = value as { type?: unknown; id?: unknown };
-  if (maybeAlias.type === "VARIABLE_ALIAS" && typeof maybeAlias.id === "string") {
+  if (
+    maybeAlias.type === "VARIABLE_ALIAS" &&
+    typeof maybeAlias.id === "string"
+  ) {
     ids.add(maybeAlias.id);
     return;
   }
@@ -64,8 +67,11 @@ async function deriveModeCollections(
   collectNodeBoundVariableIds(node, aliasIds);
   if (aliasIds.size === 0) return [];
 
-  const localCollections = await figma.variables.getLocalVariableCollectionsAsync();
-  const localById = new Map(localCollections.map((collection) => [collection.id, collection]));
+  const localCollections =
+    await figma.variables.getLocalVariableCollectionsAsync();
+  const localById = new Map(
+    localCollections.map((collection) => [collection.id, collection]),
+  );
 
   // Fetch all bound variables in one parallel batch (was N sequential awaits).
   const variableIds = [...aliasIds];
@@ -120,7 +126,8 @@ function deriveHeights(
   }
 
   const childDescriptors = node.children.map((child) => ({
-    variantProperties: child.type === "COMPONENT" ? child.variantProperties : null,
+    variantProperties:
+      child.type === "COMPONENT" ? child.variantProperties : null,
   }));
 
   const heights: SizeMeasurement[] = [];
@@ -182,11 +189,17 @@ export async function deriveFacts(
   const modeCollections = await deriveModeCollections(node);
   const relatedCandidates = await findRelatedCandidates(node);
 
-  const widthSource = node.type === "COMPONENT_SET" ? node.defaultVariant ?? node : node;
-  const width = deriveWidthFact(widthSource.minWidth ?? null, widthSource.maxWidth ?? null);
+  const widthSource =
+    node.type === "COMPONENT_SET" ? (node.defaultVariant ?? node) : node;
+  const width = deriveWidthFact(
+    widthSource.minWidth ?? null,
+    widthSource.maxWidth ?? null,
+  );
   const iconPlacement = detectIconPlacement(propertyDescriptors);
   const heights =
-    node.type === "COMPONENT_SET" ? deriveHeights(node, categorization, defaults) : [];
+    node.type === "COMPONENT_SET"
+      ? deriveHeights(node, categorization, defaults)
+      : [];
 
   return {
     componentId: node.id,

--- a/src/plugins/tidy-doc/utils/deriveFacts.ts
+++ b/src/plugins/tidy-doc/utils/deriveFacts.ts
@@ -6,11 +6,12 @@
 // treat the Figma-API adapter as validated by manual/plugin verification.
 
 import { categorizeAxes, type AxisDescriptor } from "./categorizeAxes";
+import { findRelatedCandidates } from "./findRelatedCandidates";
 import type { DerivedFacts } from "./facts";
 
-export function deriveFacts(
+export async function deriveFacts(
   node: ComponentNode | ComponentSetNode,
-): DerivedFacts {
+): Promise<DerivedFacts> {
   const descriptors: AxisDescriptor[] = [];
 
   if (node.type === "COMPONENT_SET") {
@@ -28,10 +29,12 @@ export function deriveFacts(
   }
 
   const categorization = categorizeAxes(descriptors);
+  const relatedCandidates = await findRelatedCandidates(node);
 
   return {
     componentId: node.id,
     componentName: node.name,
+    relatedCandidates,
     ...categorization,
   };
 }

--- a/src/plugins/tidy-doc/utils/didYouMean.ts
+++ b/src/plugins/tidy-doc/utils/didYouMean.ts
@@ -1,0 +1,46 @@
+// Pure nearest-match hint over a candidate list, used by resolveReferences
+// to help an author fix an unresolved reference (ADR-0008).
+
+function levenshtein(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const dist: number[][] = Array.from({ length: rows }, (_, i) =>
+    Array.from({ length: cols }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
+  );
+
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dist[i][j] = Math.min(
+        dist[i - 1][j] + 1,
+        dist[i][j - 1] + 1,
+        dist[i - 1][j - 1] + cost,
+      );
+    }
+  }
+  return dist[rows - 1][cols - 1];
+}
+
+/**
+ * Returns the closest candidate to `value`, or undefined if none is close
+ * enough to be a useful hint (distance must be at most a third of the
+ * longer string's length, and always at most 4 edits).
+ */
+export function didYouMean(
+  value: string,
+  candidates: string[],
+): string | undefined {
+  if (candidates.length === 0) return undefined;
+
+  let best: { candidate: string; distance: number } | null = null;
+  for (const candidate of candidates) {
+    const distance = levenshtein(value.toLowerCase(), candidate.toLowerCase());
+    if (!best || distance < best.distance) {
+      best = { candidate, distance };
+    }
+  }
+  if (!best) return undefined;
+
+  const threshold = Math.min(4, Math.ceil(Math.max(value.length, best.candidate.length) / 3));
+  return best.distance <= threshold ? best.candidate : undefined;
+}

--- a/src/plugins/tidy-doc/utils/didYouMean.ts
+++ b/src/plugins/tidy-doc/utils/didYouMean.ts
@@ -41,6 +41,9 @@ export function didYouMean(
   }
   if (!best) return undefined;
 
-  const threshold = Math.min(4, Math.ceil(Math.max(value.length, best.candidate.length) / 3));
+  const threshold = Math.min(
+    4,
+    Math.ceil(Math.max(value.length, best.candidate.length) / 3),
+  );
   return best.distance <= threshold ? best.candidate : undefined;
 }

--- a/src/plugins/tidy-doc/utils/docSpec.test.ts
+++ b/src/plugins/tidy-doc/utils/docSpec.test.ts
@@ -63,4 +63,96 @@ describe("DocSpecSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  const validScene = {
+    layout: "row" as const,
+    instances: [{ props: { Type: "Primary" }, labelOverride: "Primary" }],
+  };
+
+  it("accepts a guidelines block with bullet lists and a doDonts pair", () => {
+    const result = DocSpecSchema.safeParse({
+      status: "IDEATION",
+      guidelines: {
+        whenToUse: ["When a single primary action is needed."],
+        doDonts: [
+          {
+            description: "Don't pair two primary buttons in the same row.",
+            good: validScene,
+            bad: { layout: "row", instances: [validScene.instances[0], validScene.instances[0]] },
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a present-but-empty guidelines object (presence-only minimum rule)", () => {
+    const result = DocSpecSchema.safeParse({ status: "LIVE", guidelines: {} });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a doDonts pair missing the bad scene", () => {
+    const result = DocSpecSchema.safeParse({
+      status: "IDEATION",
+      guidelines: { doDonts: [{ description: "ok", good: validScene }] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a SpecimenScene with zero instances", () => {
+    const result = DocSpecSchema.safeParse({
+      status: "IDEATION",
+      guidelines: {
+        doDonts: [
+          {
+            description: "ok",
+            good: { layout: "row", instances: [] },
+            bad: validScene,
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a SpecimenScene with more than 4 instances", () => {
+    const result = DocSpecSchema.safeParse({
+      status: "IDEATION",
+      guidelines: {
+        doDonts: [
+          {
+            description: "ok",
+            good: { layout: "row", instances: Array(5).fill(validScene.instances[0]) },
+            bad: validScene,
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a doDonts array longer than 6 pairs", () => {
+    const pair = { description: "ok", good: validScene, bad: validScene };
+    const result = DocSpecSchema.safeParse({
+      status: "IDEATION",
+      guidelines: { doDonts: Array(7).fill(pair) },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid SpecimenScene layout", () => {
+    const result = DocSpecSchema.safeParse({
+      status: "IDEATION",
+      guidelines: {
+        doDonts: [
+          {
+            description: "ok",
+            good: { layout: "diagonal", instances: [validScene.instances[0]] },
+            bad: validScene,
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/plugins/tidy-doc/utils/docSpec.test.ts
+++ b/src/plugins/tidy-doc/utils/docSpec.test.ts
@@ -16,16 +16,25 @@ describe("DocSpecSchema", () => {
     const result = DocSpecSchema.safeParse({
       status: "REVIEWING",
       variants: {
-        Primary: { description: "The default call to action.", whenToUse: ["Use for the main action on a page."] },
+        Primary: {
+          description: "The default call to action.",
+          whenToUse: ["Use for the main action on a page."],
+        },
       },
-      breakdown: { heightCaption: "Height scales with size.", widthCaption: "Width hugs content.", iconPlacementCaption: "Icons sit left of the label." },
+      breakdown: {
+        heightCaption: "Height scales with size.",
+        widthCaption: "Width hugs content.",
+        iconPlacementCaption: "Icons sit left of the label.",
+      },
       mode: { caption: "Adapts to light and dark themes." },
       guidelines: {
         whenToUse: ["When a single primary action is needed."],
         whenNotToUse: ["When multiple equal-weight actions are shown."],
         general: ["Keep labels short and action-oriented."],
       },
-      related: { "Icon Button": { guidance: "Use when the action has no text label." } },
+      related: {
+        "Icon Button": { guidance: "Use when the action has no text label." },
+      },
     });
     expect(result.success).toBe(true);
   });
@@ -51,7 +60,9 @@ describe("DocSpecSchema", () => {
   it("rejects an over-length whenToUse item", () => {
     const result = DocSpecSchema.safeParse({
       status: "IDEATION",
-      variants: { Primary: { description: "ok", whenToUse: ["x".repeat(121)] } },
+      variants: {
+        Primary: { description: "ok", whenToUse: ["x".repeat(121)] },
+      },
     });
     expect(result.success).toBe(false);
   });
@@ -59,7 +70,9 @@ describe("DocSpecSchema", () => {
   it("rejects a whenToUse array longer than 6 items", () => {
     const result = DocSpecSchema.safeParse({
       status: "IDEATION",
-      variants: { Primary: { description: "ok", whenToUse: Array(7).fill("short") } },
+      variants: {
+        Primary: { description: "ok", whenToUse: Array(7).fill("short") },
+      },
     });
     expect(result.success).toBe(false);
   });
@@ -78,7 +91,10 @@ describe("DocSpecSchema", () => {
           {
             description: "Don't pair two primary buttons in the same row.",
             good: validScene,
-            bad: { layout: "row", instances: [validScene.instances[0], validScene.instances[0]] },
+            bad: {
+              layout: "row",
+              instances: [validScene.instances[0], validScene.instances[0]],
+            },
           },
         ],
       },
@@ -122,7 +138,10 @@ describe("DocSpecSchema", () => {
         doDonts: [
           {
             description: "ok",
-            good: { layout: "row", instances: Array(5).fill(validScene.instances[0]) },
+            good: {
+              layout: "row",
+              instances: Array(5).fill(validScene.instances[0]),
+            },
             bad: validScene,
           },
         ],

--- a/src/plugins/tidy-doc/utils/docSpec.test.ts
+++ b/src/plugins/tidy-doc/utils/docSpec.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { DocSpecSchema } from "./docSpec";
+
+describe("DocSpecSchema", () => {
+  it("accepts a minimal valid spec (status only)", () => {
+    const result = DocSpecSchema.safeParse({ status: "IDEATION" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a present-but-empty variants object (presence-only minimum rule)", () => {
+    const result = DocSpecSchema.safeParse({ status: "LIVE", variants: {} });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a full spec across every Section key", () => {
+    const result = DocSpecSchema.safeParse({
+      status: "REVIEWING",
+      variants: {
+        Primary: { description: "The default call to action.", whenToUse: ["Use for the main action on a page."] },
+      },
+      breakdown: { heightCaption: "Height scales with size.", widthCaption: "Width hugs content.", iconPlacementCaption: "Icons sit left of the label." },
+      mode: { caption: "Adapts to light and dark themes." },
+      guidelines: {
+        whenToUse: ["When a single primary action is needed."],
+        whenNotToUse: ["When multiple equal-weight actions are shown."],
+        general: ["Keep labels short and action-oriented."],
+      },
+      related: { "Icon Button": { guidance: "Use when the action has no text label." } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a spec missing status", () => {
+    const result = DocSpecSchema.safeParse({ variants: {} });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown status enum value", () => {
+    const result = DocSpecSchema.safeParse({ status: "SHIPPED" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an over-length variant description", () => {
+    const result = DocSpecSchema.safeParse({
+      status: "IDEATION",
+      variants: { Primary: { description: "x".repeat(241) } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an over-length whenToUse item", () => {
+    const result = DocSpecSchema.safeParse({
+      status: "IDEATION",
+      variants: { Primary: { description: "ok", whenToUse: ["x".repeat(121)] } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a whenToUse array longer than 6 items", () => {
+    const result = DocSpecSchema.safeParse({
+      status: "IDEATION",
+      variants: { Primary: { description: "ok", whenToUse: Array(7).fill("short") } },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/plugins/tidy-doc/utils/docSpec.ts
+++ b/src/plugins/tidy-doc/utils/docSpec.ts
@@ -1,0 +1,68 @@
+// The Doc Spec schema — the boundary object between authored content (an
+// LLM, or tidy-doc's own facts-only fallback) and the layout side
+// (buildDocPage). Validated at the MCP boundary (mcp-server/src/catalogue.ts
+// imports this schema directly) per ADR-0007: hard maximums, presence-only
+// minimums, no forced item counts.
+//
+// v1 (#52 tracer bullet) renders only `status` + `variants`. The remaining
+// Section keys are accepted here so a later slice (#51) doesn't need a
+// breaking schema change, but nothing builds them yet — see
+// utils/buildDocPage.ts.
+
+import { z } from "zod";
+
+export const DOC_STATUSES = [
+  "IDEATION",
+  "in process",
+  "DESIGN COMPLETED",
+  "REVIEWING",
+  "DEV HAND-OFF",
+  "ON HOLD",
+  "CANCELED",
+  "LIVE",
+] as const;
+
+export type DocStatus = (typeof DOC_STATUSES)[number];
+
+const VariantFamilySchema = z.object({
+  description: z.string().max(240),
+  whenToUse: z.array(z.string().max(120)).max(6).optional(),
+});
+
+export const DocSpecSchema = z.object({
+  status: z.enum(DOC_STATUSES),
+
+  variants: z.record(z.string(), VariantFamilySchema).optional(),
+
+  // Accepted-but-not-yet-rendered slots (full #51 shape). Shape/length is
+  // enforced now so authoring against it won't need to change once these
+  // Sections render; `doDonts` (a SpecimenScene) is omitted — there is no
+  // renderer to validate that decision against yet.
+  breakdown: z
+    .object({
+      heightCaption: z.string().max(200).optional(),
+      widthCaption: z.string().max(200).optional(),
+      iconPlacementCaption: z.string().max(200).optional(),
+    })
+    .optional(),
+
+  mode: z
+    .object({
+      caption: z.string().max(200).optional(),
+    })
+    .optional(),
+
+  guidelines: z
+    .object({
+      whenToUse: z.array(z.string().max(120)).max(8).optional(),
+      whenNotToUse: z.array(z.string().max(120)).max(8).optional(),
+      general: z.array(z.string().max(160)).max(8).optional(),
+    })
+    .optional(),
+
+  related: z
+    .record(z.string(), z.object({ guidance: z.string().max(160) }))
+    .optional(),
+});
+
+export type DocSpec = z.infer<typeof DocSpecSchema>;

--- a/src/plugins/tidy-doc/utils/docSpec.ts
+++ b/src/plugins/tidy-doc/utils/docSpec.ts
@@ -4,7 +4,8 @@
 // imports this schema directly) per ADR-0007: hard maximums, presence-only
 // minimums, no forced item counts.
 //
-// v1 (#52 tracer bullet) renders only `status` + `variants`. The remaining
+// v1 (#52 tracer bullet) renders only `status` + `variants`; #56 adds
+// `guidelines` (bullet lists + `doDonts` Specimen Scenes). The remaining
 // Section keys are accepted here so a later slice (#51) doesn't need a
 // breaking schema change, but nothing builds them yet — see
 // utils/buildDocPage.ts.
@@ -29,6 +30,28 @@ const VariantFamilySchema = z.object({
   whenToUse: z.array(z.string().max(120)).max(6).optional(),
 });
 
+// Specimen Scene (CONTEXT.md "Specimen"): the constrained vocabulary shared
+// by Variants, Mode, and Do/Don't. 1–4 source-component instances, each with
+// axis-value refs (bare strings, re-resolved at build per ADR-0008) and an
+// optional label, arranged in a row or stack. It cannot place arbitrary
+// nodes or other components — a scene outside this vocabulary is simply not
+// expressible here.
+const SpecimenSceneInstanceSchema = z.object({
+  props: z.record(z.string(), z.string()),
+  labelOverride: z.string().max(60).optional(),
+});
+
+const SpecimenSceneSchema = z.object({
+  layout: z.enum(["row", "stack"]),
+  instances: z.array(SpecimenSceneInstanceSchema).min(1).max(4),
+});
+
+const DoDontPairSchema = z.object({
+  description: z.string().max(200),
+  good: SpecimenSceneSchema,
+  bad: SpecimenSceneSchema,
+});
+
 export const DocSpecSchema = z.object({
   status: z.enum(DOC_STATUSES),
 
@@ -36,8 +59,7 @@ export const DocSpecSchema = z.object({
 
   // Accepted-but-not-yet-rendered slots (full #51 shape). Shape/length is
   // enforced now so authoring against it won't need to change once these
-  // Sections render; `doDonts` (a SpecimenScene) is omitted — there is no
-  // renderer to validate that decision against yet.
+  // Sections render.
   breakdown: z
     .object({
       heightCaption: z.string().max(200).optional(),
@@ -57,6 +79,7 @@ export const DocSpecSchema = z.object({
       whenToUse: z.array(z.string().max(120)).max(8).optional(),
       whenNotToUse: z.array(z.string().max(120)).max(8).optional(),
       general: z.array(z.string().max(160)).max(8).optional(),
+      doDonts: z.array(DoDontPairSchema).max(6).optional(),
     })
     .optional(),
 
@@ -66,3 +89,5 @@ export const DocSpecSchema = z.object({
 });
 
 export type DocSpec = z.infer<typeof DocSpecSchema>;
+export type SpecimenScene = z.infer<typeof SpecimenSceneSchema>;
+export type DoDontPair = z.infer<typeof DoDontPairSchema>;

--- a/src/plugins/tidy-doc/utils/docSpec.ts
+++ b/src/plugins/tidy-doc/utils/docSpec.ts
@@ -4,11 +4,9 @@
 // imports this schema directly) per ADR-0007: hard maximums, presence-only
 // minimums, no forced item counts.
 //
-// v1 (#52 tracer bullet) renders only `status` + `variants`; #56 adds
-// `guidelines` (bullet lists + `doDonts` Specimen Scenes). The remaining
-// Section keys are accepted here so a later slice (#51) doesn't need a
-// breaking schema change, but nothing builds them yet — see
-// utils/buildDocPage.ts.
+// All Section keys are now rendered: Variants (#53), Breakdown (#54),
+// Mode (#55), Guidelines (#56), and Related (#57). The build orchestrator
+// is in utils/buildDocPage.ts.
 
 import { z } from "zod";
 

--- a/src/plugins/tidy-doc/utils/facts.ts
+++ b/src/plugins/tidy-doc/utils/facts.ts
@@ -1,0 +1,10 @@
+// Plain-data shape for a component's derived facts. Deliberately free of any
+// Figma type so pure modules (resolveReferences, and this module's own
+// tests) can depend on it without pulling in the Figma runtime.
+
+import type { CategorizationResult } from "./categorizeAxes";
+
+export interface DerivedFacts extends CategorizationResult {
+  componentId: string;
+  componentName: string;
+}

--- a/src/plugins/tidy-doc/utils/facts.ts
+++ b/src/plugins/tidy-doc/utils/facts.ts
@@ -3,8 +3,10 @@
 // tests) can depend on it without pulling in the Figma runtime.
 
 import type { CategorizationResult } from "./categorizeAxes";
+import type { RelatedCandidate } from "./rankRelatedCandidates";
 
 export interface DerivedFacts extends CategorizationResult {
   componentId: string;
   componentName: string;
+  relatedCandidates: RelatedCandidate[];
 }

--- a/src/plugins/tidy-doc/utils/facts.ts
+++ b/src/plugins/tidy-doc/utils/facts.ts
@@ -5,6 +5,7 @@
 import type { CategorizationResult } from "./categorizeAxes";
 import type { IconPlacementFact, SizeMeasurement, WidthFact } from "./anatomy";
 import type { RelatedCandidate } from "./rankRelatedCandidates";
+import type { ModeCollectionFact } from "./modes";
 
 export interface BreakdownFacts {
   heights: SizeMeasurement[];
@@ -16,5 +17,6 @@ export interface DerivedFacts extends CategorizationResult {
   componentId: string;
   componentName: string;
   breakdown: BreakdownFacts;
+  modeCollections: ModeCollectionFact[];
   relatedCandidates: RelatedCandidate[];
 }

--- a/src/plugins/tidy-doc/utils/facts.ts
+++ b/src/plugins/tidy-doc/utils/facts.ts
@@ -3,8 +3,16 @@
 // tests) can depend on it without pulling in the Figma runtime.
 
 import type { CategorizationResult } from "./categorizeAxes";
+import type { IconPlacementFact, SizeMeasurement, WidthFact } from "./anatomy";
+
+export interface BreakdownFacts {
+  heights: SizeMeasurement[];
+  width: WidthFact | null;
+  iconPlacement: IconPlacementFact | null;
+}
 
 export interface DerivedFacts extends CategorizationResult {
   componentId: string;
   componentName: string;
+  breakdown: BreakdownFacts;
 }

--- a/src/plugins/tidy-doc/utils/findRelatedCandidates.ts
+++ b/src/plugins/tidy-doc/utils/findRelatedCandidates.ts
@@ -31,7 +31,9 @@ async function collectBuildingBlockNames(
   return names;
 }
 
-function collectOwnFamilyNames(source: ComponentNode | ComponentSetNode): string[] {
+function collectOwnFamilyNames(
+  source: ComponentNode | ComponentSetNode,
+): string[] {
   if (source.type === "COMPONENT_SET") {
     return source.children.map((child) => child.name);
   }

--- a/src/plugins/tidy-doc/utils/findRelatedCandidates.ts
+++ b/src/plugins/tidy-doc/utils/findRelatedCandidates.ts
@@ -54,6 +54,10 @@ export async function findRelatedCandidates(
   await figma.loadAllPagesAsync();
   const allNames = figma.root
     .findAllWithCriteria({ types: ["COMPONENT_SET", "COMPONENT"] })
+    // Exclude variant children of component sets — findAllWithCriteria
+    // matches every nested component, but related-candidate ranking is
+    // about top-level peers, not internal variant children.
+    .filter((node) => node.parent?.type !== "COMPONENT_SET")
     .map((node) => node.name);
 
   return rankRelatedCandidates(source.name, allNames, excludeNames, cap);

--- a/src/plugins/tidy-doc/utils/findRelatedCandidates.ts
+++ b/src/plugins/tidy-doc/utils/findRelatedCandidates.ts
@@ -1,0 +1,60 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Figma-touching adapter: file-wide token-overlap scan for Related-component
+// candidates (CONTEXT.md "Related-component candidates…"). Excludes the
+// source's own family (itself + sibling variants in the same component set)
+// and its building blocks (components reachable as nested instances inside
+// it, resolved via findAllWithCriteria(['INSTANCE']) + getMainComponentAsync
+// per component). No dependency on the ds-explorer registry — works over any
+// client file. Not unit tested — Figma-API adapter; the pure ranking core is
+// tested in rankRelatedCandidates.test.ts.
+
+import {
+  DEFAULT_RELATED_CANDIDATES_CAP,
+  rankRelatedCandidates,
+  type RelatedCandidate,
+} from "./rankRelatedCandidates";
+
+async function collectBuildingBlockNames(
+  source: ComponentNode | ComponentSetNode,
+): Promise<string[]> {
+  const names: string[] = [];
+  const instances = source.findAllWithCriteria({ types: ["INSTANCE"] });
+  for (const instance of instances) {
+    const main = await instance.getMainComponentAsync();
+    if (!main) continue;
+    names.push(main.name);
+    if (main.parent?.type === "COMPONENT_SET") {
+      names.push(main.parent.name);
+    }
+  }
+  return names;
+}
+
+function collectOwnFamilyNames(source: ComponentNode | ComponentSetNode): string[] {
+  if (source.type === "COMPONENT_SET") {
+    return source.children.map((child) => child.name);
+  }
+  if (source.parent?.type === "COMPONENT_SET") {
+    return [source.parent.name, ...source.parent.children.map((c) => c.name)];
+  }
+  return [];
+}
+
+export async function findRelatedCandidates(
+  source: ComponentNode | ComponentSetNode,
+  cap: number = DEFAULT_RELATED_CANDIDATES_CAP,
+): Promise<RelatedCandidate[]> {
+  const excludeNames = new Set<string>([
+    source.name,
+    ...collectOwnFamilyNames(source),
+    ...(await collectBuildingBlockNames(source)),
+  ]);
+
+  await figma.loadAllPagesAsync();
+  const allNames = figma.root
+    .findAllWithCriteria({ types: ["COMPONENT_SET", "COMPONENT"] })
+    .map((node) => node.name);
+
+  return rankRelatedCandidates(source.name, allNames, excludeNames, cap);
+}

--- a/src/plugins/tidy-doc/utils/modes.test.ts
+++ b/src/plugins/tidy-doc/utils/modes.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildModeCrossProduct, modeShowcaseLabel, type ModeCollectionFact } from "./modes";
+import {
+  buildModeCrossProduct,
+  modeShowcaseLabel,
+  type ModeCollectionFact,
+} from "./modes";
 
 const theme: ModeCollectionFact = {
   id: "collection-theme",

--- a/src/plugins/tidy-doc/utils/modes.test.ts
+++ b/src/plugins/tidy-doc/utils/modes.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { buildModeCrossProduct, modeShowcaseLabel, type ModeCollectionFact } from "./modes";
+
+const theme: ModeCollectionFact = {
+  id: "collection-theme",
+  name: "Theme",
+  defaultModeId: "light",
+  modes: [
+    { modeId: "light", name: "Light" },
+    { modeId: "dark", name: "Dark" },
+  ],
+};
+
+const density: ModeCollectionFact = {
+  id: "collection-density",
+  name: "Density",
+  defaultModeId: "regular",
+  modes: [
+    { modeId: "regular", name: "Regular" },
+    { modeId: "compact", name: "Compact" },
+  ],
+};
+
+describe("buildModeCrossProduct", () => {
+  it("returns no showcases for no multi-mode collections", () => {
+    expect(buildModeCrossProduct([])).toEqual({ showcases: [], dropped: 0 });
+  });
+
+  it("renders one showcase per mode for a single collection", () => {
+    const result = buildModeCrossProduct([theme]);
+    expect(result.dropped).toBe(0);
+    expect(result.showcases.map(modeShowcaseLabel)).toEqual([
+      "Theme: Light",
+      "Theme: Dark",
+    ]);
+  });
+
+  it("crosses multiple collections in collection/mode order", () => {
+    const result = buildModeCrossProduct([theme, density]);
+    expect(result.dropped).toBe(0);
+    expect(result.showcases.map(modeShowcaseLabel)).toEqual([
+      "Theme: Light · Density: Regular",
+      "Theme: Light · Density: Compact",
+      "Theme: Dark · Density: Regular",
+      "Theme: Dark · Density: Compact",
+    ]);
+  });
+
+  it("caps showcases and reports the dropped remainder", () => {
+    const state: ModeCollectionFact = {
+      id: "collection-state",
+      name: "State",
+      defaultModeId: "rest",
+      modes: [
+        { modeId: "rest", name: "Rest" },
+        { modeId: "hover", name: "Hover" },
+        { modeId: "pressed", name: "Pressed" },
+      ],
+    };
+    const result = buildModeCrossProduct([theme, density, state], 8);
+    expect(result.showcases).toHaveLength(8);
+    expect(result.dropped).toBe(4);
+  });
+});

--- a/src/plugins/tidy-doc/utils/modes.ts
+++ b/src/plugins/tidy-doc/utils/modes.ts
@@ -1,0 +1,70 @@
+// Pure helpers for the Mode Section. Figma API adapters live in deriveFacts.ts
+// and buildModeSection.ts; this file stays plain-data so cross-product/cap
+// behaviour is unit-testable.
+
+export interface ModeFact {
+  modeId: string;
+  name: string;
+}
+
+export interface ModeCollectionFact {
+  id: string;
+  name: string;
+  defaultModeId: string;
+  modes: ModeFact[];
+}
+
+export interface ModeSelectionFact {
+  collectionId: string;
+  collectionName: string;
+  modeId: string;
+  modeName: string;
+}
+
+export interface ModeShowcaseFact {
+  selections: ModeSelectionFact[];
+}
+
+export interface ModeCrossProductResult {
+  showcases: ModeShowcaseFact[];
+  dropped: number;
+}
+
+export function buildModeCrossProduct(
+  collections: ModeCollectionFact[],
+  cap = 8,
+): ModeCrossProductResult {
+  if (collections.length === 0) return { showcases: [], dropped: 0 };
+
+  let combos: ModeShowcaseFact[] = [{ selections: [] }];
+  for (const collection of collections) {
+    const next: ModeShowcaseFact[] = [];
+    for (const combo of combos) {
+      for (const mode of collection.modes) {
+        next.push({
+          selections: [
+            ...combo.selections,
+            {
+              collectionId: collection.id,
+              collectionName: collection.name,
+              modeId: mode.modeId,
+              modeName: mode.name,
+            },
+          ],
+        });
+      }
+    }
+    combos = next;
+  }
+
+  return {
+    showcases: combos.slice(0, cap),
+    dropped: Math.max(0, combos.length - cap),
+  };
+}
+
+export function modeShowcaseLabel(showcase: ModeShowcaseFact): string {
+  return showcase.selections
+    .map((selection) => `${selection.collectionName}: ${selection.modeName}`)
+    .join(" · ");
+}

--- a/src/plugins/tidy-doc/utils/rankRelatedCandidates.test.ts
+++ b/src/plugins/tidy-doc/utils/rankRelatedCandidates.test.ts
@@ -80,7 +80,11 @@ describe("rankRelatedCandidates", () => {
   });
 
   it("returns an empty list when nothing shares a token", () => {
-    const result = rankRelatedCandidates("Button", ["Toggle", "Checkbox"], new Set());
+    const result = rankRelatedCandidates(
+      "Button",
+      ["Toggle", "Checkbox"],
+      new Set(),
+    );
     expect(result).toEqual([]);
   });
 });

--- a/src/plugins/tidy-doc/utils/rankRelatedCandidates.test.ts
+++ b/src/plugins/tidy-doc/utils/rankRelatedCandidates.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { rankRelatedCandidates } from "./rankRelatedCandidates";
+
+describe("rankRelatedCandidates", () => {
+  it("matches by distinctive-token containment, not prefix/substring", () => {
+    const result = rankRelatedCandidates(
+      "Button",
+      ["Icon Button", "Link Button", "Severity Button", "Buttonish", "Toggle"],
+      new Set(),
+    );
+    expect(result.map((c) => c.name).sort()).toEqual([
+      "Icon Button",
+      "Link Button",
+      "Severity Button",
+    ]);
+  });
+
+  it("excludes the source name itself even when present in the scan", () => {
+    const result = rankRelatedCandidates(
+      "Button",
+      ["Button", "Icon Button"],
+      new Set(),
+    );
+    expect(result.map((c) => c.name)).toEqual(["Icon Button"]);
+  });
+
+  it("excludes every name in excludeNames (own variants + building blocks)", () => {
+    const result = rankRelatedCandidates(
+      "Button",
+      ["Icon Button", "Link Button", "Icon"],
+      new Set(["Icon Button", "Icon"]),
+    );
+    expect(result.map((c) => c.name)).toEqual(["Link Button"]);
+  });
+
+  it("ranks by shared-token count descending", () => {
+    const result = rankRelatedCandidates(
+      "Icon Button",
+      ["Link Button", "Icon Link Button", "Icon"],
+      new Set(),
+    );
+    expect(result.map((c) => c.name)).toEqual([
+      "Icon Link Button",
+      "Icon",
+      "Link Button",
+    ]);
+  });
+
+  it("breaks ties alphabetically for deterministic output", () => {
+    const result = rankRelatedCandidates(
+      "Button",
+      ["Severity Button", "Link Button", "Icon Button"],
+      new Set(),
+    );
+    expect(result.map((c) => c.name)).toEqual([
+      "Icon Button",
+      "Link Button",
+      "Severity Button",
+    ]);
+  });
+
+  it("caps the ranked result list", () => {
+    const result = rankRelatedCandidates(
+      "Button",
+      ["A Button", "B Button", "C Button", "D Button"],
+      new Set(),
+      2,
+    );
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.name)).toEqual(["A Button", "B Button"]);
+  });
+
+  it("dedupes repeated names in the scan input", () => {
+    const result = rankRelatedCandidates(
+      "Button",
+      ["Icon Button", "Icon Button"],
+      new Set(),
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("returns an empty list when nothing shares a token", () => {
+    const result = rankRelatedCandidates("Button", ["Toggle", "Checkbox"], new Set());
+    expect(result).toEqual([]);
+  });
+});

--- a/src/plugins/tidy-doc/utils/rankRelatedCandidates.ts
+++ b/src/plugins/tidy-doc/utils/rankRelatedCandidates.ts
@@ -1,0 +1,65 @@
+// Pure candidate-ranking core for the Related Components Section
+// (CONTEXT.md "Related-component candidates…"). No Figma types — operates on
+// plain name strings so it can be unit tested without a Figma runtime
+// (mirrors categorizeAxes.ts). The Figma-touching file-wide scan +
+// exclusion-set assembly lives in findRelatedCandidates.ts.
+//
+// Matching is by *distinctive-token containment*: a candidate name shares at
+// least one whitespace/case/punctuation-delimited token with the source name
+// (source "Button" -> "Icon Button", "Link Button", "Severity Button"), not
+// substring/prefix (so "Buttonish" does not match "Button").
+
+export interface RelatedCandidate {
+  name: string;
+  matchedTokens: string[];
+}
+
+export const DEFAULT_RELATED_CANDIDATES_CAP = 12;
+
+function tokenize(name: string): string[] {
+  return name
+    .split(/[^a-zA-Z0-9]+/)
+    .flatMap((chunk) => chunk.split(/(?<=[a-z0-9])(?=[A-Z])/))
+    .map((token) => token.toLowerCase())
+    .filter(Boolean);
+}
+
+/**
+ * Rank candidate names by distinctive-token containment against
+ * `sourceName`, excluding `sourceName` itself and every name in
+ * `excludeNames`, capped at `cap`. Ties break alphabetically for
+ * deterministic output.
+ */
+export function rankRelatedCandidates(
+  sourceName: string,
+  allComponentNames: string[],
+  excludeNames: ReadonlySet<string>,
+  cap: number = DEFAULT_RELATED_CANDIDATES_CAP,
+): RelatedCandidate[] {
+  const sourceTokens = new Set(tokenize(sourceName));
+  const seen = new Set<string>();
+  const candidates: RelatedCandidate[] = [];
+
+  for (const name of allComponentNames) {
+    if (name === sourceName) continue;
+    if (excludeNames.has(name)) continue;
+    if (seen.has(name)) continue;
+    seen.add(name);
+
+    const matchedTokens = [
+      ...new Set(tokenize(name).filter((token) => sourceTokens.has(token))),
+    ];
+    if (matchedTokens.length === 0) continue;
+
+    candidates.push({ name, matchedTokens });
+  }
+
+  candidates.sort((a, b) => {
+    if (b.matchedTokens.length !== a.matchedTokens.length) {
+      return b.matchedTokens.length - a.matchedTokens.length;
+    }
+    return a.name.localeCompare(b.name);
+  });
+
+  return candidates.slice(0, cap);
+}

--- a/src/plugins/tidy-doc/utils/resolveReferences.test.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.test.ts
@@ -11,6 +11,10 @@ const facts: DerivedFacts = {
   sizeAxis: null,
   demoted: [],
   pinnedDefaults: { State: "Idle" },
+  relatedCandidates: [
+    { name: "Icon Button", matchedTokens: ["button"] },
+    { name: "Link Button", matchedTokens: ["button"] },
+  ],
 };
 
 describe("resolveDocSpecReferences", () => {
@@ -63,5 +67,41 @@ describe("resolveDocSpecReferences", () => {
     const spec: DocSpec = { status: "LIVE" };
     const result = resolveDocSpecReferences(spec, facts);
     expect(result.unresolved).toEqual([]);
+  });
+
+  it("resolves every related key that matches a ranked candidate", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      related: { "Icon Button": { guidance: "Use when the action has no text label." } },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("fails resolution for a related key naming a non-existent component", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      related: { Zzzzzzzzzz: { guidance: "not a real sibling" } },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toEqual([
+      {
+        slot: "related",
+        kind: "siblingName",
+        value: "Zzzzzzzzzz",
+        didYouMean: undefined,
+      },
+    ]);
+  });
+
+  it("batches unresolved related keys alongside unresolved variant keys", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      variants: { Bogus: { description: "not a family value" } },
+      related: { Nope: { guidance: "not a real sibling" } },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toHaveLength(2);
+    expect(result.unresolved.map((u) => u.slot).sort()).toEqual(["related", "variants"]);
   });
 });

--- a/src/plugins/tidy-doc/utils/resolveReferences.test.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.test.ts
@@ -11,6 +11,7 @@ const facts: DerivedFacts = {
   sizeAxis: null,
   demoted: [],
   pinnedDefaults: { State: "Idle" },
+  breakdown: { heights: [], width: null, iconPlacement: null },
 };
 
 describe("resolveDocSpecReferences", () => {

--- a/src/plugins/tidy-doc/utils/resolveReferences.test.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.test.ts
@@ -44,8 +44,15 @@ describe("resolveDocSpecReferences", () => {
     };
     const result = resolveDocSpecReferences(spec, facts);
     expect(result.unresolved).toHaveLength(2);
-    expect(result.unresolved.map((u) => u.value).sort()).toEqual(["Bogus", "Primry"]);
-    expect(result.unresolved.every((u) => u.slot === "variants" && u.kind === "familyValue")).toBe(true);
+    expect(result.unresolved.map((u) => u.value).sort()).toEqual([
+      "Bogus",
+      "Primry",
+    ]);
+    expect(
+      result.unresolved.every(
+        (u) => u.slot === "variants" && u.kind === "familyValue",
+      ),
+    ).toBe(true);
   });
 
   it("attaches a didYouMean hint for a near-miss", () => {
@@ -79,7 +86,10 @@ describe("resolveDocSpecReferences", () => {
         doDonts: [
           {
             description: "Don't show two primaries side by side.",
-            good: { layout: "row", instances: [{ props: { Type: "Primary" } }] },
+            good: {
+              layout: "row",
+              instances: [{ props: { Type: "Primary" } }],
+            },
             bad: {
               layout: "row",
               instances: [
@@ -115,7 +125,9 @@ describe("resolveDocSpecReferences", () => {
       value: "Typ",
       didYouMean: "Type",
     });
-    expect(result.unresolved[0].slot).toBe("guidelines.doDonts[0].good.instances[0].props");
+    expect(result.unresolved[0].slot).toBe(
+      "guidelines.doDonts[0].good.instances[0].props",
+    );
   });
 
   it("flags an unknown axis value in a doDonts scene as kind=axisValue", () => {
@@ -154,7 +166,10 @@ describe("resolveDocSpecReferences", () => {
           },
           {
             description: "pair 1",
-            good: { layout: "row", instances: [{ props: { Type: "Primary" } }] },
+            good: {
+              layout: "row",
+              instances: [{ props: { Type: "Primary" } }],
+            },
             bad: { layout: "row", instances: [{ props: { State: "Zzzzz" } }] },
           },
         ],
@@ -171,7 +186,9 @@ describe("resolveDocSpecReferences", () => {
   it("resolves every related key that matches a ranked candidate", () => {
     const spec: DocSpec = {
       status: "IDEATION",
-      related: { "Icon Button": { guidance: "Use when the action has no text label." } },
+      related: {
+        "Icon Button": { guidance: "Use when the action has no text label." },
+      },
     };
     const result = resolveDocSpecReferences(spec, facts);
     expect(result.unresolved).toEqual([]);
@@ -201,14 +218,20 @@ describe("resolveDocSpecReferences", () => {
     };
     const result = resolveDocSpecReferences(spec, facts);
     expect(result.unresolved).toHaveLength(2);
-    expect(result.unresolved.map((u) => u.slot).sort()).toEqual(["related", "variants"]);
+    expect(result.unresolved.map((u) => u.slot).sort()).toEqual([
+      "related",
+      "variants",
+    ]);
   });
 
   it("resolves a Do/Don't scene that references a demoted axis", () => {
     const factsWithDemoted: DerivedFacts = {
       ...facts,
       demoted: ["Emphasis", "Icon"],
-      demotedAxisValues: { Emphasis: ["Bold", "Subtle"], Icon: ["Leading", "Trailing"] },
+      demotedAxisValues: {
+        Emphasis: ["Bold", "Subtle"],
+        Icon: ["Leading", "Trailing"],
+      },
     };
     const spec: DocSpec = {
       status: "IDEATION",
@@ -216,8 +239,14 @@ describe("resolveDocSpecReferences", () => {
         doDonts: [
           {
             description: "demoted axis in a scene",
-            good: { layout: "row", instances: [{ props: { Emphasis: "Bold", Icon: "Leading" } }] },
-            bad: { layout: "row", instances: [{ props: { Emphasis: "Subtle" } }] },
+            good: {
+              layout: "row",
+              instances: [{ props: { Emphasis: "Bold", Icon: "Leading" } }],
+            },
+            bad: {
+              layout: "row",
+              instances: [{ props: { Emphasis: "Subtle" } }],
+            },
           },
         ],
       },

--- a/src/plugins/tidy-doc/utils/resolveReferences.test.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.test.ts
@@ -12,6 +12,7 @@ const facts: DerivedFacts = {
   demoted: [],
   pinnedDefaults: { State: "Idle" },
   breakdown: { heights: [], width: null, iconPlacement: null },
+  modeCollections: [],
   relatedCandidates: [
     { name: "Icon Button", matchedTokens: ["button"] },
     { name: "Link Button", matchedTokens: ["button"] },

--- a/src/plugins/tidy-doc/utils/resolveReferences.test.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.test.ts
@@ -64,4 +64,100 @@ describe("resolveDocSpecReferences", () => {
     const result = resolveDocSpecReferences(spec, facts);
     expect(result.unresolved).toEqual([]);
   });
+
+  it("resolves a doDonts SpecimenScene whose props match real axis values", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      guidelines: {
+        doDonts: [
+          {
+            description: "Don't show two primaries side by side.",
+            good: { layout: "row", instances: [{ props: { Type: "Primary" } }] },
+            bad: {
+              layout: "row",
+              instances: [
+                { props: { Type: "Primary" } },
+                { props: { Type: "Primary" } },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toEqual([]);
+  });
+
+  it("flags an unknown axis name in a doDonts scene as kind=axisName", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      guidelines: {
+        doDonts: [
+          {
+            description: "typo'd axis name",
+            good: { layout: "row", instances: [{ props: { Typ: "Primary" } }] },
+            bad: { layout: "row", instances: [{ props: { Type: "Primary" } }] },
+          },
+        ],
+      },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toHaveLength(1);
+    expect(result.unresolved[0]).toMatchObject({
+      kind: "axisName",
+      value: "Typ",
+      didYouMean: "Type",
+    });
+    expect(result.unresolved[0].slot).toBe("guidelines.doDonts[0].good.instances[0].props");
+  });
+
+  it("flags an unknown axis value in a doDonts scene as kind=axisValue", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      guidelines: {
+        doDonts: [
+          {
+            description: "typo'd value",
+            good: { layout: "row", instances: [{ props: { Type: "Primry" } }] },
+            bad: { layout: "row", instances: [{ props: { Type: "Primary" } }] },
+          },
+        ],
+      },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toEqual([
+      {
+        slot: "guidelines.doDonts[0].good.instances[0].props.Type",
+        kind: "axisValue",
+        value: "Primry",
+        didYouMean: "Primary",
+      },
+    ]);
+  });
+
+  it("batches unresolved refs across both good and bad scenes of multiple pairs", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      guidelines: {
+        doDonts: [
+          {
+            description: "pair 0",
+            good: { layout: "row", instances: [{ props: { Type: "Bogus" } }] },
+            bad: { layout: "row", instances: [{ props: { State: "Hover" } }] },
+          },
+          {
+            description: "pair 1",
+            good: { layout: "row", instances: [{ props: { Type: "Primary" } }] },
+            bad: { layout: "row", instances: [{ props: { State: "Zzzzz" } }] },
+          },
+        ],
+      },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toHaveLength(2);
+    expect(result.unresolved.map((u) => u.slot)).toEqual([
+      "guidelines.doDonts[0].good.instances[0].props.Type",
+      "guidelines.doDonts[1].bad.instances[0].props.State",
+    ]);
+  });
 });

--- a/src/plugins/tidy-doc/utils/resolveReferences.test.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { resolveDocSpecReferences } from "./resolveReferences";
+import type { DerivedFacts } from "./facts";
+import type { DocSpec } from "./docSpec";
+
+const facts: DerivedFacts = {
+  componentId: "1:2",
+  componentName: "Button",
+  familyAxis: { name: "Type", values: ["Primary", "Secondary", "Tertiary"] },
+  stateAxis: { name: "State", values: ["Hover", "Idle", "Pressed"] },
+  sizeAxis: null,
+  demoted: [],
+  pinnedDefaults: { State: "Idle" },
+};
+
+describe("resolveDocSpecReferences", () => {
+  it("resolves every variant key that matches a real family value", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      variants: {
+        Primary: { description: "The default action." },
+        Secondary: { description: "A lower-emphasis action." },
+      },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toEqual([]);
+    expect(result.resolved).toBe(spec);
+  });
+
+  it("batches every unresolved variant key in one call, not fail-on-first", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      variants: {
+        Primry: { description: "typo'd family value" },
+        Bogus: { description: "not a family value at all" },
+      },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toHaveLength(2);
+    expect(result.unresolved.map((u) => u.value).sort()).toEqual(["Bogus", "Primry"]);
+    expect(result.unresolved.every((u) => u.slot === "variants" && u.kind === "familyValue")).toBe(true);
+  });
+
+  it("attaches a didYouMean hint for a near-miss", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      variants: { Primry: { description: "typo" } },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved[0].didYouMean).toBe("Primary");
+  });
+
+  it("omits didYouMean for a value with no close match", () => {
+    const spec: DocSpec = {
+      status: "IDEATION",
+      variants: { Zzzzzzzzzz: { description: "nowhere close" } },
+    };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved[0].didYouMean).toBeUndefined();
+  });
+
+  it("resolves nothing (no error) when variants is absent", () => {
+    const spec: DocSpec = { status: "LIVE" };
+    const result = resolveDocSpecReferences(spec, facts);
+    expect(result.unresolved).toEqual([]);
+  });
+});

--- a/src/plugins/tidy-doc/utils/resolveReferences.test.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.test.ts
@@ -10,6 +10,7 @@ const facts: DerivedFacts = {
   stateAxis: { name: "State", values: ["Hover", "Idle", "Pressed"] },
   sizeAxis: null,
   demoted: [],
+  demotedAxisValues: {},
   pinnedDefaults: { State: "Idle" },
   breakdown: { heights: [], width: null, iconPlacement: null },
   modeCollections: [],
@@ -201,5 +202,27 @@ describe("resolveDocSpecReferences", () => {
     const result = resolveDocSpecReferences(spec, facts);
     expect(result.unresolved).toHaveLength(2);
     expect(result.unresolved.map((u) => u.slot).sort()).toEqual(["related", "variants"]);
+  });
+
+  it("resolves a Do/Don't scene that references a demoted axis", () => {
+    const factsWithDemoted: DerivedFacts = {
+      ...facts,
+      demoted: ["Emphasis", "Icon"],
+      demotedAxisValues: { Emphasis: ["Bold", "Subtle"], Icon: ["Leading", "Trailing"] },
+    };
+    const spec: DocSpec = {
+      status: "IDEATION",
+      guidelines: {
+        doDonts: [
+          {
+            description: "demoted axis in a scene",
+            good: { layout: "row", instances: [{ props: { Emphasis: "Bold", Icon: "Leading" } }] },
+            bad: { layout: "row", instances: [{ props: { Emphasis: "Subtle" } }] },
+          },
+        ],
+      },
+    };
+    const result = resolveDocSpecReferences(spec, factsWithDemoted);
+    expect(result.unresolved).toEqual([]);
   });
 });

--- a/src/plugins/tidy-doc/utils/resolveReferences.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.ts
@@ -38,6 +38,9 @@ function resolvableAxes(facts: DerivedFacts): Map<string, string[]> {
   if (facts.sizeAxis?.name) {
     axes.set(facts.sizeAxis.name, facts.sizeAxis.values);
   }
+  for (const [name, values] of Object.entries(facts.demotedAxisValues)) {
+    axes.set(name, values);
+  }
   return axes;
 }
 

--- a/src/plugins/tidy-doc/utils/resolveReferences.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.ts
@@ -4,8 +4,9 @@
 // fast; this runs second and collects *every* unresolved reference into one
 // batched payload rather than failing on the first (ADR-0003).
 //
-// v1 only resolves `variants` keys — the only reference kind this slice
-// renders. Sibling/mode reference kinds land with the Sections that use them.
+// Resolves `variants` keys (against the family axis) and `related` keys
+// (against the ranked sibling-candidate list). Mode reference kinds land
+// with the Section that uses them.
 
 import type { DocSpec } from "./docSpec";
 import type { DerivedFacts } from "./facts";
@@ -38,6 +39,20 @@ export function resolveDocSpecReferences(
           kind: "familyValue",
           value: key,
           didYouMean: didYouMean(key, familyValues),
+        });
+      }
+    }
+  }
+
+  if (spec.related) {
+    const candidateNames = facts.relatedCandidates.map((c) => c.name);
+    for (const key of Object.keys(spec.related)) {
+      if (!candidateNames.includes(key)) {
+        unresolved.push({
+          slot: "related",
+          kind: "siblingName",
+          value: key,
+          didYouMean: didYouMean(key, candidateNames),
         });
       }
     }

--- a/src/plugins/tidy-doc/utils/resolveReferences.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.ts
@@ -1,0 +1,47 @@
+// Reference resolution (ADR-0008): the Doc Spec carries symbolic references
+// to derived facts (here, family-axis values) rather than the facts
+// themselves. Structural Zod validation (docSpec.ts) runs first and fails
+// fast; this runs second and collects *every* unresolved reference into one
+// batched payload rather than failing on the first (ADR-0003).
+//
+// v1 only resolves `variants` keys — the only reference kind this slice
+// renders. Sibling/mode reference kinds land with the Sections that use them.
+
+import type { DocSpec } from "./docSpec";
+import type { DerivedFacts } from "./facts";
+import { didYouMean } from "./didYouMean";
+
+export interface UnresolvedRef {
+  slot: string;
+  kind: string;
+  value: string;
+  didYouMean?: string;
+}
+
+export interface ResolveReferencesResult {
+  resolved: DocSpec;
+  unresolved: UnresolvedRef[];
+}
+
+export function resolveDocSpecReferences(
+  spec: DocSpec,
+  facts: DerivedFacts,
+): ResolveReferencesResult {
+  const unresolved: UnresolvedRef[] = [];
+
+  if (spec.variants) {
+    const familyValues = facts.familyAxis.values;
+    for (const key of Object.keys(spec.variants)) {
+      if (!familyValues.includes(key)) {
+        unresolved.push({
+          slot: "variants",
+          kind: "familyValue",
+          value: key,
+          didYouMean: didYouMean(key, familyValues),
+        });
+      }
+    }
+  }
+
+  return { resolved: spec, unresolved };
+}

--- a/src/plugins/tidy-doc/utils/resolveReferences.ts
+++ b/src/plugins/tidy-doc/utils/resolveReferences.ts
@@ -4,10 +4,16 @@
 // fast; this runs second and collects *every* unresolved reference into one
 // batched payload rather than failing on the first (ADR-0003).
 //
-// v1 only resolves `variants` keys — the only reference kind this slice
-// renders. Sibling/mode reference kinds land with the Sections that use them.
+// v1 resolved only `variants` keys. #56 adds `guidelines.doDonts`: each
+// Do/Don't pair's good/bad SpecimenScene carries axis-value refs in its
+// instances' `props` — bare `{ axisName: value }` pairs resolved against the
+// component's *categorised* axes (family/state/size), per ADR-0008's
+// "references are bare-by-position; the slot declares the kind." An unknown
+// axis name and an unknown value on a known axis are distinct failure modes
+// so the batched payload stays actionable. Sibling/mode reference kinds land
+// with the Sections that use them.
 
-import type { DocSpec } from "./docSpec";
+import type { DocSpec, SpecimenScene } from "./docSpec";
 import type { DerivedFacts } from "./facts";
 import { didYouMean } from "./didYouMean";
 
@@ -21,6 +27,52 @@ export interface UnresolvedRef {
 export interface ResolveReferencesResult {
   resolved: DocSpec;
   unresolved: UnresolvedRef[];
+}
+
+// The categorised axes a SpecimenScene's `props` may reference by name — the
+// only axes for which facts carries a full value set to validate against.
+function resolvableAxes(facts: DerivedFacts): Map<string, string[]> {
+  const axes = new Map<string, string[]>();
+  if (facts.familyAxis.name) {
+    axes.set(facts.familyAxis.name, facts.familyAxis.values);
+  }
+  if (facts.stateAxis?.name) {
+    axes.set(facts.stateAxis.name, facts.stateAxis.values);
+  }
+  if (facts.sizeAxis?.name) {
+    axes.set(facts.sizeAxis.name, facts.sizeAxis.values);
+  }
+  return axes;
+}
+
+function resolveSpecimenScene(
+  scene: SpecimenScene,
+  axes: Map<string, string[]>,
+  slotPrefix: string,
+  unresolved: UnresolvedRef[],
+): void {
+  scene.instances.forEach((instance, index) => {
+    for (const [axisName, value] of Object.entries(instance.props)) {
+      const values = axes.get(axisName);
+      if (!values) {
+        unresolved.push({
+          slot: `${slotPrefix}.instances[${index}].props`,
+          kind: "axisName",
+          value: axisName,
+          didYouMean: didYouMean(axisName, [...axes.keys()]),
+        });
+        continue;
+      }
+      if (!values.includes(value)) {
+        unresolved.push({
+          slot: `${slotPrefix}.instances[${index}].props.${axisName}`,
+          kind: "axisValue",
+          value,
+          didYouMean: didYouMean(value, values),
+        });
+      }
+    }
+  });
 }
 
 export function resolveDocSpecReferences(
@@ -41,6 +93,24 @@ export function resolveDocSpecReferences(
         });
       }
     }
+  }
+
+  if (spec.guidelines?.doDonts) {
+    const axes = resolvableAxes(facts);
+    spec.guidelines.doDonts.forEach((pair, index) => {
+      resolveSpecimenScene(
+        pair.good,
+        axes,
+        `guidelines.doDonts[${index}].good`,
+        unresolved,
+      );
+      resolveSpecimenScene(
+        pair.bad,
+        axes,
+        `guidelines.doDonts[${index}].bad`,
+        unresolved,
+      );
+    });
   }
 
   return { resolved: spec, unresolved };

--- a/src/plugins/tidy-doc/utils/statusBadge.ts
+++ b/src/plugins/tidy-doc/utils/statusBadge.ts
@@ -1,0 +1,21 @@
+// Per-status badge constants (CONTEXT.md "Chrome"): code-generated pill +
+// emoji + label, never a library-component instance, so the status badge
+// carries zero linkage.
+
+import type { DocStatus } from "./docSpec";
+
+export interface StatusBadgeStyle {
+  emoji: string;
+  hex: string;
+}
+
+export const STATUS_BADGE: Record<DocStatus, StatusBadgeStyle> = {
+  IDEATION: { emoji: "\u{1F4A1}", hex: "#9CA3AF" },
+  "in process": { emoji: "\u{1F6E0}\u{FE0F}", hex: "#60A5FA" },
+  "DESIGN COMPLETED": { emoji: "\u{2705}", hex: "#34D399" },
+  REVIEWING: { emoji: "\u{1F440}", hex: "#FBBF24" },
+  "DEV HAND-OFF": { emoji: "\u{1F680}", hex: "#818CF8" },
+  "ON HOLD": { emoji: "\u{23F8}\u{FE0F}", hex: "#F97316" },
+  CANCELED: { emoji: "\u{274C}", hex: "#F87171" },
+  LIVE: { emoji: "\u{1F7E2}", hex: "#22C55E" },
+};

--- a/src/shared/operations/register-all.ts
+++ b/src/shared/operations/register-all.ts
@@ -4,3 +4,4 @@
 import "../../plugins/utilities/operations";
 import "../../plugins/component-labels/operations";
 import "../../plugins/ds-explorer/operations";
+import "../../plugins/tidy-doc/operations";

--- a/src/shared/operations/resolveComponent.ts
+++ b/src/shared/operations/resolveComponent.ts
@@ -9,7 +9,9 @@ import { ErrorCode, OperationError } from "./errors";
 
 type ComponentLike = ComponentNode | ComponentSetNode;
 
-function typeName<T extends ComponentLike["type"]>(types: readonly T[]): string {
+function typeName<T extends ComponentLike["type"]>(
+  types: readonly T[],
+): string {
   return types.join(" or ");
 }
 

--- a/src/shared/operations/resolveComponent.ts
+++ b/src/shared/operations/resolveComponent.ts
@@ -1,0 +1,66 @@
+/// <reference types="@figma/plugin-typings" />
+
+// Selection/id fallback (ADR-0001): resolve an Operation's target node from
+// an optional explicit id, falling back to the current Figma selection.
+// Extracted from the near-identical resolvers duplicated in
+// component-labels/operations.ts and tidy-doc/operations.ts.
+
+import { ErrorCode, OperationError } from "./errors";
+
+type ComponentLike = ComponentNode | ComponentSetNode;
+
+function typeName<T extends ComponentLike["type"]>(types: readonly T[]): string {
+  return types.join(" or ");
+}
+
+/**
+ * Resolves `nodeId` (if given) or the sole current selection to a node whose
+ * type is one of `allowedTypes`. Throws a typed OperationError otherwise.
+ */
+export async function resolveComponentByIdOrSelection<
+  T extends ComponentLike["type"],
+>(
+  nodeId: string | undefined,
+  allowedTypes: readonly T[],
+): Promise<Extract<ComponentLike, { type: T }>> {
+  const expected = typeName(allowedTypes);
+
+  if (nodeId) {
+    const node = await figma.getNodeByIdAsync(nodeId);
+    if (!node) {
+      throw new OperationError(
+        ErrorCode.NOT_FOUND,
+        `node ${nodeId} not found`,
+        true,
+        { nodeId },
+      );
+    }
+    if (!allowedTypes.includes(node.type as T)) {
+      throw new OperationError(
+        ErrorCode.WRONG_NODE_TYPE,
+        `node ${nodeId} is ${node.type}, expected ${expected}`,
+        true,
+        { nodeId, type: node.type },
+      );
+    }
+    return node as Extract<ComponentLike, { type: T }>;
+  }
+
+  const selection = figma.currentPage.selection;
+  if (selection.length === 0) {
+    throw new OperationError(
+      ErrorCode.INVALID_PARAMS,
+      `no nodeId provided and nothing is selected — select a ${expected} or pass nodeId`,
+    );
+  }
+  const first = selection[0];
+  if (!allowedTypes.includes(first.type as T)) {
+    throw new OperationError(
+      ErrorCode.WRONG_NODE_TYPE,
+      `selected node is ${first.type}, expected ${expected}`,
+      true,
+      { nodeId: first.id, type: first.type },
+    );
+  }
+  return first as Extract<ComponentLike, { type: T }>;
+}

--- a/src/shared/operations/ui-bridge-startup.ts
+++ b/src/shared/operations/ui-bridge-startup.ts
@@ -1,13 +1,35 @@
 // Glue between UiBridge and the existing UI↔main postMessage channel.
 // Mounted once at app startup (from main.tsx).
 
-import { UiBridge } from "./ui-bridge";
+import { UiBridge, type BridgeStatus } from "./ui-bridge";
 import type { BridgeRequest, BridgeResponse } from "./types";
 
 let bridge: UiBridge | null = null;
 
 const pending = new Map<string, (res: BridgeResponse) => void>();
 let nextRequestId = 0;
+
+// Module-level connection status, subscribable by any module UI that wants
+// to show a live Bridge indicator (e.g. tidy-doc's minimal shell) without
+// threading a new prop through ShellContext for every consumer.
+let currentStatus: BridgeStatus = "closed";
+const statusSubscribers = new Set<(status: BridgeStatus) => void>();
+
+function setStatus(status: BridgeStatus): void {
+  currentStatus = status;
+  for (const cb of statusSubscribers) cb(status);
+}
+
+export function getBridgeStatus(): BridgeStatus {
+  return currentStatus;
+}
+
+export function subscribeBridgeStatus(
+  cb: (status: BridgeStatus) => void,
+): () => void {
+  statusSubscribers.add(cb);
+  return () => statusSubscribers.delete(cb);
+}
 
 function postOperationToMain(req: BridgeRequest): Promise<BridgeResponse> {
   return new Promise((resolve) => {
@@ -63,6 +85,7 @@ export function startBridge(url?: string): void {
     url,
     dispatch: postOperationToMain,
     log: (m) => console.debug(`[mcp-bridge] ${m}`),
+    onStatusChange: setStatus,
   });
   bridge.start();
 }

--- a/src/shared/operations/ui-bridge.ts
+++ b/src/shared/operations/ui-bridge.ts
@@ -23,16 +23,20 @@ const MAX_BACKOFF_MS = 10_000;
 
 type DispatchFn = (req: BridgeRequest) => Promise<BridgeResponse>;
 
+export type BridgeStatus = "connecting" | "open" | "closed";
+
 interface BridgeOptions {
   url?: string;
   dispatch: DispatchFn;
   log?: (msg: string) => void;
+  onStatusChange?: (status: BridgeStatus) => void;
 }
 
 export class UiBridge {
   private url: string;
   private dispatch: DispatchFn;
   private log: (msg: string) => void;
+  private onStatusChange: (status: BridgeStatus) => void;
   private ws: WebSocket | null = null;
   private backoff = MIN_BACKOFF_MS;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -42,6 +46,7 @@ export class UiBridge {
     this.url = opts.url ?? DEFAULT_URL;
     this.dispatch = opts.dispatch;
     this.log = opts.log ?? (() => {});
+    this.onStatusChange = opts.onStatusChange ?? (() => {});
   }
 
   start(): void {
@@ -63,11 +68,13 @@ export class UiBridge {
       }
       this.ws = null;
     }
+    this.onStatusChange("closed");
   }
 
   private connect(): void {
     if (this.stopped) return;
     this.log(`connecting to ${this.url}`);
+    this.onStatusChange("connecting");
     let ws: WebSocket;
     try {
       ws = new WebSocket(this.url);
@@ -81,6 +88,7 @@ export class UiBridge {
     ws.addEventListener("open", () => {
       this.log("connected");
       this.backoff = MIN_BACKOFF_MS;
+      this.onStatusChange("open");
     });
 
     ws.addEventListener("message", async (ev) => {
@@ -90,6 +98,7 @@ export class UiBridge {
     ws.addEventListener("close", () => {
       this.log("closed");
       this.ws = null;
+      this.onStatusChange("closed");
       this.scheduleReconnect();
     });
 


### PR DESCRIPTION
## Summary

Adds the full tidy-doc component documentation flow:

- New `tidy-doc` module and Operations:
  - `tidy_doc_read_component`
  - `tidy_doc_build_page`
- Generated Documentation Page Sections:
  - Variants
  - Component Breakdown
  - Mode
  - Usage Guidelines
  - Related Components
- Batched reference resolution / Doc Spec validation flow
- Claude plugin `/tidy-doc` command and bundled tidy-doc skill:
  - orchestration instructions
  - per-Section authoring rules
  - Kido editorial standard
  - Button exemplar
- Usage docs: `docs/tidy-doc.md`

Closes #51
Closes #52
Closes #53
Closes #54
Closes #55
Closes #56
Closes #57
Closes #58

## Verification

- `npm run typecheck`
- `npm run test`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build:plugin`