### PR TITLE
QA Tier 2: item 8 icons/illustrations/logos — negative detection (#101)

### DIFF
--- a/claude-plugin/commands/tidy-qa.md
+++ b/claude-plugin/commands/tidy-qa.md
@@ -23,8 +23,8 @@ Split `$ARGUMENTS` on whitespace into tokens, then classify each:
 - **Check-id** — a token that exactly matches one of the known check ids:
   `set-name-casing`, `prop-order`, `tokens`, `layer-naming-structure`,
   `grid-4px`, `interaction-hover-only`, `description`, `no-conflicts`,
-  `preferred-values`, `nesting-depth`. Collect these into the `checks` array (a
-  filter — only these checks run).
+  `preferred-values`, `nesting-depth`, `asset-provenance`. Collect these into
+  the `checks` array (a filter — only these checks run).
 - **Id** — a token matching `^\d+:\d+$` (e.g. `2625:10445`). Use as `nodeId`.
 - **Target name / glob** — every remaining token. Join them with spaces (names
   can contain spaces, e.g. `Button Icon`) and pass as `name`. A `*` makes it a

--- a/docs/prd-automated-qa.md
+++ b/docs/prd-automated-qa.md
@@ -86,6 +86,21 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 
 ### 8. Icons / Illustrations / Logos Connected to Foundations
 
+> Shipped as check `asset-provenance` (issue #101) — **negative detection
+> only**. The plugin API exposes no library attribution for components
+> (`libraryName` exists only for variable collections; an instance gives you
+> its main component's `key` and `remote` flag, never a file key or library
+> name), so "originating directly from the approved Foundations Library" is not
+> answerable in-plugin. The check therefore fails what is *certainly* not a
+> library instance — raw path geometry alongside other content, and nested
+> instances whose main component is local — passes remote nested instances, and
+> carries the unverifiable-origin caveat in the result's `note` rather than
+> implying a guarantee it can't make. An approved-key manifest (and the
+> deprecated-directory rule that depends on it) is deferred to its own ticket,
+> since generating one needs the REST API or a dump run inside the Foundations
+> file plus a refresh story. A component that *is* the asset (every leaf in the
+> variant trees is geometry) reports `not_applicable`.
+
 * **Intent:** Ensure all iconography utilized inside components stems from the single source of truth library.
 * **Automated Plugin Action:**
 * Inspect nested icon sub-components.

--- a/docs/prd-automated-qa.md
+++ b/docs/prd-automated-qa.md
@@ -91,10 +91,14 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 > (`libraryName` exists only for variable collections; an instance gives you
 > its main component's `key` and `remote` flag, never a file key or library
 > name), so "originating directly from the approved Foundations Library" is not
-> answerable in-plugin. The check therefore fails what is *certainly* not a
-> library instance — raw path geometry alongside other content, and nested
-> instances whose main component is local — passes remote nested instances, and
-> carries the unverifiable-origin caveat in the result's `note` rather than
+> answerable in-plugin. The check therefore **fails** only what is *certainly*
+> not a library instance — raw path geometry alongside other content — and
+> **warns** on a nested instance whose main component is local: a component
+> legitimately built from private sub-components in its own file (Kido's
+> `_elements / …` parts) looks identical here to a stray local copy of an icon,
+> so the row asks the designer to decide rather than asserting a defect and
+> telling her to publish a deliberately private part. Remote nested instances
+> pass, with the unverifiable-origin caveat in the result's `note` rather than
 > implying a guarantee it can't make. An approved-key manifest (and the
 > deprecated-directory rule that depends on it) is deferred to its own ticket,
 > since generating one needs the REST API or a dump run inside the Foundations

--- a/docs/prd-qa-canvas-checklist.md
+++ b/docs/prd-qa-canvas-checklist.md
@@ -98,7 +98,7 @@ Three new pieces, plus one operation:
 | 5 | Tokens (Styles & Variables) | `tokens` |
 | 6 | Typography Desktop\|Mobile | manual |
 | 7 | Responsiveness (+ Min-Max) | manual |
-| 8 | Icons/Illustrations/Logos → Foundations | manual (Tier 2) |
+| 8 | Icons/Illustrations/Logos → Foundations | `asset-provenance` |
 | 9 | Layer Naming + Structure | `layer-naming-structure` |
 | 10 | 4px Grid Alignment | `grid-4px` |
 | 11 | Interaction (Hover Only) | `interaction-hover-only` |

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -279,7 +279,7 @@ export const CATALOGUE: CatalogueEntry[] = [
         .array(z.string())
         .optional()
         .describe(
-          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth.",
+          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth, asset-provenance.",
         ),
     },
     timeoutMs: 60_000,

--- a/src/plugins/qa/checklist-catalogue.test.ts
+++ b/src/plugins/qa/checklist-catalogue.test.ts
@@ -35,6 +35,7 @@ const PRD_ITEMS: ReadonlyArray<{
     n: 8,
     title: "Icons/Illustrations/Logos → Foundations",
     tier: 2,
+    checkId: "asset-provenance",
   },
   {
     n: 9,
@@ -104,8 +105,8 @@ describe("CHECKLIST_CATALOGUE", () => {
 
   it("gives every automated item a unique checkId, tiered 1 or 2", () => {
     const automated = CHECKLIST_CATALOGUE.filter((item) => item.checkId);
-    expect(automated).toHaveLength(10);
-    expect(new Set(automated.map((item) => item.checkId)).size).toBe(10);
+    expect(automated).toHaveLength(11);
+    expect(new Set(automated.map((item) => item.checkId)).size).toBe(11);
     for (const item of automated) {
       expect(item.tier === 1 || item.tier === 2).toBe(true);
     }

--- a/src/plugins/qa/checklist-catalogue.ts
+++ b/src/plugins/qa/checklist-catalogue.ts
@@ -74,6 +74,7 @@ export const CHECKLIST_CATALOGUE: readonly CatalogueItem[] = [
     n: 8,
     title: "Icons/Illustrations/Logos → Foundations",
     tier: 2,
+    checkId: "asset-provenance",
     blurb: "Nested icons, illustrations and logos come from the DS library.",
   },
   {

--- a/src/plugins/qa/checks/asset-provenance.test.ts
+++ b/src/plugins/qa/checks/asset-provenance.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from "vitest";
+import { checkAssetProvenance } from "./asset-provenance";
+import type { ComponentSetSnapshot, NodeSnapshot } from "../snapshot";
+
+let seq = 0;
+
+function node(overrides: Partial<NodeSnapshot>): NodeSnapshot {
+  seq += 1;
+  return {
+    id: `1:${seq}`,
+    name: "layer",
+    type: "FRAME",
+    visible: true,
+    width: 24,
+    height: 24,
+    children: [],
+    ...overrides,
+  };
+}
+
+/** A nested instance pointing at a resolvable main component. */
+function instance(
+  name: string,
+  main: { key: string; name: string; remote: boolean },
+  overrides: Partial<NodeSnapshot> = {},
+): NodeSnapshot {
+  return node({
+    name,
+    type: "INSTANCE",
+    mainComponent: { id: `main-${main.key}`, ...main },
+    ...overrides,
+  });
+}
+
+const REMOTE_ICON = { key: "abc123", name: "Icon/check", remote: true };
+const LOCAL_ICON = { key: "def456", name: "ic-arrow", remote: false };
+
+function fixture(
+  children: NodeSnapshot[][],
+  name = "Button",
+): ComponentSetSnapshot {
+  return {
+    id: "1:0",
+    name,
+    type: "COMPONENT_SET",
+    description: "",
+    propertyNames: [],
+    properties: [],
+    variants: children.map((kids, i) => ({
+      id: `v:${i}`,
+      name: `${name}-${i}`,
+      variantProperties: {},
+      tree: node({
+        id: `v:${i}`,
+        name: `${name}-${i}`,
+        type: "COMPONENT",
+        children: kids,
+      }),
+    })),
+  };
+}
+
+describe("checkAssetProvenance", () => {
+  it("passes a component whose only nested instance is remote, and says origin is unverifiable", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [node({ name: "label", type: "TEXT" }), instance("ic", REMOTE_ICON)],
+      ]),
+    );
+    expect(result.checkId).toBe("asset-provenance");
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+    // The caveat is part of the result, not a comment in the source.
+    expect(result.note).toMatch(/origin/i);
+    expect(result.note).toMatch(/cannot be verified/i);
+  });
+
+  it("fails raw vector geometry sitting alongside other content", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [
+          node({ name: "label", type: "TEXT" }),
+          node({ name: "Vector 12", type: "VECTOR" }),
+        ],
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toMatch(/raw vector/i);
+    expect(result.findings[0].nodeName).toBe("Vector 12");
+  });
+
+  it("fails a nested instance whose main component is local", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [node({ name: "label", type: "TEXT" }), instance("ic", LOCAL_ICON)],
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toMatch(/local component/i);
+    // The message names the main component, not the layer — the count spans
+    // usage sites with different layer names.
+    expect(result.findings[0].message).toContain("ic-arrow");
+    expect(result.findings[0].nodeName).toBe("ic");
+    expect(result.findings[0].count).toBe(1);
+  });
+
+  it("is not_applicable for a vector-only leaf tree — the component IS the asset", () => {
+    // Kido shape: COMPONENT > frame "ic" > VECTOR. The frame is a container,
+    // not a leaf, so the structural rule exempts it without knowing the name.
+    const result = checkAssetProvenance(
+      fixture(
+        [
+          [
+            node({
+              name: "ic",
+              children: [node({ name: "Vector", type: "VECTOR" })],
+            }),
+          ],
+        ],
+        "IconCheck",
+      ),
+    );
+    expect(result.status).toBe("not_applicable");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("judges the exemption per variant, so one odd variant doesn't fail the whole icon set", () => {
+    // Three vector-only variants plus one carrying a stray empty frame. Pooling
+    // the leaf tally across the set would un-exempt everything and then fail
+    // every vector in the icon — exactly the false positive the exemption is for.
+    const iconVariant = () => [
+      node({
+        name: "ic",
+        children: [node({ name: "Vector", type: "VECTOR" })],
+      }),
+    ];
+    const result = checkAssetProvenance(
+      fixture(
+        [
+          iconVariant(),
+          iconVariant(),
+          iconVariant(),
+          [
+            node({
+              name: "ic",
+              children: [node({ name: "Vector", type: "VECTOR" })],
+            }),
+            node({ name: "spacer" }),
+          ],
+        ],
+        "IconCheck",
+      ),
+    );
+    // Only the odd variant is scanned, so its own vector is the lone finding —
+    // not one per variant across the set.
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(1);
+  });
+
+  it("exempts a mixed-geometry illustration (vectors plus primitives)", () => {
+    const result = checkAssetProvenance(
+      fixture(
+        [
+          [
+            node({ name: "bg", type: "ELLIPSE" }),
+            node({ name: "glyph", type: "BOOLEAN_OPERATION" }),
+            node({ name: "bar", type: "RECTANGLE" }),
+          ],
+        ],
+        "LogoKido",
+      ),
+    );
+    expect(result.status).toBe("not_applicable");
+  });
+
+  it("does not flag primitives used as decoration inside a real component", () => {
+    // A rectangle divider is not pasted artwork — only true path geometry
+    // (VECTOR / BOOLEAN_OPERATION / STAR / POLYGON / LINE) reads as detached art.
+    const result = checkAssetProvenance(
+      fixture([
+        [
+          node({ name: "label", type: "TEXT" }),
+          node({ name: "divider", type: "RECTANGLE" }),
+          instance("ic", REMOTE_ICON),
+        ],
+      ]),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("is not_applicable when there is nothing to judge — no vectors, no nested instances", () => {
+    const result = checkAssetProvenance(
+      fixture([[node({ name: "label", type: "TEXT" })]]),
+    );
+    expect(result.status).toBe("not_applicable");
+    expect(result.findings).toEqual([]);
+    expect(result.note).toBeUndefined();
+  });
+
+  it("dedupes to one finding per offending main component, with an occurrence count", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [node({ name: "label", type: "TEXT" }), instance("ic", LOCAL_ICON)],
+        [node({ name: "label", type: "TEXT" }), instance("ic", LOCAL_ICON)],
+        [
+          node({ name: "label", type: "TEXT" }),
+          instance("trailing", LOCAL_ICON),
+        ],
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(3);
+    // One representative node, the first occurrence.
+    expect(result.findings[0].nodeName).toBe("ic");
+  });
+
+  it("keeps distinct offending main components as separate findings", () => {
+    const other = { key: "ghi789", name: "ic-close", remote: false };
+    const result = checkAssetProvenance(
+      fixture([
+        [
+          instance("a", LOCAL_ICON),
+          instance("b", other),
+          node({ name: "t", type: "TEXT" }),
+        ],
+      ]),
+    );
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.map((f) => f.count)).toEqual([1, 1]);
+  });
+
+  it("reports the mixed case: raw vector and a local instance together", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [
+          node({ name: "label", type: "TEXT" }),
+          node({ name: "Vector 3", type: "VECTOR" }),
+          instance("ic", LOCAL_ICON),
+          instance("badge", REMOTE_ICON),
+        ],
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.map((f) => f.message).join(" ")).toMatch(
+      /raw vector/i,
+    );
+    expect(result.findings.map((f) => f.message).join(" ")).toMatch(
+      /local component/i,
+    );
+    // A remote instance was still seen, so the caveat still applies.
+    expect(result.note).toBeDefined();
+  });
+
+  it("warns rather than guessing when a main component cannot be resolved", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [
+          node({ name: "label", type: "TEXT" }),
+          node({ name: "ic", type: "INSTANCE" }),
+        ],
+      ]),
+    );
+    expect(result.status).toBe("warn");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toMatch(/could not be resolved/i);
+  });
+
+  it("dedupes raw vectors by layer name across variants", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [
+          node({ name: "label", type: "TEXT" }),
+          node({ name: "Vector", type: "VECTOR" }),
+        ],
+        [
+          node({ name: "label", type: "TEXT" }),
+          node({ name: "Vector", type: "VECTOR" }),
+        ],
+      ]),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(2);
+  });
+
+  it("looks through nested frames for vectors and instances", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [
+          node({
+            name: "content",
+            children: [
+              node({ name: "label", type: "TEXT" }),
+              node({
+                name: "art",
+                children: [node({ name: "Vector 1", type: "VECTOR" })],
+              }),
+            ],
+          }),
+        ],
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].nodeName).toBe("Vector 1");
+  });
+});

--- a/src/plugins/qa/checks/asset-provenance.test.ts
+++ b/src/plugins/qa/checks/asset-provenance.test.ts
@@ -21,7 +21,7 @@ function node(overrides: Partial<NodeSnapshot>): NodeSnapshot {
 /** A nested instance pointing at a resolvable main component. */
 function instance(
   name: string,
-  main: { key: string; name: string; remote: boolean },
+  main: Omit<NonNullable<NodeSnapshot["mainComponent"]>, "id">,
   overrides: Partial<NodeSnapshot> = {},
 ): NodeSnapshot {
   return node({
@@ -90,15 +90,21 @@ describe("checkAssetProvenance", () => {
     expect(result.findings[0].nodeName).toBe("Vector 12");
   });
 
-  it("fails a nested instance whose main component is local", () => {
+  it("warns, not fails, on a nested instance whose main component is local", () => {
+    // Indistinguishable from a component legitimately built out of private
+    // sub-components in its own file, so the check surfaces it and leaves the
+    // call to the designer rather than asserting a defect.
     const result = checkAssetProvenance(
       fixture([
         [node({ name: "label", type: "TEXT" }), instance("ic", LOCAL_ICON)],
       ]),
     );
-    expect(result.status).toBe("fail");
+    expect(result.status).toBe("warn");
     expect(result.findings).toHaveLength(1);
-    expect(result.findings[0].message).toMatch(/local component/i);
+    expect(result.findings[0].severity).toBe("medium");
+    expect(result.findings[0].message).toMatch(
+      /in this file rather than a library/i,
+    );
     // The message names the main component, not the layer — the count spans
     // usage sites with different layer names.
     expect(result.findings[0].message).toContain("ic-arrow");
@@ -127,7 +133,7 @@ describe("checkAssetProvenance", () => {
   });
 
   it("judges the exemption per variant, so one odd variant doesn't fail the whole icon set", () => {
-    // Three vector-only variants plus one carrying a stray empty frame. Pooling
+    // Three vector-only variants plus one carrying a stray text label. Pooling
     // the leaf tally across the set would un-exempt everything and then fail
     // every vector in the icon — exactly the false positive the exemption is for.
     const iconVariant = () => [
@@ -147,7 +153,7 @@ describe("checkAssetProvenance", () => {
               name: "ic",
               children: [node({ name: "Vector", type: "VECTOR" })],
             }),
-            node({ name: "spacer" }),
+            node({ name: "label", type: "TEXT" }),
           ],
         ],
         "IconCheck",
@@ -158,6 +164,134 @@ describe("checkAssetProvenance", () => {
     expect(result.status).toBe("fail");
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0].count).toBe(1);
+  });
+
+  it("still exempts an asset variant that contains an empty container frame", () => {
+    // A clip frame or spacer holds nothing. Treating it as a non-geometry leaf
+    // un-exempted the variant and then failed every vector inside it.
+    const result = checkAssetProvenance(
+      fixture(
+        [
+          [
+            node({ name: "clip" }),
+            node({
+              name: "ic",
+              children: [node({ name: "Vector", type: "VECTOR" })],
+            }),
+          ],
+        ],
+        "IconCheck",
+      ),
+    );
+    expect(result.status).toBe("not_applicable");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("does not fail a drawn divider LINE, but still counts it as artwork", () => {
+    // A LINE is the divider primitive, exactly like RECTANGLE — flagging it
+    // would fail ordinary cards. Inside a real component: not a finding.
+    const inComponent = checkAssetProvenance(
+      fixture([
+        [
+          node({ name: "label", type: "TEXT" }),
+          node({ name: "rule", type: "LINE" }),
+        ],
+      ]),
+    );
+    expect(inComponent.status).toBe("not_applicable");
+    expect(inComponent.findings).toEqual([]);
+
+    // Inside a logo built from lines and vectors: still pure artwork, so the
+    // asset exemption applies rather than the variant being scanned.
+    const asAsset = checkAssetProvenance(
+      fixture(
+        [
+          [
+            node({ name: "bar", type: "LINE" }),
+            node({ name: "Vector", type: "VECTOR" }),
+          ],
+        ],
+        "Logo",
+      ),
+    );
+    expect(asAsset.status).toBe("not_applicable");
+    expect(asAsset.findings).toEqual([]);
+  });
+
+  it("names the offending component's owning set, not the variant", () => {
+    // An instance's main component is the *variant*, so labelling with its own
+    // name reads as "State=Default" — identical across unrelated sets, which
+    // both hides which component is at fault and lets the canvas grouping
+    // collapse distinct offenders into one row.
+    const result = checkAssetProvenance(
+      fixture([
+        [
+          instance("DropdownItem1", {
+            key: "k1",
+            name: "State=Default",
+            setId: "set-1",
+            setName: "_elements / DesktopItems",
+            remote: false,
+          }),
+          instance("Person1", {
+            key: "k2",
+            name: "State=Default",
+            setId: "set-2",
+            setName: "_elements / PersonSelectorStates",
+            remote: false,
+          }),
+        ],
+      ]),
+    );
+
+    expect(result.status).toBe("warn");
+    expect(result.findings).toHaveLength(2);
+    const messages = result.findings.map((f) => f.message);
+    expect(messages.some((m) => m.includes("_elements / DesktopItems"))).toBe(
+      true,
+    );
+    expect(
+      messages.some((m) => m.includes("_elements / PersonSelectorStates")),
+    ).toBe(true);
+    // Distinct messages, so grouping can't merge them.
+    expect(new Set(messages).size).toBe(2);
+  });
+
+  it("reports one finding per offending set even when several of its variants are used", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [
+          instance("item", {
+            key: "k-default",
+            name: "State=Default",
+            setId: "set-1",
+            setName: "_elements / DesktopItems",
+            remote: false,
+          }),
+          instance("item", {
+            key: "k-hover",
+            name: "State=Hover",
+            setId: "set-1",
+            setName: "_elements / DesktopItems",
+            remote: false,
+          }),
+        ],
+      ]),
+    );
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(2);
+    expect(result.findings[0].message).toContain("_elements / DesktopItems");
+  });
+
+  it("falls back to the component's own name when it has no owning set", () => {
+    const result = checkAssetProvenance(
+      fixture([
+        [instance("ic", { key: "solo", name: "ic-arrow", remote: false })],
+      ]),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toContain("ic-arrow");
   });
 
   it("exempts a mixed-geometry illustration (vectors plus primitives)", () => {
@@ -212,7 +346,7 @@ describe("checkAssetProvenance", () => {
         ],
       ]),
     );
-    expect(result.status).toBe("fail");
+    expect(result.status).toBe("warn");
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0].count).toBe(3);
     // One representative node, the first occurrence.
@@ -235,6 +369,8 @@ describe("checkAssetProvenance", () => {
   });
 
   it("reports the mixed case: raw vector and a local instance together", () => {
+    // Raw geometry is the only certain defect, so it drives the fail status
+    // even though the local-instance finding alongside it is only a warning.
     const result = checkAssetProvenance(
       fixture([
         [
@@ -251,7 +387,7 @@ describe("checkAssetProvenance", () => {
       /raw vector/i,
     );
     expect(result.findings.map((f) => f.message).join(" ")).toMatch(
-      /local component/i,
+      /in this file rather than a library/i,
     );
     // A remote instance was still seen, so the caveat still applies.
     expect(result.note).toBeDefined();

--- a/src/plugins/qa/checks/asset-provenance.ts
+++ b/src/plugins/qa/checks/asset-provenance.ts
@@ -1,0 +1,275 @@
+/**
+ * #8 — Icons / illustrations / logos connected to Foundations (issue #101).
+ *
+ * This check ships the part that the plugin API can establish with certainty
+ * and states the rest honestly, rather than guessing at library origin:
+ *
+ * - **There is no library attribution for components.** `libraryName` exists
+ *   only for variable collections. An instance exposes its main component's
+ *   `key` and `remote` flag — no file key, no library name. So "is this icon
+ *   from the approved Foundations file?" is simply not answerable in-plugin,
+ *   and an approved-key manifest is deferred to its own ticket (it needs a
+ *   generation + refresh pipeline outside the plugin sandbox).
+ *
+ * The three rules are therefore *negative* detection — things that are
+ * definitely not a library instance:
+ *
+ * 1. Raw path geometry alongside other content → `fail`. Detached paths and
+ *    copy-pasted art. Only true path types count (VECTOR, BOOLEAN_OPERATION,
+ *    STAR, POLYGON, LINE); RECTANGLE and ELLIPSE are primitives designers
+ *    legitimately draw as dividers, backgrounds and dots, so flagging those
+ *    would bury the real signal in noise.
+ * 2. A nested instance whose main component is local (`remote === false`) →
+ *    `fail`. This applies to *every* nested instance, not just icons — a local
+ *    nested component inside a library component is a smell whatever it is,
+ *    which is why this check needs no "is this an icon?" classifier.
+ * 3. A remote nested instance → `pass`, with the unverifiable-origin caveat
+ *    carried in `note` so the row doesn't read as a stronger guarantee than it
+ *    is. No false `fail` on legitimate remote icons.
+ *
+ * An instance whose main component doesn't resolve at all is a fourth,
+ * unavoidable case: it is neither certainly local nor certainly remote, so it
+ * `warn`s instead of being silently sorted into one of the two.
+ *
+ * **The asset-component exemption.** When the thing under QA *is* the asset its
+ * own geometry is legitimate, and rule 1 would otherwise fail every icon in
+ * the library. The exemption is structural, not name-based: a variant whose
+ * every leaf is geometry is the asset, and is skipped. Here the geometry set is
+ * deliberately *wider* than rule 1's (primitives included), because an
+ * illustration mixing paths with circles and rects is still nothing but
+ * artwork. The Kido convention that an icon contains an element named `ic` is
+ * compatible but unused: a frame named `ic` is a container, not a leaf, so a
+ * vector-only icon exempts anyway — and when `ic` is an *instance* inside a
+ * Button, rule 2 catches it on its own.
+ *
+ * The exemption is judged **per variant**, not pooled over the set: pooling
+ * would let one stray non-geometry leaf in a single variant un-exempt the whole
+ * icon set and then fail every vector in it — precisely the false positive the
+ * exemption exists to prevent.
+ *
+ * Findings are one per offending main component (or per offending layer name,
+ * for raw geometry — pasted artwork has no main component to key on) with an
+ * occurrence count and one representative node, never one per usage site
+ * (#100).
+ */
+
+import type { ComponentSetSnapshot, NodeSnapshot } from "../snapshot";
+import type { CheckResult, CheckStatus, Finding } from "../types";
+
+/** Rule 1: node types that only exist as drawn/pasted path artwork. */
+const RAW_PATH_TYPES: readonly string[] = [
+  "VECTOR",
+  "BOOLEAN_OPERATION",
+  "STAR",
+  "POLYGON",
+  "LINE",
+];
+
+/**
+ * The exemption test: leaf types that are pure artwork. Wider than
+ * RAW_PATH_TYPES — a logo built from circles and bars is still just artwork,
+ * even though a lone rectangle inside a Button is not a provenance problem.
+ */
+const GEOMETRY_LEAF_TYPES: readonly string[] = [
+  ...RAW_PATH_TYPES,
+  "RECTANGLE",
+  "ELLIPSE",
+];
+
+const CAVEAT =
+  "Library origin cannot be verified through the plugin API: Figma exposes a main component's key and remote flag but no file key or library name, so a remote nested instance is reported as passing on the strength of being remote alone. Confirm by eye that these come from Foundations.";
+
+const TITLE = "Icons / illustrations / logos from Foundations";
+
+interface Offender {
+  /** What the finding names — a main component, or a raw layer name. */
+  label: string;
+  /** First occurrence — the representative node for "jump to offender". */
+  nodeId: string;
+  nodeName: string;
+  count: number;
+}
+
+/** Accumulate an occurrence under `key`, remembering the first node seen. */
+function tally(
+  into: Map<string, Offender>,
+  key: string,
+  label: string,
+  node: NodeSnapshot,
+): void {
+  const existing = into.get(key);
+  if (existing) {
+    existing.count += 1;
+  } else {
+    into.set(key, { label, nodeId: node.id, nodeName: node.name, count: 1 });
+  }
+}
+
+interface Scan {
+  /** Offending raw path layers, keyed by layer name. */
+  rawPaths: Map<string, Offender>;
+  /** Local main components, keyed by publish key. */
+  localMains: Map<string, Offender>;
+  /** Instances whose main component didn't resolve, keyed by layer name. */
+  unresolved: Map<string, Offender>;
+  remoteInstanceCount: number;
+}
+
+function emptyScan(): Scan {
+  return {
+    rawPaths: new Map(),
+    localMains: new Map(),
+    unresolved: new Map(),
+    remoteInstanceCount: 0,
+  };
+}
+
+/**
+ * True when every leaf under `root` is pure geometry — i.e. this variant *is*
+ * the asset. The variant root itself is never a leaf: a childless component
+ * frame is empty, not artwork.
+ */
+function isAssetVariant(root: NodeSnapshot): boolean {
+  let leaves = 0;
+  let geometryLeaves = 0;
+
+  function visit(node: NodeSnapshot, isRoot: boolean): void {
+    // INSTANCE interiors are never collected (see the collector), so a nested
+    // instance is always a leaf here — and a leaf that is not geometry, which
+    // is what stops a set with an icon *slot* from exempting itself.
+    if (node.children.length === 0 && !isRoot) {
+      leaves += 1;
+      if (GEOMETRY_LEAF_TYPES.includes(node.type)) geometryLeaves += 1;
+    }
+    for (const child of node.children) visit(child, false);
+  }
+  visit(root, true);
+
+  return leaves > 0 && geometryLeaves === leaves;
+}
+
+/** Collect this variant's provenance offenders into the shared set-wide scan. */
+function scanOffenders(node: NodeSnapshot, scan: Scan): void {
+  if (node.type === "INSTANCE") {
+    const main = node.mainComponent;
+    if (!main) {
+      // Provenance genuinely unknown — report it rather than silently treating
+      // it as either local or remote.
+      tally(scan.unresolved, node.name, node.name, node);
+    } else if (main.remote) {
+      scan.remoteInstanceCount += 1;
+    } else {
+      tally(scan.localMains, main.key, main.name, node);
+    }
+  } else if (RAW_PATH_TYPES.includes(node.type)) {
+    tally(scan.rawPaths, node.name, node.name, node);
+  }
+
+  for (const child of node.children) scanOffenders(child, scan);
+}
+
+function finding(
+  offender: Offender,
+  parts: Pick<Finding, "severity" | "message" | "expected" | "actual"> &
+    Partial<Pick<Finding, "suggestedFix">>,
+): Finding {
+  return {
+    ...parts,
+    nodeId: offender.nodeId,
+    nodeName: offender.nodeName,
+    count: offender.count,
+  };
+}
+
+export function checkAssetProvenance(
+  snapshot: ComponentSetSnapshot,
+): CheckResult {
+  const scan = emptyScan();
+  let assetVariants = 0;
+  for (const variant of snapshot.variants) {
+    if (isAssetVariant(variant.tree)) {
+      assetVariants += 1;
+      continue;
+    }
+    scanOffenders(variant.tree, scan);
+  }
+
+  // Every variant is the asset itself — nothing here is a nested library
+  // instance, so there is nothing for this check to judge.
+  if (assetVariants > 0 && assetVariants === snapshot.variants.length) {
+    return {
+      checkId: "asset-provenance",
+      title: TITLE,
+      status: "not_applicable",
+      findings: [],
+    };
+  }
+
+  const findings: Finding[] = [];
+
+  for (const offender of scan.rawPaths.values()) {
+    findings.push(
+      finding(offender, {
+        severity: "high",
+        message: `Layer "${offender.label}" is raw vector geometry alongside other content, not a library instance.`,
+        expected: "an instance of an icon/illustration/logo from Foundations",
+        actual: "raw vector geometry",
+        suggestedFix:
+          "Replace the pasted/detached artwork with an instance of the Foundations asset.",
+      }),
+    );
+  }
+
+  // The message names the *main component*, not the offending layer: the count
+  // aggregates every usage site, and those sites can carry different layer
+  // names ("ic", "trailing"), so quoting one of them would under-describe the
+  // count. `nodeId`/`nodeName` still point at one representative site.
+  for (const offender of scan.localMains.values()) {
+    findings.push(
+      finding(offender, {
+        severity: "high",
+        message: `A nested instance points at local component "${offender.label}", not a library instance.`,
+        expected: "a nested instance from a published library",
+        actual: "a local component in this file",
+        suggestedFix:
+          "Publish the component to the library (or swap in the Foundations equivalent) and re-point the instance.",
+      }),
+    );
+  }
+
+  for (const offender of scan.unresolved.values()) {
+    findings.push(
+      finding(offender, {
+        severity: "medium",
+        message: `Main component for nested instance "${offender.label}" could not be resolved — its provenance is unknown.`,
+        expected: "a resolvable main component",
+        actual: "unresolved main component",
+      }),
+    );
+  }
+
+  findings.sort((a, b) => a.message.localeCompare(b.message));
+
+  // `not_applicable` when nothing provenance-bearing exists at all: no nested
+  // instances, no raw geometry. Nothing was measured, which is a different
+  // fact from "measured and it's fine" and must not inflate the pass count.
+  const status: CheckStatus =
+    scan.rawPaths.size > 0 || scan.localMains.size > 0
+      ? "fail"
+      : scan.unresolved.size > 0
+        ? "warn"
+        : scan.remoteInstanceCount > 0
+          ? "pass"
+          : "not_applicable";
+
+  return {
+    checkId: "asset-provenance",
+    title: TITLE,
+    status,
+    findings,
+    // Stated whenever any remote instance was trusted on the strength of being
+    // remote — including alongside failures, since the remaining instances
+    // still rest on that partial evidence.
+    ...(scan.remoteInstanceCount > 0 ? { note: CAVEAT } : {}),
+  };
+}

--- a/src/plugins/qa/checks/asset-provenance.ts
+++ b/src/plugins/qa/checks/asset-provenance.ts
@@ -14,15 +14,19 @@
  * The three rules are therefore *negative* detection — things that are
  * definitely not a library instance:
  *
- * 1. Raw path geometry alongside other content → `fail`. Detached paths and
- *    copy-pasted art. Only true path types count (VECTOR, BOOLEAN_OPERATION,
- *    STAR, POLYGON, LINE); RECTANGLE and ELLIPSE are primitives designers
- *    legitimately draw as dividers, backgrounds and dots, so flagging those
- *    would bury the real signal in noise.
+ * 1. Raw path geometry alongside other content → `fail`, the only defect this
+ *    check is certain of. Detached paths and copy-pasted art. Only true path
+ *    types count (VECTOR, BOOLEAN_OPERATION, STAR, POLYGON); LINE, RECTANGLE
+ *    and ELLIPSE are primitives designers legitimately draw as dividers,
+ *    backgrounds and dots, so flagging those would bury the real signal.
  * 2. A nested instance whose main component is local (`remote === false`) →
- *    `fail`. This applies to *every* nested instance, not just icons — a local
- *    nested component inside a library component is a smell whatever it is,
- *    which is why this check needs no "is this an icon?" classifier.
+ *    `warn`, not `fail`. This applies to *every* nested instance, not just
+ *    icons, which is why this check needs no "is this an icon?" classifier —
+ *    but that breadth is exactly why it can't assert a defect. A component
+ *    legitimately built from private sub-components in its own file (Kido's
+ *    `_elements / …` parts) is indistinguishable here from a stray local copy
+ *    of an icon, so the check surfaces it and leaves the judgement to the
+ *    designer instead of telling her to publish a deliberately private part.
  * 3. A remote nested instance → `pass`, with the unverifiable-origin caveat
  *    carried in `note` so the row doesn't read as a stronger guarantee than it
  *    is. No false `fail` on legitimate remote icons.
@@ -56,13 +60,20 @@
 import type { ComponentSetSnapshot, NodeSnapshot } from "../snapshot";
 import type { CheckResult, CheckStatus, Finding } from "../types";
 
-/** Rule 1: node types that only exist as drawn/pasted path artwork. */
+/**
+ * Rule 1: node types that only exist as drawn/pasted path artwork.
+ *
+ * `LINE` is deliberately absent, for the same reason `RECTANGLE` and `ELLIPSE`
+ * are: it is the primitive designers reach for to draw a divider or rule, so
+ * flagging it would fail ordinary cards and menus at high severity and bury the
+ * real signal. It still counts as geometry for the exemption below — a line
+ * inside a logo is artwork.
+ */
 const RAW_PATH_TYPES: readonly string[] = [
   "VECTOR",
   "BOOLEAN_OPERATION",
   "STAR",
   "POLYGON",
-  "LINE",
 ];
 
 /**
@@ -72,8 +83,29 @@ const RAW_PATH_TYPES: readonly string[] = [
  */
 const GEOMETRY_LEAF_TYPES: readonly string[] = [
   ...RAW_PATH_TYPES,
+  "LINE",
   "RECTANGLE",
   "ELLIPSE",
+];
+
+/**
+ * Containers that hold nothing. A childless frame — a clip frame, a spacer —
+ * is not artwork, but it is not evidence *against* being an asset either, so
+ * the exemption test ignores it. Counting it as a non-geometry leaf let one
+ * invisible empty frame un-exempt an icon variant and then fail every vector
+ * in it: the exact false positive the exemption exists to prevent.
+ *
+ * INSTANCE is pointedly not in this list. Instance interiors are never
+ * collected, so a nested instance is always childless here, and it must keep
+ * counting as a non-geometry leaf — that is what stops a component with an
+ * icon *slot* from exempting itself.
+ */
+const EMPTY_CONTAINER_TYPES: readonly string[] = [
+  "FRAME",
+  "GROUP",
+  "COMPONENT",
+  "COMPONENT_SET",
+  "SECTION",
 ];
 
 const CAVEAT =
@@ -108,7 +140,7 @@ function tally(
 interface Scan {
   /** Offending raw path layers, keyed by layer name. */
   rawPaths: Map<string, Offender>;
-  /** Local main components, keyed by publish key. */
+  /** Local main components, keyed by owning set (falling back to publish key). */
   localMains: Map<string, Offender>;
   /** Instances whose main component didn't resolve, keyed by layer name. */
   unresolved: Map<string, Offender>;
@@ -137,7 +169,11 @@ function isAssetVariant(root: NodeSnapshot): boolean {
     // INSTANCE interiors are never collected (see the collector), so a nested
     // instance is always a leaf here — and a leaf that is not geometry, which
     // is what stops a set with an icon *slot* from exempting itself.
-    if (node.children.length === 0 && !isRoot) {
+    if (
+      node.children.length === 0 &&
+      !isRoot &&
+      !EMPTY_CONTAINER_TYPES.includes(node.type)
+    ) {
       leaves += 1;
       if (GEOMETRY_LEAF_TYPES.includes(node.type)) geometryLeaves += 1;
     }
@@ -159,7 +195,19 @@ function scanOffenders(node: NodeSnapshot, scan: Scan): void {
     } else if (main.remote) {
       scan.remoteInstanceCount += 1;
     } else {
-      tally(scan.localMains, main.key, main.name, node);
+      // Key and label on the owning *set*, not the variant. An instance's main
+      // component is a variant, so `main.name` is `State=Default` — which names
+      // nothing a designer recognises, and worse, is identical across unrelated
+      // sets: five distinct offenders produced five byte-identical messages,
+      // which `groupFindings` then collapsed into a single canvas row. Keying
+      // on the set also stops one offending set being reported twice because
+      // two of its variants were used.
+      tally(
+        scan.localMains,
+        main.setId ?? main.key,
+        main.setName ?? main.name,
+        node,
+      );
     }
   } else if (RAW_PATH_TYPES.includes(node.type)) {
     tally(scan.rawPaths, node.name, node.name, node);
@@ -227,12 +275,13 @@ export function checkAssetProvenance(
   for (const offender of scan.localMains.values()) {
     findings.push(
       finding(offender, {
-        severity: "high",
-        message: `A nested instance points at local component "${offender.label}", not a library instance.`,
-        expected: "a nested instance from a published library",
+        severity: "medium",
+        message: `Nested instance comes from "${offender.label}", a component in this file rather than a library.`,
+        expected:
+          "a library instance, unless this is deliberately a local part",
         actual: "a local component in this file",
         suggestedFix:
-          "Publish the component to the library (or swap in the Foundations equivalent) and re-point the instance.",
+          "Fine if this is an internal building block. If it should come from Foundations, swap in the library instance.",
       }),
     );
   }
@@ -253,10 +302,13 @@ export function checkAssetProvenance(
   // `not_applicable` when nothing provenance-bearing exists at all: no nested
   // instances, no raw geometry. Nothing was measured, which is a different
   // fact from "measured and it's fine" and must not inflate the pass count.
+  // Only raw geometry is a defect the check is sure of. A local nested
+  // instance and an unresolvable main component are both "look at this" — they
+  // warn, so the row asks for a decision rather than claiming one.
   const status: CheckStatus =
-    scan.rawPaths.size > 0 || scan.localMains.size > 0
+    scan.rawPaths.size > 0
       ? "fail"
-      : scan.unresolved.size > 0
+      : scan.localMains.size > 0 || scan.unresolved.size > 0
         ? "warn"
         : scan.remoteInstanceCount > 0
           ? "pass"

--- a/src/plugins/qa/checks/index.test.ts
+++ b/src/plugins/qa/checks/index.test.ts
@@ -35,12 +35,13 @@ const FIXTURE: ComponentSetSnapshot = {
 };
 
 describe("check catalogue", () => {
-  it("lists the 9 Tier 1 checks plus Tier 2's nesting-depth, with unique ids", () => {
-    expect(CHECKS).toHaveLength(10);
-    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(10);
-    // The static Tier 1 PRD sections (issue #76) plus #14 (issue #99).
+  it("lists the 9 Tier 1 checks plus the Tier 2 checks, with unique ids", () => {
+    expect(CHECKS).toHaveLength(11);
+    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(11);
+    // The static Tier 1 PRD sections (issue #76), then Tier 2 appended in
+    // shipping order: #14 (issue #99), #8 (issue #101).
     expect(CHECKS.map((c) => c.prdSection)).toEqual([
-      2, 4, 5, 9, 10, 11, 12, 13, 15, 14,
+      2, 4, 5, 9, 10, 11, 12, 13, 15, 14, 8,
     ]);
   });
 

--- a/src/plugins/qa/checks/index.ts
+++ b/src/plugins/qa/checks/index.ts
@@ -18,6 +18,7 @@ import { checkTokens } from "./tokens";
 import { checkGrid4px } from "./grid-4px";
 import { checkLayerNamingStructure } from "./layer-naming-structure";
 import { checkNestingDepth } from "./nesting-depth";
+import { checkAssetProvenance } from "./asset-provenance";
 
 export type CheckFn = (snapshot: ComponentSetSnapshot) => CheckResult;
 
@@ -37,6 +38,7 @@ export const CHECK_REGISTRY: Partial<Record<CheckId, CheckFn>> = {
   "grid-4px": checkGrid4px,
   "layer-naming-structure": checkLayerNamingStructure,
   "nesting-depth": checkNestingDepth,
+  "asset-provenance": checkAssetProvenance,
 };
 
 export interface RunOutcome {

--- a/src/plugins/qa/checks/layer-naming-structure.test.ts
+++ b/src/plugins/qa/checks/layer-naming-structure.test.ts
@@ -85,7 +85,12 @@ describe("checkLayerNamingStructure — name cleanliness", () => {
               id: "3:1",
               name: "Avatar",
               type: "INSTANCE",
-              mainComponentId: "9:9",
+              mainComponent: {
+                id: "9:9",
+                key: "k9",
+                name: "Icon",
+                remote: true,
+              },
               children: [
                 node({ id: "3:2", name: "Vector 3" }),
                 node({ id: "3:3", name: "Rectangle 7" }),

--- a/src/plugins/qa/collector.ts
+++ b/src/plugins/qa/collector.ts
@@ -71,9 +71,18 @@ function snapshotNode(node: SceneNode): NodeSnapshot {
 
   if (node.type === "INSTANCE") {
     // Interiors of nested instances are deliberately not collected — their
-    // guts belong to the source component (#8 handles provenance). Only the
-    // exposed-instance side-tree is captured (#14 nesting depth).
-    snap.mainComponentId = node.mainComponent?.id;
+    // guts belong to the source component (#8 judges provenance from the main
+    // component's identity alone). Only the exposed-instance side-tree is
+    // captured (#14 nesting depth).
+    const main = node.mainComponent;
+    if (main) {
+      snap.mainComponent = {
+        id: main.id,
+        key: main.key,
+        name: main.name,
+        remote: main.remote,
+      };
+    }
     snap.isExposedInstance = node.isExposedInstance;
     if (node.exposedInstances.length > 0) {
       snap.exposedInstances = node.exposedInstances.map(

--- a/src/plugins/qa/collector.ts
+++ b/src/plugins/qa/collector.ts
@@ -76,10 +76,12 @@ function snapshotNode(node: SceneNode): NodeSnapshot {
     // captured (#14 nesting depth).
     const main = node.mainComponent;
     if (main) {
+      const set = main.parent?.type === "COMPONENT_SET" ? main.parent : null;
       snap.mainComponent = {
         id: main.id,
         key: main.key,
         name: main.name,
+        ...(set ? { setId: set.id, setName: set.name } : {}),
         remote: main.remote,
       };
     }

--- a/src/plugins/qa/render/renderChecklist.ts
+++ b/src/plugins/qa/render/renderChecklist.ts
@@ -167,6 +167,9 @@ const SEVERITY_COLOR: Record<SeverityLevel, string> = {
 // could still grow a row without limit otherwise.
 const MAX_FINDING_GROUPS = 8;
 
+/** Indent for the detail lines under a row, aligning them past the item number. */
+const DETAIL_INDENT = 36;
+
 /**
  * Build a finding line (`×count  message`) and append it to `parent`. The label
  * wraps instead of overflowing the card: Figma only honours `FILL` once the
@@ -291,6 +294,26 @@ export async function renderChecklist(
     }
     itemBlock.appendChild(row);
 
+    // A check's caveat (#8: library origin is unverifiable in-plugin) renders
+    // even on a passing row — that is exactly where the reader needs to know
+    // the tick rests on partial evidence.
+    if (item.note) {
+      const noteBlock = buildAutoLayoutFrame(
+        `item-${item.n}-note`,
+        "VERTICAL",
+        0,
+        0,
+        0,
+      );
+      noteBlock.layoutAlign = "STRETCH";
+      noteBlock.paddingLeft = DETAIL_INDENT;
+      const noteText = text(`Caveat: ${item.note}`, 11, FONT_REGULAR, MUTED);
+      noteBlock.appendChild(noteText);
+      noteText.textAutoResize = "HEIGHT";
+      noteText.layoutSizingHorizontal = "FILL";
+      itemBlock.appendChild(noteBlock);
+    }
+
     if (item.findings.length > 0) {
       const groups = groupFindings(item.findings);
       const findingsBlock = buildAutoLayoutFrame(
@@ -301,7 +324,7 @@ export async function renderChecklist(
         4,
       );
       findingsBlock.layoutAlign = "STRETCH";
-      findingsBlock.paddingLeft = 36;
+      findingsBlock.paddingLeft = DETAIL_INDENT;
       for (const group of groups.slice(0, MAX_FINDING_GROUPS)) {
         appendFindingLine(
           findingsBlock,

--- a/src/plugins/qa/report.test.ts
+++ b/src/plugins/qa/report.test.ts
@@ -111,13 +111,35 @@ describe("buildChecklistReport", () => {
       expect(item.status).toBe("manual");
       expect(item.findings).toEqual([]);
     }
-    // Item 8 is Tier 2 planned — still manual until a check ships.
-    const icons = report.items.find((i) => i.n === 8)!;
-    expect(icons).toMatchObject({
-      tier: 2,
+    // Item 18 is manual-only in the PRD — no check will ever back it.
+    const template = report.items.find((i) => i.n === 18)!;
+    expect(template).toMatchObject({
+      tier: null,
       automated: false,
       status: "manual",
     });
+  });
+
+  it("carries a check's caveat onto its row, even when the check passed", () => {
+    const report = buildChecklistReport({
+      target: TARGET,
+      results: [
+        {
+          checkId: "asset-provenance",
+          title: "Icons / illustrations / logos from Foundations",
+          status: "pass",
+          findings: [],
+          note: "Library origin cannot be verified through the plugin API.",
+        },
+      ],
+      notImplemented: [],
+    });
+    const icons = report.items.find((i) => i.n === 8)!;
+    expect(icons.status).toBe("pass");
+    // A pass carries no findings, so the note is the only place the partial
+    // evidence can surface.
+    expect(icons.findings).toEqual([]);
+    expect(icons.note).toMatch(/cannot be verified/);
   });
 
   it("resolves catalogued-but-unbuilt automated items to not_implemented", () => {

--- a/src/plugins/qa/report.ts
+++ b/src/plugins/qa/report.ts
@@ -46,6 +46,9 @@ export function buildChecklistReport(
     const automated = entry.checkId !== undefined;
     let status: ItemStatus;
     let findings: Finding[] = [];
+    // Unlike findings, a note survives a `pass` — a caveat only matters
+    // precisely when the check passed on partial evidence (#8).
+    let note: string | undefined;
 
     if (!entry.checkId) {
       status = "manual";
@@ -60,6 +63,7 @@ export function buildChecklistReport(
         // Findings are only meaningful for warn/fail; pass/not_applicable carry none.
         findings =
           status === "warn" || status === "fail" ? engine.findings : [];
+        note = engine.note;
       } else if (notImplemented.has(entry.checkId)) {
         status = "not_implemented";
       } else {
@@ -96,6 +100,7 @@ export function buildChecklistReport(
       automated,
       status,
       findings,
+      ...(note ? { note } : {}),
     };
   });
 

--- a/src/plugins/qa/snapshot.ts
+++ b/src/plugins/qa/snapshot.ts
@@ -51,8 +51,29 @@ export interface NodeSnapshot {
    * interiors are another component's problem (#8 handles provenance).
    */
   children: NodeSnapshot[];
-  /** INSTANCE nodes only: the main component this instance points to. */
-  mainComponentId?: string;
+  /**
+   * INSTANCE nodes only: identity of the main component this instance points
+   * at. Absent when Figma can't resolve one — and that absence is a real third
+   * state (provenance unknown), distinct from a resolved `remote: false` (a
+   * local component), which is why the fields travel as one object rather than
+   * three separately-optional ones.
+   *
+   * Note there is deliberately no library *identity* here: the plugin API
+   * exposes a component's `key` and `remote` flag but no file key or library
+   * name (only variable collections carry `libraryName`), so "came from the
+   * approved Foundations file" is not answerable in-plugin (#8).
+   */
+  mainComponent?: {
+    id: string;
+    /**
+     * Publish key — stable across files, so it is the dedupe key for "one
+     * finding per offending main component" (#8).
+     */
+    key: string;
+    name: string;
+    /** Whether the component lives in another (published) file. */
+    remote: boolean;
+  };
   /**
    * INSTANCE nodes only: whether this instance itself is exposed to its
    * containing component's panel (#14). When false, none of its exposed

--- a/src/plugins/qa/snapshot.ts
+++ b/src/plugins/qa/snapshot.ts
@@ -66,11 +66,24 @@ export interface NodeSnapshot {
   mainComponent?: {
     id: string;
     /**
-     * Publish key — stable across files, so it is the dedupe key for "one
-     * finding per offending main component" (#8).
+     * Publish key — stable across files. Identifies the *variant*, so it is
+     * only the dedupe key for a component with no owning set (#8).
      */
     key: string;
+    /**
+     * The variant's own name, e.g. `State=Default`. Rarely what a reader
+     * wants on its own — see `setName`.
+     */
     name: string;
+    /**
+     * Owning component set, when the main component is a variant. An
+     * instance's main component is the *variant*, so `name` alone reads as
+     * `State=Default` and identifies nothing; the set is the thing a designer
+     * recognises, and the thing findings dedupe on (#8). Absent for a
+     * standalone component, where `name` is already the identity.
+     */
+    setId?: string;
+    setName?: string;
     /** Whether the component lives in another (published) file. */
     remote: boolean;
   };

--- a/src/plugins/qa/types.ts
+++ b/src/plugins/qa/types.ts
@@ -11,7 +11,7 @@ export type { SeverityLevel };
 
 export type CheckStatus = "pass" | "warn" | "fail" | "not_applicable";
 
-/** Stable ids of the static checks (PRD section in CHECKS): 9 Tier 1 plus Tier 2's nesting-depth. */
+/** Stable ids of the static checks (PRD section in CHECKS): 9 Tier 1 plus Tier 2's. */
 export type CheckId =
   | "set-name-casing"
   | "prop-order"
@@ -22,7 +22,8 @@ export type CheckId =
   | "description"
   | "no-conflicts"
   | "preferred-values"
-  | "nesting-depth";
+  | "nesting-depth"
+  | "asset-provenance";
 
 export interface Finding {
   severity: SeverityLevel;
@@ -46,6 +47,14 @@ export interface CheckResult {
   title: string;
   status: CheckStatus;
   findings: Finding[];
+  /**
+   * What this check could *not* establish, stated in the result rather than
+   * left for the caller to know. A `pass` that rests on partial evidence
+   * (#8: the plugin API exposes no library identity for a component, so a
+   * remote instance can't be traced to an approved library) has to say so, or
+   * the checklist reads as a stronger guarantee than it is.
+   */
+  note?: string;
 }
 
 export interface CheckDefinition {
@@ -87,6 +96,11 @@ export const CHECKS: readonly CheckDefinition[] = [
     prdSection: 14,
     title: "Nested instance depth",
   },
+  {
+    id: "asset-provenance",
+    prdSection: 8,
+    title: "Icons / illustrations / logos from Foundations",
+  },
 ];
 
 export function getCheck(id: string): CheckDefinition | undefined {
@@ -116,6 +130,8 @@ export interface ChecklistItem {
    * not_applicable, not_implemented, and not_run carry no findings).
    */
   findings: Finding[];
+  /** Engine caveat for this row, when the backing check declared one. */
+  note?: string;
 }
 
 export interface ChecklistReport {


### PR DESCRIPTION
## Summary

Closes #101. Checklist item **8 "Icons / Illustrations / Logos → Foundations"**
becomes the automated `asset-provenance` check.

**What it ships, and what it deliberately doesn't.** The plugin API exposes no
library attribution for components — `libraryName` exists only for variable
collections, and an instance gives you its main component's `key` and `remote`
flag, never a file key or library name. So "did this icon come from the approved
Foundations file?" is not answerable in-plugin. Rather than guess, the check does
negative detection and states the gap in a new `CheckResult.note`, rendered on
canvas so a passing row can't read as a stronger guarantee than it is.

| Situation | Result |
|---|---|
| Raw path geometry alongside other content | `fail` — the only certain defect |
| Nested instance whose main component is **local** | `warn` — see below |
| Nested instance that is **remote** | `pass`, with the caveat note |
| Main component unresolvable | `warn` — neither certainly local nor remote |
| Every leaf in the variant is geometry (it *is* the asset) | `not_applicable` |

**Why local nested instances warn rather than fail.** Rule 2 applies to *every*
nested instance, which is what lets the check work without an "is this an icon?"
classifier. But that breadth is exactly why it can't assert a defect: a component
legitimately built from private sub-components in its own file (Kido's
`_elements / …` parts) is indistinguishable here from a stray local copy of an
icon. A live run on `Dropdown` failed at high severity for five such parts and
advised publishing them — wrong advice for something private by design. This was
a deliberate product decision, not a limitation: the row surfaces the fact and
the designer decides.

**The asset exemption is structural, not name-based.** A variant whose every leaf
is geometry is the asset and is skipped, judged **per variant** rather than pooled
over the set — pooling would let one stray leaf un-exempt a whole icon set and
then fail every vector in it.

## Review fixes (`f8aabda`)

Three of these only surfaced on real components, not in tests:

- **Findings named the variant, not the component.** An instance's main component
  is the *variant*, so the label read `State=Default` — identifying nothing, and
  identical across unrelated sets. `Dropdown` produced five findings with
  byte-identical messages, which `groupFindings` would have collapsed into one
  canvas row with count 42. Snapshots now carry the owning set (`setId`/`setName`)
  and findings key and label on it.
- **`LINE` contradicted rule 1's own rationale** — excluded `RECTANGLE`/`ELLIPSE`
  as legitimate divider primitives while flagging the actual divider primitive.
  Any card with a drawn rule failed at high severity.
- **A childless frame un-exempted an asset variant**, so one invisible clip frame
  cost an icon its exemption and failed every vector inside it.
- **Severity/wording** for local mains, per the decision above.

## Test plan

- [x] `npm run typecheck`, `npm run lint` (0 errors), `npm run test` — 401 passing
- [x] Both commits typecheck and test green in isolation (396 → 401), so the
      branch bisects
- [x] Verified live in Figma: `banner-outlined` → `pass` + caveat (its `slot` is
      genuinely remote); `Dropdown` → `warn` with five distinct, actionable
      labels (`_elements / DesktopItems` ×10, `_elements / WithIconsStates` ×10,
      `_elements / DropdownMultiselectionStates` ×10, `_elements / TwoLinesStates`
      ×6, `_elements / PersonSelectorStates` ×6)

## Known and deferred

- The **approved-key manifest** that would let item 8 actually verify Foundations
  origin needs a generation + refresh pipeline outside the plugin sandbox, so it
  stays its own future ticket. The PRD's "flag instances pointing to deprecated
  icon directories" depends on it and is likewise not covered here.
- The caveat text is ~330 characters and renders in full on every passing row; a
  shorter canvas form would be an improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
