### PR TITLE
QA Tier 2: item 17 themes — per-mode resolution probe (#102)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,9 @@ Layout:
 - `src/shared/operations/register-all.ts` — side-effect import that pulls in every module's operation registrations. Add a line here when a new module exposes operations.
 - `src/shared/operations/ui-bridge.ts`, `ui-bridge-startup.ts` — UI-iframe WebSocket to `ws://localhost:9876`; relays envelopes to the main thread via the existing `postMessage` channel.
 - `src/plugins/<module>/operations.ts` — per-module `registerOperation(...)` calls. Each id is snake_case and `tidy_`-prefixed (e.g. `tidy_misprint_find_components`).
+
+The QA engine keeps its figma-touching code in exactly two files: `src/plugins/qa/collector.ts` (reads the set into a plain-JSON snapshot) and `src/plugins/qa/theme-probe.ts` (resolves variables per theme mode against one temporary frame, the ADR-0001 read-only carve-out).
+Everything else under `src/plugins/qa/checks/` is pure `(snapshot) -> CheckResult` and fixture-tested.
 - `mcp-server/` — Node MCP server that **listens** on `127.0.0.1:9876` and accepts the plugin's outbound connection (plugin sandbox can't accept inbound, hence inverted server/client roles).
 - `claude-plugin/` — canonical source of the **Claude Code plugin** (`.claude-plugin/plugin.json`, `commands/tidy-*.md`, `skills/`). `npm run build:plugin` bundles the MCP server into it and assembles an installable, marketplace-rooted tree under `dist-plugin/` (version synced from the root `package.json`). The `/tidy-*` commands live here (not in `.claude/commands/`); see `docs/plugin-dev.md` for the local-install dogfood loop. Tools from the plugin-bundled server are namespaced `mcp__plugin_tidy-ds_tidy-ds-toolbox__<op>`.
 

--- a/claude-plugin/commands/tidy-qa.md
+++ b/claude-plugin/commands/tidy-qa.md
@@ -23,7 +23,7 @@ Split `$ARGUMENTS` on whitespace into tokens, then classify each:
 - **Check-id** — a token that exactly matches one of the known check ids:
   `set-name-casing`, `prop-order`, `tokens`, `layer-naming-structure`,
   `grid-4px`, `interaction-hover-only`, `description`, `no-conflicts`,
-  `preferred-values`, `nesting-depth`, `asset-provenance`. Collect these into
+  `preferred-values`, `nesting-depth`, `asset-provenance`, `themes`. Collect these into
   the `checks` array (a filter — only these checks run).
 - **Id** — a token matching `^\d+:\d+$` (e.g. `2625:10445`). Use as `nodeId`.
 - **Target name / glob** — every remaining token. Join them with spaces (names

--- a/docs/adr/0001-plan-execute-split-for-operations.md
+++ b/docs/adr/0001-plan-execute-split-for-operations.md
@@ -7,3 +7,19 @@ To make agent-driven Figma work deterministic without baking DS knowledge into t
 - The unit of agent interaction is the **Operation**, not the **Module** or **Feature**. A Module may expose several Operations across the Query / Plan / Execute categories.
 - Designers can review plans before execution when they want to; the agent can also self-approve simple cases and chain `plan → execute` without prompting.
 - Existing modules (Sticker Sheet Builder, Tidy Mapper, Audit) need to be examined to find their natural plan/execute seam — some already have it implicitly.
+
+## Carve-out: transient probe nodes in a Query Operation (2026-07-26, issue #102)
+
+"Read-only" for a Query Operation means **read-only toward its target**, not "performs no document write at all".
+`tidy_qa_run` creates and removes one temporary off-canvas frame in order to resolve variables per theme mode (#17, see `src/plugins/qa/theme-probe.ts`).
+It is permitted under these conditions:
+
+- The probe node is created, used and removed inside a single Operation call, in a `finally` so the error path cleans up too.
+  Nothing survives the call.
+- It is never a descendant of, and never modifies, the Operation's target.
+- The Operation's MCP summary states it, so an agent reading the catalogue is not misled about what "query" implies here.
+
+The reason it lives in the Query rather than only in the sibling Execute Operation: probing in one and not the other would leave the two QA surfaces silently disagreeing about what was checked, which is a worse failure than a documented exception.
+The alternative implementations were reimplementing Figma's mode resolution in-plugin (silently wrong numbers, inherited by #16's contrast maths) and cloning the component set into a scratch page (disproportionate, and a much larger write).
+
+A future Operation wanting the same latitude should be held to the three conditions above rather than treating this as a general licence.

--- a/docs/prd-automated-qa.md
+++ b/docs/prd-automated-qa.md
@@ -193,6 +193,20 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 
 ### 17. Themes (Core / DNA / OldNews)
 
+> Shipped as check `themes` (issue #102), covering **resolution integrity only**.
+> It reports a bound variable with **no value for some theme mode** (the missing override on an extended collection) and an **alias chain that cannot be resolved** in some mode.
+> Invisible text is deliberately *not* reported here: it is contrast 1.0, so #16 owns it, and reporting it twice would describe one defect in two rows.
+> Raw unbound values stay with the `tokens` check.
+>
+> Nothing switches modes on the page or the component.
+> Per-mode values come from a **resolution probe**: one temporary off-canvas frame with explicit modes pinned on it, each used variable resolved against it once per mode, removed in a `finally`.
+> Figma does the resolving, so the values are faithful rather than a reimplementation of mode inheritance, and cost scales with variables used rather than variants x modes x nodes.
+> This is a documented carve-out from ADR-0001's read-only Query definition.
+>
+> The theme collection is **not configured by name**: it is the bound collection with the most modes (the shared helper the generated doc pages use), and the result states which collection and modes it evaluated so a wrong pick is visible instead of silently green.
+> Where nodes pin their own explicit modes the probe cannot speak for them, and the check `warn`s rather than reporting a confidently wrong value.
+> Flagging colours bound to a *single-mode* collection as "not theme-aware" is a candidate follow-up, not v1 work: a false-positive factory until narrowed much harder.
+
 * **Intent:** Validate that variables map cleanly across dynamic display scenarios without visual bugs.
 * **Automated Plugin Action:**
 * Programmatically switch the parent page or component frame through all designated Design System theme collection modes (`Core`, `DNA`, `OldNews`).

--- a/docs/prd-qa-canvas-checklist.md
+++ b/docs/prd-qa-canvas-checklist.md
@@ -107,7 +107,7 @@ Three new pieces, plus one operation:
 | 14 | Nested Instance Depth (PRD: "Easy to Use") | `nesting-depth` |
 | 15 | Preferred (Instance Swapping) | `preferred-values` |
 | 16 | High Contrast (A11y) | manual |
-| 17 | Themes (Core/DNA/OldNews) | manual |
+| 17 | Themes (Core/DNA/OldNews) | `themes` |
 | 18 | Page Template | manual |
 | 19 | Documentation | manual |
 

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -261,7 +261,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "query",
     module: "qa",
     summary:
-      "Run the DS Component QA checklist against a component set (static checks — never mutates the file). Target by nodeId or by name/glob, or omit both to use the current Figma selection; any instance/component resolves up to its owning set. Returns structured CheckResults (status per check, severity + offender node per finding), ids of requested checks not implemented yet, and a 19-item `checklist` model (PRD order) merging engine results with the full DS QA catalogue (pass/warn/fail/manual/not_implemented/not_run/not_applicable — the last when a check ran but had nothing applicable to evaluate, e.g. no instance-swap properties).",
+      "Run the DS Component QA checklist against a component set. Read-only toward the target - it never modifies the component set - with one documented exception: the themes check (#17) creates and removes a temporary off-canvas probe frame in order to resolve variables per theme mode (carve-out from ADR-0001). Target by nodeId or by name/glob, or omit both to use the current Figma selection; any instance/component resolves up to its owning set. Returns structured CheckResults (status per check, severity + offender node per finding), ids of requested checks not implemented yet, and a 19-item `checklist` model (PRD order) merging engine results with the full DS QA catalogue (pass/warn/fail/manual/not_implemented/not_run/not_applicable - the last when a check ran but had nothing applicable to evaluate, e.g. no instance-swap properties).",
     inputSchema: {
       nodeId: z
         .string()
@@ -279,7 +279,7 @@ export const CATALOGUE: CatalogueEntry[] = [
         .array(z.string())
         .optional()
         .describe(
-          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth, asset-provenance.",
+          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth, asset-provenance, themes.",
         ),
     },
     timeoutMs: 60_000,

--- a/src/plugins/qa/checklist-catalogue.test.ts
+++ b/src/plugins/qa/checklist-catalogue.test.ts
@@ -70,7 +70,12 @@ const PRD_ITEMS: ReadonlyArray<{
     checkId: "preferred-values",
   },
   { n: 16, title: "High Contrast (A11y)", tier: null },
-  { n: 17, title: "Themes (Core/DNA/OldNews)", tier: null },
+  {
+    n: 17,
+    title: "Themes (Core/DNA/OldNews)",
+    tier: 2,
+    checkId: "themes",
+  },
   { n: 18, title: "Page Template", tier: null },
   { n: 19, title: "Documentation", tier: null },
 ];
@@ -105,8 +110,8 @@ describe("CHECKLIST_CATALOGUE", () => {
 
   it("gives every automated item a unique checkId, tiered 1 or 2", () => {
     const automated = CHECKLIST_CATALOGUE.filter((item) => item.checkId);
-    expect(automated).toHaveLength(11);
-    expect(new Set(automated.map((item) => item.checkId)).size).toBe(11);
+    expect(automated).toHaveLength(12);
+    expect(new Set(automated.map((item) => item.checkId)).size).toBe(12);
     for (const item of automated) {
       expect(item.tier === 1 || item.tier === 2).toBe(true);
     }

--- a/src/plugins/qa/checklist-catalogue.ts
+++ b/src/plugins/qa/checklist-catalogue.ts
@@ -136,7 +136,8 @@ export const CHECKLIST_CATALOGUE: readonly CatalogueItem[] = [
   {
     n: 17,
     title: "Themes (Core/DNA/OldNews)",
-    tier: null,
+    tier: 2,
+    checkId: "themes",
     blurb: "Every bound variable resolves in all theme modes, with no gaps.",
   },
   {

--- a/src/plugins/qa/checks/index.test.ts
+++ b/src/plugins/qa/checks/index.test.ts
@@ -36,12 +36,12 @@ const FIXTURE: ComponentSetSnapshot = {
 
 describe("check catalogue", () => {
   it("lists the 9 Tier 1 checks plus the Tier 2 checks, with unique ids", () => {
-    expect(CHECKS).toHaveLength(11);
-    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(11);
+    expect(CHECKS).toHaveLength(12);
+    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(12);
     // The static Tier 1 PRD sections (issue #76), then Tier 2 appended in
-    // shipping order: #14 (issue #99), #8 (issue #101).
+    // shipping order: #14 (issue #99), #8 (issue #101), #17 (issue #102).
     expect(CHECKS.map((c) => c.prdSection)).toEqual([
-      2, 4, 5, 9, 10, 11, 12, 13, 15, 14, 8,
+      2, 4, 5, 9, 10, 11, 12, 13, 15, 14, 8, 17,
     ]);
   });
 

--- a/src/plugins/qa/checks/index.ts
+++ b/src/plugins/qa/checks/index.ts
@@ -19,6 +19,7 @@ import { checkGrid4px } from "./grid-4px";
 import { checkLayerNamingStructure } from "./layer-naming-structure";
 import { checkNestingDepth } from "./nesting-depth";
 import { checkAssetProvenance } from "./asset-provenance";
+import { checkThemes } from "./themes";
 
 export type CheckFn = (snapshot: ComponentSetSnapshot) => CheckResult;
 
@@ -39,6 +40,7 @@ export const CHECK_REGISTRY: Partial<Record<CheckId, CheckFn>> = {
   "layer-naming-structure": checkLayerNamingStructure,
   "nesting-depth": checkNestingDepth,
   "asset-provenance": checkAssetProvenance,
+  themes: checkThemes,
 };
 
 export interface RunOutcome {

--- a/src/plugins/qa/checks/themes.test.ts
+++ b/src/plugins/qa/checks/themes.test.ts
@@ -335,6 +335,46 @@ describe("checkThemes", () => {
     expect(result.findings).toEqual([]);
   });
 
+  it("fails a binding Figma could not load, rather than dropping it", () => {
+    // getVariableByIdAsync returning null is the broken-remote-variable case.
+    // Discarding it let a set with one dead binding pass on the strength of its
+    // remaining healthy variables.
+    const result = checkThemes(
+      fixture(
+        [[filled("v-dead"), filled("v-ok", "fine")]],
+        theme({
+          variables: { "v-ok": resolved("bg/default", ["m-core", "m-dna"]) },
+          unavailableVariableIds: ["v-dead"],
+        }),
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toContain("v-dead");
+    expect(result.findings[0].message).toMatch(/could not be loaded/i);
+    // The consuming layer, so "jump to offender" still lands somewhere real.
+    expect(result.findings[0].nodeName).toBe("bg");
+  });
+
+  it("still reports dead bindings when no theme collection could be determined", () => {
+    // Every lookup failed, so there is no bound collection to call the theme
+    // and no modes to evaluate. The dead bindings are the whole story.
+    const result = checkThemes(
+      fixture(
+        [[filled("v-dead")]],
+        theme({
+          collectionId: undefined,
+          collectionName: undefined,
+          modes: [],
+          unavailableVariableIds: ["v-dead"],
+        }),
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.note).toMatch(/no theme collection could be determined/i);
+  });
+
   it("orders findings deterministically by message", () => {
     const result = checkThemes(
       fixture(

--- a/src/plugins/qa/checks/themes.test.ts
+++ b/src/plugins/qa/checks/themes.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect } from "vitest";
+import { checkThemes } from "./themes";
+import type {
+  ComponentSetSnapshot,
+  NodeSnapshot,
+  ThemeSnapshot,
+  VariableResolutionSnapshot,
+} from "../snapshot";
+
+let seq = 0;
+
+function node(overrides: Partial<NodeSnapshot> = {}): NodeSnapshot {
+  seq += 1;
+  return {
+    id: `1:${seq}`,
+    name: "layer",
+    type: "FRAME",
+    visible: true,
+    width: 24,
+    height: 24,
+    children: [],
+    ...overrides,
+  };
+}
+
+/** A variable resolving cleanly in every listed mode. */
+function resolved(
+  name: string,
+  modeIds: string[],
+  collectionId = "c-theme",
+): VariableResolutionSnapshot {
+  return {
+    name,
+    collectionId,
+    byMode: Object.fromEntries(
+      modeIds.map((m) => [m, { ok: true, type: "COLOR", hex: "#123456" }]),
+    ),
+  };
+}
+
+const THEME_MODES = [
+  { modeId: "m-core", name: "Core" },
+  { modeId: "m-dna", name: "DNA" },
+];
+
+function theme(overrides: Partial<ThemeSnapshot> = {}): ThemeSnapshot {
+  return {
+    collectionId: "c-theme",
+    collectionName: "Theme",
+    modes: THEME_MODES,
+    variables: {},
+    ...overrides,
+  };
+}
+
+function fixture(
+  trees: NodeSnapshot[][],
+  themeSnapshot?: ThemeSnapshot,
+): ComponentSetSnapshot {
+  return {
+    id: "1:0",
+    name: "Button",
+    type: "COMPONENT_SET",
+    description: "",
+    propertyNames: [],
+    properties: [],
+    variants: trees.map((kids, i) => ({
+      id: `v:${i}`,
+      name: `Button-${i}`,
+      variantProperties: {},
+      tree: node({ id: `v:${i}`, type: "COMPONENT", children: kids }),
+    })),
+    ...(themeSnapshot ? { theme: themeSnapshot } : {}),
+  };
+}
+
+/** A node consuming `variableId` through a fill. */
+function filled(variableId: string, name = "bg"): NodeSnapshot {
+  return node({
+    name,
+    fills: [
+      {
+        type: "SOLID",
+        visible: true,
+        opacity: 1,
+        hex: "#123456",
+        boundVariableId: variableId,
+      },
+    ],
+  });
+}
+
+describe("checkThemes", () => {
+  it("is not_applicable when the probe produced no theme table", () => {
+    const result = checkThemes(fixture([[node()]]));
+    expect(result.checkId).toBe("themes");
+    expect(result.status).toBe("not_applicable");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("passes when every used variable resolves in every mode, and says what it evaluated", () => {
+    const result = checkThemes(
+      fixture(
+        [[filled("v-bg")]],
+        theme({
+          variables: { "v-bg": resolved("bg/default", ["m-core", "m-dna"]) },
+        }),
+      ),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+    // The collection pick is a heuristic, so a wrong pick has to be visible
+    // rather than silently producing green rows.
+    expect(result.note).toContain("Theme");
+    expect(result.note).toContain("Core");
+    expect(result.note).toContain("DNA");
+  });
+
+  it("fails a variable with no value for one mode, naming the variable and the mode", () => {
+    const result = checkThemes(
+      fixture(
+        [[filled("v-bg")]],
+        theme({
+          variables: {
+            "v-bg": {
+              name: "bg/default",
+              collectionId: "c-theme",
+              byMode: {
+                "m-core": { ok: true, type: "COLOR", hex: "#FFFFFF" },
+                "m-dna": { ok: false, reason: "no-value" },
+              },
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toContain("bg/default");
+    expect(result.findings[0].message).toContain("DNA");
+    expect(result.findings[0].message).toMatch(/no value/i);
+  });
+
+  it("fails an unresolvable alias chain, distinguishing it from a missing value", () => {
+    const result = checkThemes(
+      fixture(
+        [[filled("v-fg")]],
+        theme({
+          variables: {
+            "v-fg": {
+              name: "fg/muted",
+              collectionId: "c-semantic",
+              byMode: {
+                "m-core": { ok: true, type: "COLOR", hex: "#000000" },
+                "m-dna": { ok: false, reason: "unresolved-alias" },
+              },
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toMatch(/alias/i);
+    expect(result.findings[0].message).toContain("fg/muted");
+    expect(result.findings[0].message).toContain("DNA");
+  });
+
+  it("emits one finding per variable × mode, not per consuming node", () => {
+    // Same variable broken in both modes, consumed by three layers across two
+    // variants: two findings (one per mode), each counting three usages.
+    const broken: VariableResolutionSnapshot = {
+      name: "bg/default",
+      collectionId: "c-theme",
+      byMode: {
+        "m-core": { ok: false, reason: "no-value" },
+        "m-dna": { ok: false, reason: "no-value" },
+      },
+    };
+    const result = checkThemes(
+      fixture(
+        [[filled("v-bg", "a"), filled("v-bg", "b")], [filled("v-bg", "c")]],
+        theme({ variables: { "v-bg": broken } }),
+      ),
+    );
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.map((f) => f.count)).toEqual([3, 3]);
+    const modes = result.findings.map((f) => f.message);
+    expect(modes.some((m) => m.includes("Core"))).toBe(true);
+    expect(modes.some((m) => m.includes("DNA"))).toBe(true);
+  });
+
+  it("counts usages bound on node fields, not just paints", () => {
+    const result = checkThemes(
+      fixture(
+        [
+          [
+            node({ name: "row", boundVariableIds: ["v-gap"] }),
+            node({ name: "row2", boundVariableIds: ["v-gap"] }),
+          ],
+        ],
+        theme({
+          variables: {
+            "v-gap": {
+              name: "space/200",
+              collectionId: "c-theme",
+              byMode: {
+                "m-core": { ok: true, type: "FLOAT" },
+                "m-dna": { ok: false, reason: "no-value" },
+              },
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(2);
+  });
+
+  it("ignores variables the set does not actually use", () => {
+    // The probe may resolve a variable that only a style references; without a
+    // usage in this set there is nothing to report against.
+    const result = checkThemes(
+      fixture(
+        [[node()]],
+        theme({
+          variables: {
+            "v-unused": {
+              name: "bg/legacy",
+              collectionId: "c-theme",
+              byMode: {
+                "m-core": { ok: true, type: "COLOR" },
+                "m-dna": { ok: false, reason: "no-value" },
+              },
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("warns when a layer pins its own mode for the theme collection", () => {
+    const result = checkThemes(
+      fixture(
+        [
+          [
+            filled("v-bg"),
+            node({
+              id: "1:9",
+              name: "pinned",
+              explicitVariableModes: { "c-theme": "m-core" },
+            }),
+          ],
+        ],
+        theme({
+          variables: { "v-bg": resolved("bg/default", ["m-core", "m-dna"]) },
+        }),
+      ),
+    );
+    expect(result.status).toBe("warn");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toMatch(/explicit mode/i);
+    expect(result.findings[0].nodeId).toBe("1:9");
+  });
+
+  it("ignores a layer pinning some other collection's mode", () => {
+    // A density or rem/px pin says nothing about whether the theme resolved,
+    // so raising the caveat for it would flag verifiable components.
+    const result = checkThemes(
+      fixture(
+        [
+          [
+            filled("v-bg"),
+            node({
+              name: "compact",
+              explicitVariableModes: { "c-density": "m-compact" },
+            }),
+          ],
+        ],
+        theme({
+          variables: { "v-bg": resolved("bg/default", ["m-core", "m-dna"]) },
+        }),
+      ),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("still fails, not warns, when overrides coexist with a real resolution failure", () => {
+    const result = checkThemes(
+      fixture(
+        [
+          [
+            filled("v-bg"),
+            node({
+              name: "pinned",
+              explicitVariableModes: { "c-theme": "m-core" },
+            }),
+          ],
+        ],
+        theme({
+          variables: {
+            "v-bg": {
+              name: "bg/default",
+              collectionId: "c-theme",
+              byMode: {
+                "m-core": { ok: true, type: "COLOR" },
+                "m-dna": { ok: false, reason: "no-value" },
+              },
+            },
+          },
+        }),
+      ),
+    );
+    expect(result.status).toBe("fail");
+    // Both the failure and the caveat are reported.
+    expect(result.findings).toHaveLength(2);
+  });
+
+  it("is not_applicable when the theme collection has only one mode", () => {
+    // Nothing to compare across: a single-mode collection is not a theme, and
+    // flagging its variables as "not theme-aware" is explicitly out of scope.
+    const result = checkThemes(
+      fixture(
+        [[filled("v-bg")]],
+        theme({
+          modes: [{ modeId: "m-only", name: "Value" }],
+          variables: { "v-bg": resolved("bg/default", ["m-only"]) },
+        }),
+      ),
+    );
+    expect(result.status).toBe("not_applicable");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("orders findings deterministically by message", () => {
+    const result = checkThemes(
+      fixture(
+        [[filled("v-b"), filled("v-a")]],
+        theme({
+          variables: {
+            "v-b": {
+              name: "zeta",
+              collectionId: "c-theme",
+              byMode: {
+                "m-core": { ok: false, reason: "no-value" },
+                "m-dna": { ok: true },
+              },
+            },
+            "v-a": {
+              name: "alpha",
+              collectionId: "c-theme",
+              byMode: {
+                "m-core": { ok: false, reason: "no-value" },
+                "m-dna": { ok: true },
+              },
+            },
+          },
+        }),
+      ),
+    );
+    const messages = result.findings.map((f) => f.message);
+    expect(messages).toEqual([...messages].sort());
+  });
+});

--- a/src/plugins/qa/checks/themes.ts
+++ b/src/plugins/qa/checks/themes.ts
@@ -1,0 +1,145 @@
+/**
+ * #17 - Themes (issue #102). Does every variable this set uses actually
+ * resolve in every mode of the theme?
+ *
+ * **Scope: resolution integrity only.** Legibility is #16's, and invisible
+ * text is just contrast 1.0 - reporting it here as well would describe one
+ * defect twice in two rows. So there is no contrast maths in this check at all.
+ * Raw unbound values belong to `tokens`, and flagging colours bound to a
+ * single-mode collection as "not theme-aware" is deliberately out of scope: a
+ * real concern, but a false-positive factory until it is narrowed much harder.
+ *
+ * Two `fail` classes, kept apart because they have different fixes:
+ *
+ * 1. **No value for a mode** - the variable has no entry for that mode, the
+ *    classic missing override on an extended collection.
+ * 2. **Unresolvable alias chain** - Figma could not follow the aliases to a
+ *    concrete value in that mode (dangling target, broken remote variable).
+ *
+ * Both come from the resolution probe (see theme-probe.ts): Figma performs the
+ * resolution against a temporary frame with explicit modes set, so this check
+ * reads observations rather than reimplementing mode inheritance.
+ *
+ * **The probe's blind spot is reported, not hidden.** It resolves against a
+ * frame carrying no explicit modes of its own, so where nodes in the set pin
+ * their own mode the probe's answer may not be what renders. Those nodes
+ * produce a `warn` rather than a confidently wrong value.
+ *
+ * **Which collection is "the theme"** comes from the shared selection helper
+ * (most modes), so QA and the generated documentation pages cannot disagree.
+ * Because that is a heuristic, the result states which collection and modes it
+ * evaluated in `note` - a wrong pick has to be visible on the row instead of
+ * silently producing green.
+ *
+ * Findings are one per **variable × mode** with an occurrence count of the
+ * consuming usages (#100), never one row per consuming node.
+ */
+
+import type { ComponentSetSnapshot } from "../snapshot";
+import type { CheckResult, CheckStatus, Finding } from "../types";
+import { collectVariableUsage, nodesPinning } from "../variable-usage";
+
+const TITLE = "Themes (per-mode variable resolution)";
+
+export function checkThemes(snapshot: ComponentSetSnapshot): CheckResult {
+  const theme = snapshot.theme;
+
+  // No probe table (no bound variables, or no collection with modes), or a
+  // single-mode collection - which is not a theme, and comparing one mode
+  // against itself would report nothing meaningful.
+  if (!theme || theme.modes.length < 2) {
+    return {
+      checkId: "themes",
+      title: TITLE,
+      status: "not_applicable",
+      findings: [],
+    };
+  }
+
+  const usage = collectVariableUsage(snapshot);
+  const findings: Finding[] = [];
+
+  for (const [variableId, variable] of Object.entries(theme.variables)) {
+    // A variable the probe resolved but this set never consumes (a style may
+    // reference it) has nothing to report against here.
+    const consumer = usage.get(variableId);
+    if (!consumer) continue;
+    const { count, nodeId, nodeName } = consumer;
+
+    for (const mode of theme.modes) {
+      const resolution = variable.byMode[mode.modeId];
+      if (!resolution || resolution.ok) continue;
+
+      const where = `variable "${variable.name}" in mode "${mode.name}"`;
+      findings.push(
+        resolution.reason === "unresolved-alias"
+          ? {
+              severity: "high",
+              // A representative consuming layer, matching the convention the
+              // other Tier 2 checks set: the finding keys on the variable, but
+              // "jump to offender" still has to land somewhere real.
+              nodeId,
+              nodeName,
+              message: `The alias chain for ${where} cannot be resolved to a concrete value.`,
+              expected: `a resolvable value in every mode of "${theme.collectionName}"`,
+              actual: "alias chain does not resolve",
+              suggestedFix:
+                "Re-point the alias at a live variable, or restore the missing target in the source collection.",
+              count,
+            }
+          : {
+              severity: "high",
+              nodeId,
+              nodeName,
+              message: `There is no value for ${where}.`,
+              expected: `a value in every mode of "${theme.collectionName}"`,
+              actual: "no value for this mode",
+              suggestedFix:
+                "Give the variable a value for this mode (an extended collection needs the override set explicitly).",
+              count,
+            },
+      );
+    }
+  }
+
+  const resolutionFailures = findings.length;
+
+  // Only nodes pinning a mode of *this* collection: a node pinning a density
+  // or unit mode says nothing about whether the theme resolved, so counting it
+  // would raise the caveat on components that are perfectly verifiable.
+  //
+  // Reported alongside any real failures rather than instead of them: the
+  // caveat narrows what the *rest* of the row is worth, so dropping it when
+  // something else failed would overstate the remaining green.
+  const pinnedNodes = nodesPinning(snapshot, theme.collectionId);
+  for (const pinned of pinnedNodes) {
+    findings.push({
+      severity: "medium",
+      nodeId: pinned.id,
+      nodeName: pinned.name,
+      message: `Layer "${pinned.name}" pins its own explicit mode, so per-mode results for it are unverified.`,
+      expected:
+        "modes inherited from the page/frame, so every mode can be evaluated",
+      actual: "an explicit mode pinned on the layer",
+      suggestedFix:
+        "Clear the explicit mode unless it is deliberate; otherwise verify this layer by eye in each theme.",
+      count: 1,
+    });
+  }
+
+  const modeList = theme.modes.map((m) => m.name).join(", ");
+  const note = `Evaluated collection "${theme.collectionName}" across ${theme.modes.length} modes: ${modeList}. The theme collection is picked as the bound collection with the most modes; if that is the wrong collection here, these results describe the wrong axis.`;
+
+  findings.sort((a, b) => a.message.localeCompare(b.message));
+
+  const status: CheckStatus =
+    resolutionFailures > 0 ? "fail" : pinnedNodes.length > 0 ? "warn" : "pass";
+
+  return {
+    checkId: "themes",
+    title: TITLE,
+    status,
+    findings,
+    note,
+  };
+}

--- a/src/plugins/qa/checks/themes.ts
+++ b/src/plugins/qa/checks/themes.ts
@@ -44,10 +44,13 @@ const TITLE = "Themes (per-mode variable resolution)";
 export function checkThemes(snapshot: ComponentSetSnapshot): CheckResult {
   const theme = snapshot.theme;
 
-  // No probe table (no bound variables, or no collection with modes), or a
-  // single-mode collection - which is not a theme, and comparing one mode
-  // against itself would report nothing meaningful.
-  if (!theme || theme.modes.length < 2) {
+  const unavailable = theme?.unavailableVariableIds ?? [];
+
+  // No probe table (no bound variables), or a single-mode collection, which is
+  // not a theme: comparing one mode against itself reports nothing meaningful.
+  // Bindings Figma could not load are the exception, since those are broken
+  // regardless of how many modes exist.
+  if (!theme || (theme.modes.length < 2 && unavailable.length === 0)) {
     return {
       checkId: "themes",
       title: TITLE,
@@ -58,6 +61,25 @@ export function checkThemes(snapshot: ComponentSetSnapshot): CheckResult {
 
   const usage = collectVariableUsage(snapshot);
   const findings: Finding[] = [];
+
+  // Reported once per variable rather than once per mode: a binding that cannot
+  // be loaded at all is broken in every mode, so multiplying it out would add
+  // rows that differ only in a mode name and say nothing new. There is no name
+  // to quote, so the id stands in.
+  for (const variableId of unavailable) {
+    const consumer = usage.get(variableId);
+    findings.push({
+      severity: "high",
+      nodeId: consumer?.nodeId ?? snapshot.id,
+      nodeName: consumer?.nodeName ?? snapshot.name,
+      message: `Bound variable ${variableId} could not be loaded, so it resolves in no mode.`,
+      expected: "a variable that still exists and whose library is available",
+      actual: "the variable could not be loaded at all",
+      suggestedFix:
+        "Re-bind the layer to a live variable, or restore access to the library the deleted one came from.",
+      count: consumer?.count ?? 1,
+    });
+  }
 
   for (const [variableId, variable] of Object.entries(theme.variables)) {
     // A variable the probe resolved but this set never consumes (a style may
@@ -111,7 +133,9 @@ export function checkThemes(snapshot: ComponentSetSnapshot): CheckResult {
   // Reported alongside any real failures rather than instead of them: the
   // caveat narrows what the *rest* of the row is worth, so dropping it when
   // something else failed would overstate the remaining green.
-  const pinnedNodes = nodesPinning(snapshot, theme.collectionId);
+  const pinnedNodes = theme.collectionId
+    ? nodesPinning(snapshot, theme.collectionId)
+    : [];
   for (const pinned of pinnedNodes) {
     findings.push({
       severity: "medium",
@@ -128,7 +152,9 @@ export function checkThemes(snapshot: ComponentSetSnapshot): CheckResult {
   }
 
   const modeList = theme.modes.map((m) => m.name).join(", ");
-  const note = `Evaluated collection "${theme.collectionName}" across ${theme.modes.length} modes: ${modeList}. The theme collection is picked as the bound collection with the most modes; if that is the wrong collection here, these results describe the wrong axis.`;
+  const note = theme.collectionName
+    ? `Evaluated collection "${theme.collectionName}" across ${theme.modes.length} modes: ${modeList}. The theme collection is picked as the bound collection with the most modes; if that is the wrong collection here, these results describe the wrong axis.`
+    : "No theme collection could be determined: none of the variables this set binds could be loaded, so there were no modes to evaluate against.";
 
   findings.sort((a, b) => a.message.localeCompare(b.message));
 

--- a/src/plugins/qa/collector.ts
+++ b/src/plugins/qa/collector.ts
@@ -6,8 +6,10 @@
  * snapshot the pure check functions run against (issue #76).
  */
 
+import { toHex } from "./color";
 import type {
   ComponentPropertySnapshot,
+  PinnedAncestorSnapshot,
   ComponentSetSnapshot,
   ExposedInstanceSnapshot,
   NodeSnapshot,
@@ -30,15 +32,6 @@ function snapshotExposedInstance(
   };
 }
 
-function toHex(color: RGB): string {
-  const channel = (v: number) =>
-    Math.round(v * 255)
-      .toString(16)
-      .padStart(2, "0")
-      .toUpperCase();
-  return `#${channel(color.r)}${channel(color.g)}${channel(color.b)}`;
-}
-
 function snapshotPaints(
   paints: readonly Paint[] | typeof figma.mixed,
 ): PaintSnapshot[] | undefined {
@@ -56,6 +49,54 @@ function snapshotPaints(
 
 function styleId(value: string | typeof figma.mixed): string {
   return value === figma.mixed ? "MIXED" : value;
+}
+
+/**
+ * Unwrap one entry of a `boundVariables` record into the aliases it holds.
+ * The record mixes three shapes: `VariableAlias` for scalar fields such as
+ * `paddingLeft`, `VariableAlias[]` for `fills` / `strokes` / `effects` /
+ * text-range fields, and `{ [propertyName]: VariableAlias }` for
+ * `componentProperties`.
+ */
+function variableAliases(binding: unknown): VariableAlias[] {
+  if (!binding || typeof binding !== "object") return [];
+  if (Array.isArray(binding)) return binding as VariableAlias[];
+  if (typeof (binding as VariableAlias).id === "string") {
+    return [binding as VariableAlias];
+  }
+  // componentProperties: keyed by property name, one alias each.
+  return Object.values(binding as Record<string, VariableAlias>).filter(
+    (alias): alias is VariableAlias => typeof alias?.id === "string",
+  );
+}
+
+/**
+ * The subject plus every ancestor that pins explicit variable modes (#17).
+ * A pin on the component set, or on a frame or page containing it, sets the
+ * mode context for every descendant, so the probe (which resolves against a
+ * frame with only its own pin) cannot speak for those nodes. Walking the
+ * ancestry is the only way to see it: the snapshot's node trees start at the
+ * variants, below any of this.
+ */
+function collectPinnedAncestors(
+  subject: ComponentSetNode | ComponentNode,
+): PinnedAncestorSnapshot[] {
+  const pinned: PinnedAncestorSnapshot[] = [];
+  let current: BaseNode | null = subject;
+  while (current) {
+    if ("explicitVariableModes" in current) {
+      const modes = current.explicitVariableModes;
+      if (Object.keys(modes).length > 0) {
+        pinned.push({
+          id: current.id,
+          name: current.name,
+          explicitVariableModes: { ...modes },
+        });
+      }
+    }
+    current = current.parent;
+  }
+  return pinned;
 }
 
 function snapshotNode(node: SceneNode): NodeSnapshot {
@@ -134,11 +175,29 @@ function snapshotNode(node: SceneNode): NodeSnapshot {
   }
 
   if ("boundVariables" in node && node.boundVariables) {
-    const keys = Object.keys(node.boundVariables).filter(
-      (key) =>
-        (node.boundVariables as Record<string, unknown>)[key] !== undefined,
-    );
+    const bound = node.boundVariables as Record<string, unknown>;
+    const keys = Object.keys(bound).filter((key) => bound[key] !== undefined);
     if (keys.length > 0) snap.boundVariableKeys = keys;
+
+    // Ids, not just field names (#17 counts usages per variable). Three shapes
+    // live in this one record: a single alias for scalar fields, an array for
+    // paint, effect and text-range fields, and a property-name-keyed object for
+    // componentProperties.
+    // Reading `.id` off that last shape yields nothing, so each is unwrapped
+    // explicitly.
+    const ids = new Set<string>();
+    for (const key of keys) {
+      for (const alias of variableAliases(bound[key])) ids.add(alias.id);
+    }
+    if (ids.size > 0) snap.boundVariableIds = [...ids];
+  }
+
+  if ("explicitVariableModes" in node) {
+    const modes = node.explicitVariableModes;
+    // Only recorded when non-empty: a node pinning its own mode is what makes
+    // the #17 probe's per-mode answer unverifiable for it.
+    if (Object.keys(modes).length > 0)
+      snap.explicitVariableModes = { ...modes };
   }
 
   if ("reactions" in node && node.reactions.length > 0) {
@@ -167,13 +226,21 @@ function snapshotProperties(
     // simply return {}.
     return [];
   }
-  return Object.entries(definitions).map(([rawName, def]) => ({
-    name: propertyDisplayName(rawName),
-    type: def.type,
-    ...(def.type === "INSTANCE_SWAP"
-      ? { preferredValuesCount: def.preferredValues?.length ?? 0 }
-      : {}),
-  }));
+  return Object.entries(definitions).map(([rawName, def]) => {
+    // A component property can itself be bound to a variable, and that
+    // binding lives here rather than on any layer (#17).
+    const ids = Object.values(def.boundVariables ?? {})
+      .filter((alias): alias is VariableAlias => typeof alias?.id === "string")
+      .map((alias) => alias.id);
+    return {
+      name: propertyDisplayName(rawName),
+      type: def.type,
+      ...(def.type === "INSTANCE_SWAP"
+        ? { preferredValuesCount: def.preferredValues?.length ?? 0 }
+        : {}),
+      ...(ids.length > 0 ? { boundVariableIds: [...new Set(ids)] } : {}),
+    };
+  });
 }
 
 /**
@@ -200,6 +267,8 @@ export function collectSnapshot(
 
   const properties = snapshotProperties(subject);
 
+  const pinnedAncestors = collectPinnedAncestors(subject);
+
   return {
     id: subject.id,
     name: subject.name,
@@ -208,5 +277,6 @@ export function collectSnapshot(
     propertyNames: properties.map((p) => p.name),
     properties,
     variants,
+    ...(pinnedAncestors.length > 0 ? { pinnedAncestors } : {}),
   };
 }

--- a/src/plugins/qa/collector.ts
+++ b/src/plugins/qa/collector.ts
@@ -1,9 +1,13 @@
 /// <reference types="@figma/plugin-typings" />
 
 /**
- * Snapshot collector — the ONLY part of the QA engine that touches `figma.*`.
- * Walks a resolved component set once and produces the plain serializable
- * snapshot the pure check functions run against (issue #76).
+ * Snapshot collector: walks a resolved component set once and produces the
+ * plain serializable snapshot the pure check functions run against (issue #76).
+ *
+ * One of exactly two places in the QA engine that touch `figma.*`. The other is
+ * `theme-probe.ts`, which resolves variables per theme mode against a temporary
+ * frame (#17, the ADR-0001 read-only carve-out). Everything under `checks/`
+ * stays pure and fixture-tested.
  */
 
 import { toHex } from "./color";

--- a/src/plugins/qa/color.ts
+++ b/src/plugins/qa/color.ts
@@ -1,0 +1,15 @@
+/**
+ * Colour conversion shared by the QA engine's two figma-touching pieces (the
+ * collector and the #17 resolution probe), so there is one definition of what
+ * a hex string looks like in a snapshot.
+ */
+
+/** Figma's 0–1 RGB channels as an uppercase `#RRGGBB` string (alpha dropped). */
+export function toHex(color: RGB | RGBA): string {
+  const channel = (v: number) =>
+    Math.round(v * 255)
+      .toString(16)
+      .padStart(2, "0")
+      .toUpperCase();
+  return `#${channel(color.r)}${channel(color.g)}${channel(color.b)}`;
+}

--- a/src/plugins/qa/color.ts
+++ b/src/plugins/qa/color.ts
@@ -4,7 +4,7 @@
  * a hex string looks like in a snapshot.
  */
 
-/** Figma's 0–1 RGB channels as an uppercase `#RRGGBB` string (alpha dropped). */
+/** Figma's 0-1 RGB channels as an uppercase `#RRGGBB` string (alpha dropped). */
 export function toHex(color: RGB | RGBA): string {
   const channel = (v: number) =>
     Math.round(v * 255)

--- a/src/plugins/qa/operations.ts
+++ b/src/plugins/qa/operations.ts
@@ -3,14 +3,16 @@
 // src/shared/operations/register-all.ts.
 //
 // Single agent-facing surface: `tidy_qa_run`. Returns structured CheckResults
-// plus a 19-item ChecklistReport (PRD catalogue merge). All checks are static:
-// nothing in this module mutates the file.
+// plus a 19-item ChecklistReport (PRD catalogue merge). The checks never touch
+// the component set; the one document write in a run is the #17 themes probe's
+// temporary frame (see theme-probe.ts and the ADR-0001 carve-out).
 
 import { ErrorCode, OperationError } from "../../shared/operations/errors";
 import { registerOperation } from "../../shared/operations/registry";
 import { collectSnapshot } from "./collector";
 import { runChecks, unknownCheckIds } from "./checks";
 import { buildChecklistReport } from "./report";
+import { probeThemeResolution } from "./theme-probe";
 import { renderChecklist } from "./render/renderChecklist";
 import type { CheckId, QaRunResult } from "./types";
 
@@ -149,11 +151,19 @@ async function resolveTarget(params: QaRunParams): Promise<ResolvedTarget> {
   };
 }
 
+/** Whether `id` is in the requested set (an absent filter means everything). */
+function willRun(requested: string[] | undefined, id: CheckId): boolean {
+  return requested === undefined || requested.includes(id);
+}
+
 /**
  * Shared pipeline for both QA operations: validate the check filter, resolve the
  * target up to its set, snapshot it, run the checks, and build the full
  * QaRunResult (results + 19-item checklist). Returns the resolved subject and
  * origin node too, so the canvas op can place its frame next to the instance.
+ *
+ * Both operations share this, deliberately: probing only in the execute op
+ * would leave the two QA surfaces silently disagreeing about what was checked.
  */
 async function runQa(params: QaRunParams): Promise<{
   subject: QaSubject;
@@ -174,6 +184,15 @@ async function runQa(params: QaRunParams): Promise<{
 
   const { subject, origin } = await resolveTarget(params);
   const snapshot = collectSnapshot(subject);
+
+  // The #17 per-mode resolution probe is the one part of a QA run that touches
+  // the document (one temporary frame, removed in a `finally` - see
+  // theme-probe.ts and the ADR-0001 carve-out). Skipped entirely unless the
+  // themes check is actually going to run, so a filtered run stays inert.
+  if (willRun(params.checks, "themes")) {
+    snapshot.theme = await probeThemeResolution(snapshot);
+  }
+
   const outcome = runChecks(snapshot, params.checks as CheckId[] | undefined);
   const target = { id: subject.id, name: subject.name };
   // Record the instance the run started from, if any (for canvas placement).
@@ -200,7 +219,7 @@ registerOperation<QaRunParams, QaRunResult>(
     kind: "query",
     module: "qa",
     summary:
-      "Run the DS Component QA checklist (static Tier 1 checks) against a component set. Target by nodeId or name/glob, or omit both to use the current selection. Returns CheckResults plus a 19-item checklist model. Static — never mutates the file.",
+      "Run the DS Component QA checklist against a component set. Target by nodeId or name/glob, or omit both to use the current selection. Returns CheckResults plus a 19-item checklist model. Read-only toward the target: it never modifies the component set. The themes check (#17) creates and removes one temporary off-canvas probe frame to resolve variables per theme mode - a documented carve-out from ADR-0001's read-only Query definition.",
     paramsExample: { name: "Button" },
   },
   async (params) => {

--- a/src/plugins/qa/snapshot.ts
+++ b/src/plugins/qa/snapshot.ts
@@ -199,7 +199,7 @@ export interface ModeResolutionSnapshot {
   type?: string;
   /** COLOR variables only: the resolved colour, for #16 to build contrast on. */
   hex?: string;
-  /** COLOR variables only: resolved alpha, 0–1. */
+  /** COLOR variables only: resolved alpha, 0-1. */
   alpha?: number;
 }
 
@@ -224,12 +224,26 @@ export interface VariableResolutionSnapshot {
  * a theme.
  */
 export interface ThemeSnapshot {
-  /** Which collection was treated as "the theme" (most modes - see shared/theme-collection). */
-  collectionId: string;
-  collectionName: string;
+  /**
+   * Which collection was treated as "the theme" (most modes, see
+   * shared/theme-collection).
+   * Absent when no bound collection could be determined at all, which happens
+   * when every variable the set binds fails to load.
+   */
+  collectionId?: string;
+  collectionName?: string;
   modes: ThemeModeSnapshot[];
-  /** Variable id → per-mode resolution. */
+  /** Variable id to per-mode resolution. */
   variables: Record<string, VariableResolutionSnapshot>;
+  /**
+   * Ids the set binds that Figma could not load at all (#17).
+   * `getVariableByIdAsync` returning null is itself the "broken remote
+   * variable" case the check has to fail on, so these are kept rather than
+   * dropped: discarding them let a set with one dead binding report `pass` on
+   * the strength of its remaining healthy variables.
+   * There is no name to report, so the check falls back to the id.
+   */
+  unavailableVariableIds?: string[];
 }
 
 export interface ComponentSetSnapshot {

--- a/src/plugins/qa/snapshot.ts
+++ b/src/plugins/qa/snapshot.ts
@@ -121,6 +121,19 @@ export interface NodeSnapshot {
 
   /** Fields on this node bound to variables, e.g. ["paddingLeft", "itemSpacing"]. */
   boundVariableKeys?: string[];
+  /**
+   * Ids of the variables bound on this node's fields, deduped (#17). Kept
+   * separate from `boundVariableKeys`, which records only *which* fields are
+   * bound: counting how many usages a variable has needs the ids.
+   */
+  boundVariableIds?: string[];
+  /**
+   * Explicit variable modes pinned on this node itself, collection id → mode
+   * id (#17). Present only when non-empty. A node that pins its own mode
+   * renders in that mode whatever its ancestors say, which is what makes the
+   * probe's answer unverifiable for it.
+   */
+  explicitVariableModes?: Record<string, string>;
 
   /** Prototype trigger types on this node, e.g. ["ON_HOVER"] (#11). */
   reactionTriggers?: string[];
@@ -133,6 +146,26 @@ export interface ComponentPropertySnapshot {
   type: string;
   /** INSTANCE_SWAP properties only (#15). */
   preferredValuesCount?: number;
+  /**
+   * Variables bound to the property itself (#17).
+   * These bindings live on the component property definition, not on any
+   * layer, so a set whose only variable use is a bound property would
+   * otherwise look like it uses no variables at all.
+   */
+  boundVariableIds?: string[];
+}
+
+/**
+ * An ancestor (or the subject itself) pinning explicit variable modes (#17).
+ * A pin here sets the mode context for everything below it, including every
+ * variant, so the probe cannot speak for the set's real rendering.
+ * The snapshot's node trees begin at the variants, which is below any of this,
+ * so the ancestry has to be captured separately.
+ */
+export interface PinnedAncestorSnapshot {
+  id: string;
+  name: string;
+  explicitVariableModes: Record<string, string>;
 }
 
 export interface VariantSnapshot {
@@ -141,6 +174,62 @@ export interface VariantSnapshot {
   /** e.g. { Size: "Medium", State: "Default" } — empty for standalone components (#13). */
   variantProperties: Record<string, string>;
   tree: NodeSnapshot;
+}
+
+/** One mode of the evaluated theme collection (#17). */
+export interface ThemeModeSnapshot {
+  modeId: string;
+  name: string;
+}
+
+/**
+ * How one variable resolved in one mode of the theme collection, as observed
+ * through the resolution probe (#17).
+ *
+ * `ok: false` is split by reason because the two are different defects with
+ * different fixes: `no-value` means the variable itself has no entry for that
+ * mode (a missing override, typically on an extended collection), while
+ * `unresolved-alias` means Figma could not follow the alias chain to a concrete
+ * value (dangling target, or a broken remote variable).
+ */
+export interface ModeResolutionSnapshot {
+  ok: boolean;
+  reason?: "no-value" | "unresolved-alias";
+  /** Resolved type Figma reported, e.g. "COLOR" | "FLOAT" (present when ok). */
+  type?: string;
+  /** COLOR variables only: the resolved colour, for #16 to build contrast on. */
+  hex?: string;
+  /** COLOR variables only: resolved alpha, 0–1. */
+  alpha?: number;
+}
+
+/** A variable used by the set, resolved once per theme mode (#17). */
+export interface VariableResolutionSnapshot {
+  name: string;
+  /** Collection the variable itself belongs to - not necessarily the theme. */
+  collectionId: string;
+  /** Keyed by mode id of the theme collection. */
+  byMode: Record<string, ModeResolutionSnapshot>;
+}
+
+/**
+ * Per-mode resolution table for the theme collection (#17), produced by the
+ * resolution probe: one temporary frame, explicit modes set on it, each
+ * variable resolved against it once per mode, frame removed in a `finally`.
+ * Figma does the resolving, so these values are faithful by construction
+ * rather than a reimplementation of mode inheritance.
+ *
+ * Absent when the set binds no variables, or when no bound collection has
+ * modes to evaluate - the check reports `not_applicable` rather than inventing
+ * a theme.
+ */
+export interface ThemeSnapshot {
+  /** Which collection was treated as "the theme" (most modes - see shared/theme-collection). */
+  collectionId: string;
+  collectionName: string;
+  modes: ThemeModeSnapshot[];
+  /** Variable id → per-mode resolution. */
+  variables: Record<string, VariableResolutionSnapshot>;
 }
 
 export interface ComponentSetSnapshot {
@@ -153,4 +242,11 @@ export interface ComponentSetSnapshot {
   propertyNames: string[];
   properties: ComponentPropertySnapshot[];
   variants: VariantSnapshot[];
+  /**
+   * The subject and any ancestor pinning explicit variable modes (#17).
+   * Absent when nothing in the ancestry pins a mode.
+   */
+  pinnedAncestors?: PinnedAncestorSnapshot[];
+  /** Per-mode variable resolution (#17). Absent when the probe didn't run. */
+  theme?: ThemeSnapshot;
 }

--- a/src/plugins/qa/theme-probe.ts
+++ b/src/plugins/qa/theme-probe.ts
@@ -69,12 +69,26 @@ export async function probeThemeResolution(
 
   // Memoized by id, so cost scales with unique ids rather than node count.
   const variables = new Map<string, Variable>();
+  const unavailable: string[] = [];
   for (const id of variableIds) {
     if (variables.has(id)) continue;
     const variable = await figma.variables.getVariableByIdAsync(id);
-    if (variable) variables.set(id, variable);
+    if (variable) {
+      variables.set(id, variable);
+    } else {
+      // A binding Figma cannot load: a deleted variable, or a remote one whose
+      // library is unavailable. That is precisely the broken-chain case #17
+      // exists to catch, so the id is kept for the check to fail on.
+      unavailable.push(id);
+    }
   }
-  if (variables.size === 0) return undefined;
+  if (variables.size === 0) {
+    // Nothing resolvable means no bound collection to call "the theme", so the
+    // modes are unknown. The dead bindings are still reported.
+    return unavailable.length > 0
+      ? { modes: [], variables: {}, unavailableVariableIds: unavailable }
+      : undefined;
+  }
 
   const collections = new Map<string, VariableCollection>();
   for (const variable of variables.values()) {
@@ -139,6 +153,7 @@ export async function probeThemeResolution(
     collectionName: primary.name,
     modes: primary.modes.map((m) => ({ modeId: m.modeId, name: m.name })),
     variables: resolved,
+    ...(unavailable.length > 0 ? { unavailableVariableIds: unavailable } : {}),
   };
 }
 

--- a/src/plugins/qa/theme-probe.ts
+++ b/src/plugins/qa/theme-probe.ts
@@ -1,0 +1,182 @@
+/// <reference types="@figma/plugin-typings" />
+
+/**
+ * Per-mode variable resolution for #17 (issue #102) - the second and only other
+ * figma-touching piece of the QA engine besides the collector.
+ *
+ * **Why a probe at all.** Getting a variable's value *per mode* is awkward:
+ * `valuesByMode` does not resolve aliases, and `resolveForConsumer` resolves
+ * fully but only in the consumer's *current* mode context. Per-mode truth
+ * therefore needs either a reimplementation of Figma's resolution - mode
+ * inheritance, extended collections, workspace/team default modes that are
+ * explicitly absent from a node's explicit modes - or something to resolve
+ * against. Reimplementing was rejected: a wrong walk yields silently wrong
+ * numbers, and #16's contrast maths would inherit them.
+ *
+ * **What it does instead.** Create one empty temporary frame, pin an explicit
+ * mode on it, resolve each variable the set uses against it, repeat per mode,
+ * and remove the frame in a `finally`. Figma performs the resolution, so the
+ * table is faithful by construction, and cost scales with *variables used*
+ * (dozens) rather than variants × modes × nodes (thousands). Tier 2 needs no
+ * scratch-clone page; that stays a Tier 3 concern for checks that must mutate
+ * to observe.
+ *
+ * **Read-only carve-out.** `tidy_qa_run` is a Query operation, which ADR-0001
+ * defines as read-only. This creates and removes a node, so it is a documented
+ * exception (see docs/adr/0001) rather than an accident. The alternative -
+ * probing only in the execute operation - would leave the two QA surfaces
+ * silently disagreeing about what was checked, which is worse. The component
+ * set itself is never touched.
+ */
+
+import { toHex } from "./color";
+import { collectVariableUsage } from "./variable-usage";
+import { selectPrimaryCollection } from "../../shared/theme-collection";
+import type { ModeCollectionFact } from "../../shared/theme-collection";
+import type {
+  ComponentSetSnapshot,
+  ModeResolutionSnapshot,
+  ThemeSnapshot,
+  VariableResolutionSnapshot,
+} from "./snapshot";
+
+const PROBE_NAME = "__tidy-qa-mode-probe";
+
+function isAlias(value: VariableValue): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    (value as VariableAlias).type === "VARIABLE_ALIAS"
+  );
+}
+
+/**
+ * Resolve every variable the set uses, once per mode of the theme collection.
+ *
+ * Returns `undefined` when there is nothing to evaluate - no bound variables,
+ * or no bound collection with modes - so the check can report
+ * `not_applicable` rather than inventing a theme. In that case no probe node is
+ * created at all.
+ */
+export async function probeThemeResolution(
+  snapshot: ComponentSetSnapshot,
+): Promise<ThemeSnapshot | undefined> {
+  // Same traversal the check uses, so the two cannot disagree about which
+  // variables the set consumes.
+  const variableIds = [...collectVariableUsage(snapshot).keys()];
+  if (variableIds.length === 0) return undefined;
+
+  // Memoized by id, so cost scales with unique ids rather than node count.
+  const variables = new Map<string, Variable>();
+  for (const id of variableIds) {
+    if (variables.has(id)) continue;
+    const variable = await figma.variables.getVariableByIdAsync(id);
+    if (variable) variables.set(id, variable);
+  }
+  if (variables.size === 0) return undefined;
+
+  const collections = new Map<string, VariableCollection>();
+  for (const variable of variables.values()) {
+    const collectionId = variable.variableCollectionId;
+    if (collections.has(collectionId)) continue;
+    const collection =
+      await figma.variables.getVariableCollectionByIdAsync(collectionId);
+    if (collection) collections.set(collectionId, collection);
+  }
+
+  const facts: ModeCollectionFact[] = [...collections.values()].map((c) => ({
+    id: c.id,
+    name: c.name,
+    defaultModeId: c.defaultModeId,
+    modes: c.modes.map((m) => ({ modeId: m.modeId, name: m.name })),
+  }));
+  // Same helper the generated documentation pages use, so QA and the docs
+  // cannot disagree about what "the theme" is.
+  const primary = selectPrimaryCollection(facts);
+  if (!primary) return undefined;
+
+  const themeCollection = collections.get(primary.id);
+  if (!themeCollection) return undefined;
+
+  const resolved: Record<string, VariableResolutionSnapshot> = {};
+  for (const [id, variable] of variables) {
+    resolved[id] = {
+      name: variable.name,
+      collectionId: variable.variableCollectionId,
+      byMode: {},
+    };
+  }
+
+  const probe = figma.createFrame();
+  try {
+    probe.name = PROBE_NAME;
+    probe.resize(1, 1);
+    probe.fills = [];
+    probe.visible = false;
+    figma.currentPage.appendChild(probe);
+
+    for (const mode of primary.modes) {
+      probe.setExplicitVariableModeForCollection(themeCollection, mode.modeId);
+
+      for (const [id, variable] of variables) {
+        resolved[id].byMode[mode.modeId] = resolveOne(
+          variable,
+          mode.modeId,
+          primary.id,
+          probe,
+        );
+      }
+    }
+  } finally {
+    // Removed on the error path too - a probe left behind would be a stray
+    // node in the user's file, and worse, one carrying pinned modes.
+    probe.remove();
+  }
+
+  return {
+    collectionId: primary.id,
+    collectionName: primary.name,
+    modes: primary.modes.map((m) => ({ modeId: m.modeId, name: m.name })),
+    variables: resolved,
+  };
+}
+
+/**
+ * One variable in one mode. A variable belonging to the theme collection with
+ * no entry of its own for the mode is a *missing override* - reported as
+ * `no-value` even if Figma still resolves it by falling back, because the
+ * un-themed token is the defect. Anything else is judged purely on what the
+ * probe observes.
+ */
+function resolveOne(
+  variable: Variable,
+  modeId: string,
+  themeCollectionId: string,
+  probe: SceneNode,
+): ModeResolutionSnapshot {
+  if (
+    variable.variableCollectionId === themeCollectionId &&
+    variable.valuesByMode[modeId] === undefined
+  ) {
+    return { ok: false, reason: "no-value" };
+  }
+
+  try {
+    const { value, resolvedType } = variable.resolveForConsumer(probe);
+    if (value === undefined || value === null || isAlias(value)) {
+      return { ok: false, reason: "unresolved-alias" };
+    }
+    const snapshot: ModeResolutionSnapshot = { ok: true, type: resolvedType };
+    if (resolvedType === "COLOR" && typeof value === "object") {
+      const color = value as RGBA;
+      snapshot.hex = toHex(color);
+      snapshot.alpha = color.a ?? 1;
+    }
+    return snapshot;
+  } catch {
+    // resolveForConsumer throws on a chain it cannot follow - a dangling
+    // target, or a remote variable whose library is unavailable.
+    return { ok: false, reason: "unresolved-alias" };
+  }
+}

--- a/src/plugins/qa/types.ts
+++ b/src/plugins/qa/types.ts
@@ -23,7 +23,8 @@ export type CheckId =
   | "no-conflicts"
   | "preferred-values"
   | "nesting-depth"
-  | "asset-provenance";
+  | "asset-provenance"
+  | "themes";
 
 export interface Finding {
   severity: SeverityLevel;
@@ -100,6 +101,11 @@ export const CHECKS: readonly CheckDefinition[] = [
     id: "asset-provenance",
     prdSection: 8,
     title: "Icons / illustrations / logos from Foundations",
+  },
+  {
+    id: "themes",
+    prdSection: 17,
+    title: "Themes (per-mode variable resolution)",
   },
 ];
 

--- a/src/plugins/qa/variable-usage.test.ts
+++ b/src/plugins/qa/variable-usage.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { collectVariableUsage, nodesPinning } from "./variable-usage";
+import type { ComponentSetSnapshot, NodeSnapshot } from "./snapshot";
+
+let seq = 0;
+
+function node(overrides: Partial<NodeSnapshot> = {}): NodeSnapshot {
+  seq += 1;
+  return {
+    id: `1:${seq}`,
+    name: "layer",
+    type: "FRAME",
+    visible: true,
+    width: 24,
+    height: 24,
+    children: [],
+    ...overrides,
+  };
+}
+
+function fixture(
+  trees: NodeSnapshot[][],
+  extra: Partial<ComponentSetSnapshot> = {},
+): ComponentSetSnapshot {
+  return {
+    id: "1:0",
+    name: "Button",
+    type: "COMPONENT_SET",
+    description: "",
+    propertyNames: [],
+    properties: [],
+    variants: trees.map((kids, i) => ({
+      id: `v:${i}`,
+      name: `Button-${i}`,
+      variantProperties: {},
+      tree: node({ id: `v:${i}`, type: "COMPONENT", children: kids }),
+    })),
+    ...extra,
+  };
+}
+
+describe("collectVariableUsage", () => {
+  it("counts a paint-bound variable once, not once per representation", () => {
+    // Figma records a paint binding twice: on the paint itself, and in the
+    // node's own `boundVariables.fills`.
+    // Counting both doubled every paint-bound variable.
+    const layer = node({
+      name: "bg",
+      fills: [
+        {
+          type: "SOLID",
+          visible: true,
+          opacity: 1,
+          hex: "#123456",
+          boundVariableId: "v-bg",
+        },
+      ],
+      boundVariableIds: ["v-bg"],
+    });
+
+    const usage = collectVariableUsage(fixture([[layer]]));
+
+    expect(usage.get("v-bg")?.count).toBe(1);
+    expect(usage.get("v-bg")?.nodeName).toBe("bg");
+  });
+
+  it("counts one usage per consuming layer", () => {
+    const usage = collectVariableUsage(
+      fixture([
+        [node({ name: "a", boundVariableIds: ["v-gap"] })],
+        [node({ name: "b", boundVariableIds: ["v-gap"] })],
+      ]),
+    );
+    expect(usage.get("v-gap")?.count).toBe(2);
+  });
+
+  it("counts variables bound to component properties, attributed to the set", () => {
+    // These bindings live on the property definition, not on any layer, so a
+    // set whose only variable use is a bound property would otherwise look
+    // like it uses no variables at all.
+    const usage = collectVariableUsage(
+      fixture([[node()]], {
+        properties: [
+          { name: "Label", type: "TEXT", boundVariableIds: ["v-label"] },
+        ],
+      }),
+    );
+    expect(usage.get("v-label")?.count).toBe(1);
+    expect(usage.get("v-label")?.nodeId).toBe("1:0");
+    expect(usage.get("v-label")?.nodeName).toBe("Button");
+  });
+});
+
+describe("nodesPinning", () => {
+  it("finds a pin on a layer", () => {
+    const pinned = nodesPinning(
+      fixture([
+        [
+          node({
+            id: "1:9",
+            name: "pinned",
+            explicitVariableModes: { "c-theme": "m-core" },
+          }),
+        ],
+      ]),
+      "c-theme",
+    );
+    expect(pinned).toEqual([{ id: "1:9", name: "pinned" }]);
+  });
+
+  it("finds a pin on the set or an enclosing frame", () => {
+    // The snapshot's node trees start at the variants, below the set itself, so
+    // an ancestor pin is invisible to a tree walk.
+    // It still sets the mode context for every variant.
+    const pinned = nodesPinning(
+      fixture([[node()]], {
+        pinnedAncestors: [
+          {
+            id: "0:5",
+            name: "QA page",
+            explicitVariableModes: { "c-theme": "m-dna" },
+          },
+        ],
+      }),
+      "c-theme",
+    );
+    expect(pinned).toEqual([{ id: "0:5", name: "QA page" }]);
+  });
+
+  it("ignores an ancestor pinning some other collection", () => {
+    const pinned = nodesPinning(
+      fixture([[node()]], {
+        pinnedAncestors: [
+          {
+            id: "0:5",
+            name: "QA page",
+            explicitVariableModes: { "c-density": "m-compact" },
+          },
+        ],
+      }),
+      "c-theme",
+    );
+    expect(pinned).toEqual([]);
+  });
+});

--- a/src/plugins/qa/variable-usage.ts
+++ b/src/plugins/qa/variable-usage.ts
@@ -1,0 +1,94 @@
+/**
+ * Which variables a snapshot consumes, and where - the one traversal shared by
+ * the #17 probe (which needs the id set to resolve) and the #17 check (which
+ * needs usage counts and a representative node per variable). Pure, so it lives
+ * outside the collector and is testable from fixtures.
+ */
+
+import type { ComponentSetSnapshot, NodeSnapshot } from "./snapshot";
+
+export interface VariableUsage {
+  /**
+   * How many consuming sites reference this variable: layers that bind it,
+   * plus component properties bound to it.
+   * Counted once per site rather than once per binding, because a paint alias
+   * appears twice in the snapshot (on the paint and in the node's
+   * `boundVariables.fills`), and one layer using one variable is one thing to
+   * fix either way.
+   */
+  count: number;
+  /** First binding site - the representative node for "jump to offender". */
+  nodeId: string;
+  nodeName: string;
+}
+
+/** Variable id → usage, in first-seen order. */
+export function collectVariableUsage(
+  snapshot: ComponentSetSnapshot,
+): Map<string, VariableUsage> {
+  const usage = new Map<string, VariableUsage>();
+
+  const bump = (id: string, site: { id: string; name: string }) => {
+    const existing = usage.get(id);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      usage.set(id, { count: 1, nodeId: site.id, nodeName: site.name });
+    }
+  };
+
+  function visit(node: NodeSnapshot): void {
+    // Deduped per layer first: a paint-bound variable is recorded both on the
+    // paint and in the node's own `boundVariables.fills`, so counting each
+    // occurrence would double every paint binding.
+    const here = new Set<string>();
+    for (const paint of [...(node.fills ?? []), ...(node.strokes ?? [])]) {
+      if (paint.boundVariableId) here.add(paint.boundVariableId);
+    }
+    for (const id of node.boundVariableIds ?? []) here.add(id);
+    for (const id of here) bump(id, node);
+    for (const child of node.children) visit(child);
+  }
+
+  for (const variant of snapshot.variants) visit(variant.tree);
+
+  // Component properties bind variables too, and those bindings belong to the
+  // set rather than to any layer, so the set is their representative site.
+  for (const property of snapshot.properties) {
+    for (const id of property.boundVariableIds ?? []) {
+      bump(id, { id: snapshot.id, name: snapshot.name });
+    }
+  }
+
+  return usage;
+}
+
+/**
+ * Nodes pinning an explicit mode **for `collectionId`**. Only that collection
+ * matters: a node pinning a density or unit mode says nothing about whether the
+ * theme resolved correctly, so counting it would raise the #17 caveat on
+ * components whose theme results are perfectly verifiable.
+ */
+export function nodesPinning(
+  snapshot: ComponentSetSnapshot,
+  collectionId: string,
+): { id: string; name: string }[] {
+  const pinned: { id: string; name: string }[] = [];
+
+  function visit(node: NodeSnapshot): void {
+    if (node.explicitVariableModes?.[collectionId] !== undefined) {
+      pinned.push({ id: node.id, name: node.name });
+    }
+    for (const child of node.children) visit(child);
+  }
+
+  // The ancestry first: a pin on the set, or on a frame or page containing it,
+  // sets the mode context for every variant below it.
+  for (const ancestor of snapshot.pinnedAncestors ?? []) {
+    if (ancestor.explicitVariableModes[collectionId] !== undefined) {
+      pinned.push({ id: ancestor.id, name: ancestor.name });
+    }
+  }
+  for (const variant of snapshot.variants) visit(variant.tree);
+  return pinned;
+}


### PR DESCRIPTION
## Summary

Closes #102. Checklist item **17 "Themes (Core / DNA / OldNews)"** becomes the
`themes` check, together with the per-mode resolution machinery #16 will build on.

### The probe

Getting a variable's value *per mode* is constrained: `valuesByMode` doesn't resolve
aliases, and `resolveForConsumer` resolves fully but only in the consumer's **current**
mode context. Per-mode truth therefore needs either a reimplementation of Figma's
resolution — mode inheritance, extended collections, workspace/team-default modes that
are explicitly absent from a node's explicit modes — or something to resolve against.

Reimplementing was rejected: a wrong walk yields silently wrong numbers, and #16's
contrast maths would inherit them. So: **one temporary off-canvas frame**, explicit
mode pinned on it, each used variable resolved against it, repeated per mode, frame
removed in a `finally`. Figma performs the resolution, so the table is faithful by
construction, and cost scales with *variables used* (dozens) rather than
variants × modes × nodes. **Tier 2 needs no scratch-clone page** — that stays a Tier 3
concern.

### Read-only carve-out

`tidy_qa_run` is `kind: "query"`, which ADR-0001 defines as read-only. The carve-out is
recorded in the ADR with the three conditions it must meet (created and removed within
one call including the error path; never a descendant of or a modification to the
target; stated in the MCP summary), and the summary now reads "read-only toward the
target". It rides in the pipeline **both** QA operations share — probing in only one
would leave the two surfaces silently disagreeing about what was checked — and is
skipped entirely unless `themes` is in the requested checks, so a filtered run performs
no document write at all.

### What it checks

Resolution integrity only — two `fail` classes:

- a bound variable has **no value for some theme mode** (missing override on an
  extended collection)
- an **alias chain is unresolvable** in some mode (dangling target, broken remote)

Invisible text is contrast 1.0 and belongs to #16; reporting it here too would describe
one defect in two rows. Raw unbound values stay with `tokens`. Flagging single-mode
collections as "not theme-aware" remains out of scope.

The theme collection is **not configured by name** — it's the shared
`selectPrimaryCollection` helper (most modes) that the generated doc pages use, and the
result **states which collection and modes it evaluated**, so a wrong pick shows on the
row instead of producing silent green. Findings are one per **variable × mode** with an
occurrence count and a representative consuming layer.

## Review fixes (applied before commit)

A two-axis review of the working tree surfaced four things, all fixed:

- Findings pointed at the component set rather than a representative consuming layer,
  breaking the "jump to offender" convention #99/#101 established.
- The `warn` fired on **any** explicit mode pin, so a density or rem/px pin raised the
  caveat on components whose theme results were perfectly verifiable. It now only
  counts pins for the evaluated collection.
- `toHex` was duplicated between the collector and the probe → extracted to `qa/color.ts`.
- The tree walk was duplicated between probe and check → extracted to
  `qa/variable-usage.ts`, which also removed a pass-through of snapshot-derived data
  through the probe.

`CLAUDE.md` claimed the collector is the *only* figma-touching part of the QA engine;
that's now two files, and the doc says so.

## Test plan

- [x] `npm run typecheck`, `npm run lint` (0 errors), `npm run test` — 413 passing
- [x] 13 fixture tests for the pure check, no Figma API
- [x] **Verified live in Figma**: `banner-outlined` → `pass`, note reads
      `Evaluated collection "theme" across 2 modes: Light, Dark`; 64-variant `Button`
      completes well inside the 60s timeout on **both** QA operations

## Known limitation

Variables bound *inside nested instances* are invisible to this check, because the
snapshot deliberately stops at instance boundaries. A composite built entirely of
nested instances (`Dropdown` in our test file) therefore reports `not_applicable`
rather than green — honest, but worth knowing before reading a `not_applicable` as
"nothing to fix".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
