### PR TITLE
feat(mcp): automate QA item 16 with per-mode WCAG AA contrast

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Layout:
 - `src/shared/operations/ui-bridge.ts`, `ui-bridge-startup.ts` — UI-iframe WebSocket to `ws://localhost:9876`; relays envelopes to the main thread via the existing `postMessage` channel.
 - `src/plugins/<module>/operations.ts` — per-module `registerOperation(...)` calls. Each id is snake_case and `tidy_`-prefixed (e.g. `tidy_misprint_find_components`).
 
-The QA engine keeps its figma-touching code in exactly two files: `src/plugins/qa/collector.ts` (reads the set into a plain-JSON snapshot) and `src/plugins/qa/theme-probe.ts` (resolves variables per theme mode against one temporary frame, the ADR-0001 read-only carve-out).
+The QA engine keeps its figma-touching code in exactly two files: `src/plugins/qa/collector.ts` (reads the set, and the paint styles it references, into a plain-JSON snapshot) and `src/plugins/qa/theme-probe.ts` (resolves variables per theme mode against one temporary frame, the ADR-0001 read-only carve-out).
 Everything else under `src/plugins/qa/checks/` is pure `(snapshot) -> CheckResult` and fixture-tested.
 - `mcp-server/` — Node MCP server that **listens** on `127.0.0.1:9876` and accepts the plugin's outbound connection (plugin sandbox can't accept inbound, hence inverted server/client roles).
 - `claude-plugin/` — canonical source of the **Claude Code plugin** (`.claude-plugin/plugin.json`, `commands/tidy-*.md`, `skills/`). `npm run build:plugin` bundles the MCP server into it and assembles an installable, marketplace-rooted tree under `dist-plugin/` (version synced from the root `package.json`). The `/tidy-*` commands live here (not in `.claude/commands/`); see `docs/plugin-dev.md` for the local-install dogfood loop. Tools from the plugin-bundled server are namespaced `mcp__plugin_tidy-ds_tidy-ds-toolbox__<op>`.

--- a/claude-plugin/commands/tidy-qa.md
+++ b/claude-plugin/commands/tidy-qa.md
@@ -23,8 +23,9 @@ Split `$ARGUMENTS` on whitespace into tokens, then classify each:
 - **Check-id** — a token that exactly matches one of the known check ids:
   `set-name-casing`, `prop-order`, `tokens`, `layer-naming-structure`,
   `grid-4px`, `interaction-hover-only`, `description`, `no-conflicts`,
-  `preferred-values`, `nesting-depth`, `asset-provenance`, `themes`. Collect these into
-  the `checks` array (a filter — only these checks run).
+  `preferred-values`, `nesting-depth`, `asset-provenance`, `themes`,
+  `high-contrast`. Collect these into the `checks` array (a filter — only these
+  checks run).
 - **Id** — a token matching `^\d+:\d+$` (e.g. `2625:10445`). Use as `nodeId`.
 - **Target name / glob** — every remaining token. Join them with spaces (names
   can contain spaces, e.g. `Button Icon`) and pass as `name`. A `*` makes it a

--- a/claude-plugin/commands/tidy-qa.md
+++ b/claude-plugin/commands/tidy-qa.md
@@ -24,7 +24,7 @@ Split `$ARGUMENTS` on whitespace into tokens, then classify each:
   `set-name-casing`, `prop-order`, `tokens`, `layer-naming-structure`,
   `grid-4px`, `interaction-hover-only`, `description`, `no-conflicts`,
   `preferred-values`, `nesting-depth`, `asset-provenance`, `themes`,
-  `high-contrast`. Collect these into the `checks` array (a filter — only these
+  `high-contrast`. Collect these into the `checks` array (a filter - only these
   checks run).
 - **Id** — a token matching `^\d+:\d+$` (e.g. `2625:10445`). Use as `nodeId`.
 - **Target name / glob** — every remaining token. Join them with spaces (names

--- a/docs/adr/0001-plan-execute-split-for-operations.md
+++ b/docs/adr/0001-plan-execute-split-for-operations.md
@@ -11,7 +11,8 @@ To make agent-driven Figma work deterministic without baking DS knowledge into t
 ## Carve-out: transient probe nodes in a Query Operation (2026-07-26, issue #102)
 
 "Read-only" for a Query Operation means **read-only toward its target**, not "performs no document write at all".
-`tidy_qa_run` creates and removes one temporary off-canvas frame in order to resolve variables per theme mode (#17, see `src/plugins/qa/theme-probe.ts`).
+`tidy_qa_run` creates and removes one temporary off-canvas frame in order to resolve variables per theme mode (see `src/plugins/qa/theme-probe.ts`).
+Two checks depend on it: #17 themes (issue #102, which introduced the probe) and #16 high contrast (issue #103, which needs each colour token's value per mode to compute contrast ratios).
 It is permitted under these conditions:
 
 - The probe node is created, used and removed inside a single Operation call, in a `finally` so the error path cleans up too.

--- a/docs/prd-automated-qa.md
+++ b/docs/prd-automated-qa.md
@@ -199,7 +199,14 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 > Invisible text needs no special case: it arrives as the ratio-1.0 extreme, which is why #17 leaves it here.
 >
 > Findings are one per colour pair x mode with an occurrence count, naming tokens over hex.
-> Distinct pairs are never merged, since `State=Disabled` legitimately has lower contrast than `Default`.
+> Distinct pairs are never merged, since a hover surface and a default surface fail for different reasons.
+>
+> **Disabled variants are not evaluated.** WCAG 1.4.3 exempts "inactive user interface components", so a faded disabled state is not a defect.
+> The first real set this ran against produced three of its four failures from disabled states - all correct, all unfixable, and enough to teach a designer to skip the row.
+> Inactive is recognised from a `Disabled` variant property (a value of `Disabled` on any property, or a `Disabled` boolean that is on), and the row's caveat says so, since a set naming it differently would still be measured.
+>
+> A `not_applicable` result always carries a note explaining what it found nothing of - usually a component assembled entirely from nested instances, whose text belongs to those components.
+> Without it the row renders blank, which reads as a broken check rather than an inapplicable one.
 
 * **Intent:** Maintain product accessibility standards automatically.
 * **Automated Plugin Action:**

--- a/docs/prd-automated-qa.md
+++ b/docs/prd-automated-qa.md
@@ -184,6 +184,23 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 
 ### 16. High Contrast (Accessibility / A11y)
 
+> Shipped as check `high-contrast` (issue #103), computing WCAG AA per text layer **per theme mode** on top of #17's resolution tables.
+>
+> **The background is never guessed.** It is the nearest ancestor with a visible solid fill, composited outward until the stack is opaque; if nothing opaque is reached, the layer is *not evaluated* rather than measured against an assumed white.
+> Sibling geometry is out of scope, so a chip over a hero image degrades to "not evaluated" instead of to a wrong answer - deciding what sits behind a layer would need absolute bounds and a z-order model.
+> On a checklist a human still ticks through, a false negative is cheap and a false positive is expensive: failing a component against an invented background is what makes designers stop reading the row.
+>
+> Every skipped layer lands in one low-severity tally finding, and any skip makes the row `warn` rather than `pass`, so "not evaluated" can never read as green.
+> Alpha is composited rather than skipped (both paint opacity and node opacity), because the Kido DS deliberately uses opacity in place of absolute hex; only a chain that never reaches opacity is skipped.
+>
+> Colours resolve through literal hex, bound variable, paint style, and a paint style whose paint is variable-bound - the `tokens` check accepts either a variable or a style, so resolving variables alone would leave most rows unevaluated for an implementation-detail reason.
+> Granularity is the layer, not the character range: mixed fills are not evaluated, and a mixed font size is judged at its smallest.
+> Thresholds are AA's dual pair, 4.5:1 and 3:1 for large text (>= 24px, or >= 18.66px bold), with no warn tier - AA is the standard and a warn band for AAA is noise.
+> Invisible text needs no special case: it arrives as the ratio-1.0 extreme, which is why #17 leaves it here.
+>
+> Findings are one per colour pair x mode with an occurrence count, naming tokens over hex.
+> Distinct pairs are never merged, since `State=Disabled` legitimately has lower contrast than `Default`.
+
 * **Intent:** Maintain product accessibility standards automatically.
 * **Automated Plugin Action:**
 * Detect the background color token directly behind text layers inside the component variant frames.

--- a/docs/prd-qa-canvas-checklist.md
+++ b/docs/prd-qa-canvas-checklist.md
@@ -106,7 +106,7 @@ Three new pieces, plus one operation:
 | 13 | No Conflicts | `no-conflicts` |
 | 14 | Nested Instance Depth (PRD: "Easy to Use") | `nesting-depth` |
 | 15 | Preferred (Instance Swapping) | `preferred-values` |
-| 16 | High Contrast (A11y) | manual |
+| 16 | High Contrast (A11y) | `high-contrast` |
 | 17 | Themes (Core/DNA/OldNews) | `themes` |
 | 18 | Page Template | manual |
 | 19 | Documentation | manual |

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -261,7 +261,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "query",
     module: "qa",
     summary:
-      "Run the DS Component QA checklist against a component set. Read-only toward the target - it never modifies the component set - with one documented exception: the themes check (#17) creates and removes a temporary off-canvas probe frame in order to resolve variables per theme mode (carve-out from ADR-0001). Target by nodeId or by name/glob, or omit both to use the current Figma selection; any instance/component resolves up to its owning set. Returns structured CheckResults (status per check, severity + offender node per finding), ids of requested checks not implemented yet, and a 19-item `checklist` model (PRD order) merging engine results with the full DS QA catalogue (pass/warn/fail/manual/not_implemented/not_run/not_applicable - the last when a check ran but had nothing applicable to evaluate, e.g. no instance-swap properties).",
+      "Run the DS Component QA checklist against a component set. Read-only toward the target - it never modifies the component set - with one documented exception: the themes (#17) and high-contrast (#16) checks create and remove a temporary off-canvas probe frame in order to resolve variables per theme mode (carve-out from ADR-0001). Target by nodeId or by name/glob, or omit both to use the current Figma selection; any instance/component resolves up to its owning set. Returns structured CheckResults (status per check, severity + offender node per finding), ids of requested checks not implemented yet, and a 19-item `checklist` model (PRD order) merging engine results with the full DS QA catalogue (pass/warn/fail/manual/not_implemented/not_run/not_applicable - the last when a check ran but had nothing applicable to evaluate, e.g. no instance-swap properties).",
     inputSchema: {
       nodeId: z
         .string()
@@ -279,7 +279,7 @@ export const CATALOGUE: CatalogueEntry[] = [
         .array(z.string())
         .optional()
         .describe(
-          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth, asset-provenance, themes.",
+          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth, asset-provenance, themes, high-contrast.",
         ),
     },
     timeoutMs: 60_000,

--- a/src/plugins/qa/checklist-catalogue.test.ts
+++ b/src/plugins/qa/checklist-catalogue.test.ts
@@ -69,7 +69,12 @@ const PRD_ITEMS: ReadonlyArray<{
     tier: 1,
     checkId: "preferred-values",
   },
-  { n: 16, title: "High Contrast (A11y)", tier: null },
+  {
+    n: 16,
+    title: "High Contrast (A11y)",
+    tier: 2,
+    checkId: "high-contrast",
+  },
   {
     n: 17,
     title: "Themes (Core/DNA/OldNews)",
@@ -110,8 +115,8 @@ describe("CHECKLIST_CATALOGUE", () => {
 
   it("gives every automated item a unique checkId, tiered 1 or 2", () => {
     const automated = CHECKLIST_CATALOGUE.filter((item) => item.checkId);
-    expect(automated).toHaveLength(12);
-    expect(new Set(automated.map((item) => item.checkId)).size).toBe(12);
+    expect(automated).toHaveLength(13);
+    expect(new Set(automated.map((item) => item.checkId)).size).toBe(13);
     for (const item of automated) {
       expect(item.tier === 1 || item.tier === 2).toBe(true);
     }

--- a/src/plugins/qa/checklist-catalogue.ts
+++ b/src/plugins/qa/checklist-catalogue.ts
@@ -130,8 +130,10 @@ export const CHECKLIST_CATALOGUE: readonly CatalogueItem[] = [
   {
     n: 16,
     title: "High Contrast (A11y)",
-    tier: null,
-    blurb: "Text meets WCAG AA contrast against its background.",
+    tier: 2,
+    checkId: "high-contrast",
+    blurb:
+      "Text meets WCAG AA contrast against the surface behind it, in every theme mode.",
   },
   {
     n: 17,

--- a/src/plugins/qa/checks/high-contrast.test.ts
+++ b/src/plugins/qa/checks/high-contrast.test.ts
@@ -243,6 +243,55 @@ describe("checkHighContrast", () => {
     expect(result.findings[0].message).toContain("#808080");
   });
 
+  it("ignores an image behind an opaque surface that completely hides it", () => {
+    // The card is opaque, so the hero image behind it changes nothing on screen.
+    // Resolving it anyway would report "cannot measure" for a pairing that is
+    // perfectly well defined.
+    const result = checkHighContrast(
+      fixture([
+        node({
+          name: "hero",
+          fills: [{ type: "IMAGE", visible: true, opacity: 1 }],
+          children: [
+            node({
+              name: "card",
+              fills: [solid("#FFFFFF")],
+              children: [text({ fills: [solid("#999999")] })],
+            }),
+          ],
+        }),
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].actual).toBe("2.8:1");
+  });
+
+  it("does not evaluate text over an image that a translucent surface lets through", () => {
+    // Same image, but the card is at 50%, so the image really is part of what
+    // renders - and there is no single colour to measure it against.
+    const result = checkHighContrast(
+      fixture([
+        node({
+          name: "hero",
+          fills: [{ type: "IMAGE", visible: true, opacity: 1 }],
+          children: [
+            node({
+              name: "card",
+              opacity: 0.5,
+              fills: [solid("#FFFFFF")],
+              children: [text({ fills: [solid("#999999")] })],
+            }),
+          ],
+        }),
+      ]),
+    );
+    expect(result.status).toBe("warn");
+    expect(messages(result)).toEqual([
+      "1 text layer was not evaluated for contrast: 1 has a gradient or image in its colour chain.",
+    ]);
+  });
+
   it("still needs an opaque backdrop behind a translucent group", () => {
     // Same 50% wrapper, but nothing opaque behind it: the pair genuinely
     // depends on the page colour, which the check refuses to guess.

--- a/src/plugins/qa/checks/high-contrast.test.ts
+++ b/src/plugins/qa/checks/high-contrast.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect } from "vitest";
+import { checkHighContrast } from "./high-contrast";
+import type {
+  ComponentSetSnapshot,
+  NodeSnapshot,
+  PaintSnapshot,
+  ThemeSnapshot,
+} from "../snapshot";
+
+let seq = 0;
+
+function solid(hex: string, extra: Partial<PaintSnapshot> = {}): PaintSnapshot {
+  return { type: "SOLID", visible: true, opacity: 1, hex, ...extra };
+}
+
+function node(overrides: Partial<NodeSnapshot> = {}): NodeSnapshot {
+  seq += 1;
+  return {
+    id: `1:${seq}`,
+    name: "layer",
+    type: "FRAME",
+    visible: true,
+    width: 100,
+    height: 40,
+    children: [],
+    ...overrides,
+  };
+}
+
+function text(overrides: Partial<NodeSnapshot> = {}): NodeSnapshot {
+  return node({
+    name: "label",
+    type: "TEXT",
+    fontSize: 16,
+    bold: false,
+    ...overrides,
+  });
+}
+
+/** One variant per tree, each tree given as the variant root's own snapshot. */
+function fixture(
+  roots: NodeSnapshot[],
+  extra: Partial<ComponentSetSnapshot> = {},
+): ComponentSetSnapshot {
+  return {
+    id: "1:0",
+    name: "Button",
+    type: "COMPONENT_SET",
+    description: "",
+    propertyNames: [],
+    properties: [],
+    variants: roots.map((root, i) => ({
+      id: `v:${i}`,
+      name: `State=${i}`,
+      variantProperties: { State: String(i) },
+      tree: root,
+    })),
+    ...extra,
+  };
+}
+
+/** A frame with `fill` containing one text layer. */
+function surface(fill: string, child: NodeSnapshot): NodeSnapshot {
+  return node({ name: "surface", fills: [solid(fill)], children: [child] });
+}
+
+const messages = (result: { findings: { message: string }[] }) =>
+  result.findings.map((f) => f.message);
+
+describe("checkHighContrast", () => {
+  it("passes a compliant text/background pair", () => {
+    const result = checkHighContrast(
+      fixture([surface("#FFFFFF", text({ fills: [solid("#333333")] }))]),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("fails a pair below 4.5:1 and quotes the ratio", () => {
+    const result = checkHighContrast(
+      fixture([surface("#FFFFFF", text({ fills: [solid("#999999")] }))]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    const [finding] = result.findings;
+    expect(finding.severity).toBe("high");
+    expect(finding.message).toContain("#999999");
+    expect(finding.message).toContain("#FFFFFF");
+    expect(finding.message).toContain("2.8:1");
+    expect(finding.expected).toContain("4.5:1");
+    expect(finding.count).toBe(1);
+  });
+
+  it("allows 3:1 for large text that would fail as normal text", () => {
+    // #767676 on white is 4.54:1; #949494 is ~3.1:1 - under AA normal, over
+    // AA large.
+    const fills = [solid("#949494")];
+    const large = checkHighContrast(
+      fixture([surface("#FFFFFF", text({ fills, fontSize: 24 }))]),
+    );
+    expect(large.status).toBe("pass");
+
+    const normal = checkHighContrast(
+      fixture([surface("#FFFFFF", text({ fills, fontSize: 16 }))]),
+    );
+    expect(normal.status).toBe("fail");
+  });
+
+  it("applies the large threshold from 18.66px only when bold", () => {
+    const fills = [solid("#949494")];
+    const bold = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", text({ fills, fontSize: 18.66, bold: true })),
+      ]),
+    );
+    expect(bold.status).toBe("pass");
+
+    const regular = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", text({ fills, fontSize: 18.66, bold: false })),
+      ]),
+    );
+    expect(regular.status).toBe("fail");
+  });
+
+  it("reports invisible text as the ratio-1.0 extreme", () => {
+    const result = checkHighContrast(
+      fixture([surface("#1F1F1F", text({ fills: [solid("#1F1F1F")] }))]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].actual).toBe("1:1");
+  });
+
+  it("composites a semi-transparent text fill over its background", () => {
+    // Black at 30% over white is #B3B3B3 - about 2:1, a fail. Treating the raw
+    // #000000 as the colour would have passed it at 21:1.
+    const result = checkHighContrast(
+      fixture([
+        surface(
+          "#FFFFFF",
+          text({ fills: [solid("#000000", { opacity: 0.3 })] }),
+        ),
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].actual).toBe("2:1");
+  });
+
+  it("composites a semi-transparent background over the nearest opaque ancestor", () => {
+    // A 50% white scrim over black resolves to #808080; black text on that is
+    // 5.3:1 and passes. Skipping translucent surfaces would have skipped this.
+    const result = checkHighContrast(
+      fixture([
+        node({
+          name: "page",
+          fills: [solid("#000000")],
+          children: [
+            node({
+              name: "scrim",
+              fills: [solid("#FFFFFF", { opacity: 0.5 })],
+              children: [text({ fills: [solid("#000000")] })],
+            }),
+          ],
+        }),
+      ]),
+    );
+    expect(result.status).toBe("pass");
+  });
+
+  it("treats node opacity on the text like paint opacity on its fill", () => {
+    // 30% node opacity over an opaque fill is the same surface as a 30% fill,
+    // so it must reach the same ratio as the previous case.
+    const result = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", text({ opacity: 0.3, fills: [solid("#000000")] })),
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].actual).toBe("2:1");
+  });
+
+  it("attenuates the text along with the wrapper whose opacity it inherits", () => {
+    // A 50% wrapper is *not* the same as a 50% fill: it fades its own
+    // background and the text on it, so the pair loses contrast rather than
+    // keeping it. Black text on a 50% white scrim over black is 2.6:1, a fail -
+    // applying the wrapper's opacity to the background only would have called
+    // this 5.3:1 and passed it.
+    const result = checkHighContrast(
+      fixture([
+        node({
+          name: "page",
+          fills: [solid("#000000")],
+          children: [
+            node({
+              name: "scrim",
+              opacity: 0.5,
+              fills: [solid("#FFFFFF")],
+              children: [text({ fills: [solid("#000000")] })],
+            }),
+          ],
+        }),
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].actual).toBe("2.6:1");
+  });
+
+  it("does not evaluate text whose background never reaches opacity", () => {
+    const result = checkHighContrast(
+      fixture([
+        node({
+          name: "transparent wrapper",
+          children: [text({ fills: [solid("#999999")] })],
+        }),
+      ]),
+    );
+    expect(result.status).toBe("warn");
+    expect(messages(result)).toEqual([
+      "1 text layer was not evaluated for contrast: 1 had no opaque background behind it.",
+    ]);
+    expect(result.findings[0].severity).toBe("low");
+    expect(result.findings[0].count).toBe(1);
+  });
+
+  it("never assumes a white page behind a transparent chain", () => {
+    // #999999 would fail against white. Reporting nothing is the point: the
+    // check must not invent the background it was not given.
+    const result = checkHighContrast(
+      fixture([node({ children: [text({ fills: [solid("#999999")] })] })]),
+    );
+    expect(result.findings.every((f) => f.severity === "low")).toBe(true);
+  });
+
+  it("does not evaluate text with per-character fills", () => {
+    const result = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", text({ fillsMixed: true, fills: undefined })),
+      ]),
+    );
+    expect(result.status).toBe("warn");
+    expect(messages(result)).toEqual([
+      "1 text layer was not evaluated for contrast: 1 uses per-character fills.",
+    ]);
+  });
+
+  it("rolls every skip reason into one counted finding", () => {
+    const result = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", text({ fillsMixed: true, fills: undefined })),
+        surface("#FFFFFF", text({ fillsMixed: true, fills: undefined })),
+        node({ children: [text({ fills: [solid("#999999")] })] }),
+      ]),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(3);
+    expect(result.findings[0].message).toBe(
+      "3 text layers were not evaluated for contrast: 2 use per-character fills, 1 had no opaque background behind it.",
+    );
+  });
+
+  it("collapses the same colour pair across variants into one counted finding", () => {
+    const failing = () =>
+      surface("#FFFFFF", text({ fills: [solid("#999999")] }));
+    const result = checkHighContrast(
+      fixture([failing(), failing(), failing()]),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(3);
+  });
+
+  it("never merges distinct colour pairs", () => {
+    // State=Disabled legitimately differs from Default, so the two failures
+    // are two rows even though they share a background.
+    const result = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", text({ fills: [solid("#999999")] })),
+        surface("#FFFFFF", text({ fills: [solid("#AAAAAA")] })),
+      ]),
+    );
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.every((f) => f.count === 1)).toBe(true);
+  });
+
+  it("reports no text layers at all as not applicable", () => {
+    const result = checkHighContrast(
+      fixture([node({ fills: [solid("#FFFFFF")] })]),
+    );
+    expect(result.status).toBe("not_applicable");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("ignores hidden layers and hidden subtrees", () => {
+    const result = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", text({ visible: false, fills: [solid("#FFFFFF")] })),
+        node({
+          visible: false,
+          fills: [solid("#FFFFFF")],
+          children: [text({ fills: [solid("#FFFFFF")] })],
+        }),
+      ]),
+    );
+    expect(result.status).toBe("not_applicable");
+  });
+});
+
+describe("checkHighContrast with theme modes", () => {
+  const theme: ThemeSnapshot = {
+    collectionId: "c-theme",
+    collectionName: "Theme",
+    modes: [
+      { modeId: "m-core", name: "Core" },
+      { modeId: "m-dna", name: "DNA" },
+    ],
+    variables: {
+      "v-text": {
+        name: "Text/Muted",
+        collectionId: "c-theme",
+        byMode: {
+          "m-core": { ok: true, type: "COLOR", hex: "#595959", alpha: 1 },
+          "m-dna": { ok: true, type: "COLOR", hex: "#999999", alpha: 1 },
+        },
+      },
+      "v-surface": {
+        name: "Surface/Default",
+        collectionId: "c-theme",
+        byMode: {
+          "m-core": { ok: true, type: "COLOR", hex: "#FFFFFF", alpha: 1 },
+          "m-dna": { ok: true, type: "COLOR", hex: "#FFFFFF", alpha: 1 },
+        },
+      },
+    },
+  };
+
+  const boundFixture = () =>
+    fixture(
+      [
+        node({
+          name: "surface",
+          fills: [solid("#FFFFFF", { boundVariableId: "v-surface" })],
+          children: [
+            text({ fills: [solid("#595959", { boundVariableId: "v-text" })] }),
+          ],
+        }),
+      ],
+      { theme },
+    );
+
+  it("fails only in the mode where the pair falls short, naming the mode", () => {
+    const result = checkHighContrast(boundFixture());
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toContain('in mode "DNA"');
+  });
+
+  it("prefers token names over hex when both sides are bound", () => {
+    const [finding] = checkHighContrast(boundFixture()).findings;
+    expect(finding.message).toContain('"Text/Muted"');
+    expect(finding.message).toContain('"Surface/Default"');
+    expect(finding.message).not.toContain("#999999");
+  });
+
+  it("states which collection and modes it evaluated", () => {
+    const result = checkHighContrast(boundFixture());
+    expect(result.note).toContain('"Theme"');
+    expect(result.note).toContain("Core, DNA");
+  });
+
+  it("does not evaluate a layer whose bound colour fails to resolve in a mode", () => {
+    const broken: ThemeSnapshot = {
+      ...theme,
+      variables: {
+        ...theme.variables,
+        "v-text": {
+          name: "Text/Muted",
+          collectionId: "c-theme",
+          byMode: {
+            "m-core": { ok: true, type: "COLOR", hex: "#595959", alpha: 1 },
+            "m-dna": { ok: false, reason: "no-value" },
+          },
+        },
+      },
+    };
+    const result = checkHighContrast({ ...boundFixture(), theme: broken });
+    expect(result.status).toBe("warn");
+    expect(messages(result)).toEqual([
+      "1 text layer was not evaluated for contrast: 1 has a colour that does not resolve in every mode.",
+    ]);
+  });
+
+  it("resolves colours through a paint style and names it", () => {
+    const result = checkHighContrast(
+      fixture(
+        [
+          node({
+            name: "surface",
+            fillStyleId: "S:bg",
+            fills: [solid("#FFFFFF")],
+            children: [
+              text({ fillStyleId: "S:fg", fills: [solid("#999999")] }),
+            ],
+          }),
+        ],
+        {
+          colorStyles: {
+            "S:bg": { name: "Surface/Card", paints: [solid("#FFFFFF")] },
+            "S:fg": { name: "Text/Subtle", paints: [solid("#999999")] },
+          },
+        },
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].message).toContain('"Text/Subtle"');
+    expect(result.findings[0].message).toContain('"Surface/Card"');
+  });
+
+  it("resolves a variable-bound paint style through the per-mode table", () => {
+    const result = checkHighContrast(
+      fixture(
+        [
+          node({
+            name: "surface",
+            fillStyleId: "S:bg",
+            fills: [solid("#FFFFFF")],
+            children: [
+              text({
+                fills: [solid("#595959", { boundVariableId: "v-text" })],
+              }),
+            ],
+          }),
+        ],
+        {
+          theme,
+          colorStyles: {
+            "S:bg": {
+              name: "Surface/Card",
+              paints: [solid("#FFFFFF", { boundVariableId: "v-surface" })],
+            },
+          },
+        },
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].message).toContain('"Surface/Default"');
+  });
+});

--- a/src/plugins/qa/checks/high-contrast.test.ts
+++ b/src/plugins/qa/checks/high-contrast.test.ts
@@ -179,12 +179,16 @@ describe("checkHighContrast", () => {
     expect(result.findings[0].actual).toBe("2:1");
   });
 
-  it("attenuates the text along with the wrapper whose opacity it inherits", () => {
-    // A 50% wrapper is *not* the same as a 50% fill: it fades its own
-    // background and the text on it, so the pair loses contrast rather than
-    // keeping it. Black text on a 50% white scrim over black is 2.6:1, a fail -
-    // applying the wrapper's opacity to the background only would have called
-    // this 5.3:1 and passed it.
+  it("treats a wrapper's opacity as a group property, not a per-layer one", () => {
+    // Figma fades a frame's fill and its children together, as one composite.
+    // A 50% frame holding black text on a white fill, over a black page,
+    // therefore renders black text (black at 50% over black is still black) on
+    // #808080 - 5.3:1, a pass.
+    //
+    // Applying the 50% to the text and to the already-flattened background
+    // separately double-counts it: that gives #404040 on #808080, 2.6:1, and
+    // fails a component that is genuinely fine. Any DS that fades a whole
+    // surface would collect invented failures.
     const result = checkHighContrast(
       fixture([
         node({
@@ -201,8 +205,26 @@ describe("checkHighContrast", () => {
         }),
       ]),
     );
-    expect(result.status).toBe("fail");
-    expect(result.findings[0].actual).toBe("2.6:1");
+    expect(result.status).toBe("pass");
+  });
+
+  it("still needs an opaque backdrop behind a translucent group", () => {
+    // Same 50% wrapper, but nothing opaque behind it: the pair genuinely
+    // depends on the page colour, which the check refuses to guess.
+    const result = checkHighContrast(
+      fixture([
+        node({
+          name: "scrim",
+          opacity: 0.5,
+          fills: [solid("#FFFFFF")],
+          children: [text({ fills: [solid("#000000")] })],
+        }),
+      ]),
+    );
+    expect(result.status).toBe("warn");
+    expect(messages(result)).toEqual([
+      "1 text layer was not evaluated for contrast: 1 had no opaque background behind it.",
+    ]);
   });
 
   it("does not evaluate text whose background never reaches opacity", () => {
@@ -279,6 +301,49 @@ describe("checkHighContrast", () => {
     );
     expect(result.findings).toHaveLength(2);
     expect(result.findings.every((f) => f.count === 1)).toBe(true);
+  });
+
+  it("never merges layers that quote the same colour but render differently", () => {
+    // Both text layers name #999999, but one is at 50% opacity, so they land at
+    // 2.8:1 and 1.6:1. Keying on the quoted colour rather than the rendered one
+    // would report a single ratio for two different pairs.
+    const result = checkHighContrast(
+      fixture([
+        node({
+          name: "surface",
+          fills: [solid("#FFFFFF")],
+          children: [
+            text({ fills: [solid("#999999")] }),
+            text({ opacity: 0.5, fills: [solid("#999999")] }),
+          ],
+        }),
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings.map((f) => f.actual)).toEqual(["1.6:1", "2.8:1"]);
+  });
+
+  it("keeps one row for a rendered pair used at two sizes, judged at the strictest", () => {
+    // #BBBBBB on white is 1.9:1 - short of both 4.5:1 and 3:1, so the normal
+    // and the large layer both fail on the same rendered pair. That is one
+    // colour pair, hence one row, described by the threshold it misses by most.
+    const fills = [solid("#BBBBBB")];
+    const result = checkHighContrast(
+      fixture([
+        node({
+          name: "surface",
+          fills: [solid("#FFFFFF")],
+          children: [
+            text({ fills, fontSize: 16 }),
+            text({ fills, fontSize: 32 }),
+          ],
+        }),
+      ]),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(2);
+    expect(result.findings[0].expected).toContain("4.5:1");
+    expect(result.findings[0].message).toContain("normal text");
   });
 
   it("reports no text layers at all as not applicable", () => {

--- a/src/plugins/qa/checks/high-contrast.test.ts
+++ b/src/plugins/qa/checks/high-contrast.test.ts
@@ -208,6 +208,41 @@ describe("checkHighContrast", () => {
     expect(result.status).toBe("pass");
   });
 
+  it("keeps fading past an opaque surface when an outer group is translucent", () => {
+    // White text on an opaque black surface is 21:1 in isolation - but the 50%
+    // wrapper composites that whole surface over the white page, so what renders
+    // is white on #808080: 3.9:1, a fail.
+    //
+    // Stopping the walk as soon as the surface turns opaque reports the 21:1 and
+    // passes it. Reaching opacity is not the end of the chain.
+    const result = checkHighContrast(
+      fixture([
+        node({
+          name: "page",
+          fills: [solid("#FFFFFF")],
+          children: [
+            node({
+              name: "wrapper",
+              opacity: 0.5,
+              children: [
+                node({
+                  name: "surface",
+                  fills: [solid("#000000")],
+                  children: [text({ fills: [solid("#FFFFFF")] })],
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].actual).toBe("3.9:1");
+    // The pair is a composite, so it is named by the colour on screen rather
+    // than by the black token that is no longer what renders.
+    expect(result.findings[0].message).toContain("#808080");
+  });
+
   it("still needs an opaque backdrop behind a translucent group", () => {
     // Same 50% wrapper, but nothing opaque behind it: the pair genuinely
     // depends on the page colour, which the check refuses to guess.

--- a/src/plugins/qa/checks/high-contrast.test.ts
+++ b/src/plugins/qa/checks/high-contrast.test.ts
@@ -430,12 +430,16 @@ describe("checkHighContrast", () => {
     expect(result.findings[0].message).toContain("normal text");
   });
 
-  it("reports no text layers at all as not applicable", () => {
+  it("reports no text layers at all as not applicable, and says why", () => {
+    // A not-applicable row carries no findings, so without a note it renders
+    // blank and the reader cannot tell it from a broken or skipped check.
     const result = checkHighContrast(
       fixture([node({ fills: [solid("#FFFFFF")] })]),
     );
     expect(result.status).toBe("not_applicable");
     expect(result.findings).toEqual([]);
+    expect(result.note).toContain("no text layers of its own");
+    expect(result.note).toContain("nested instance");
   });
 
   it("ignores hidden layers and hidden subtrees", () => {
@@ -450,6 +454,65 @@ describe("checkHighContrast", () => {
       ]),
     );
     expect(result.status).toBe("not_applicable");
+  });
+});
+
+describe("checkHighContrast and disabled variants", () => {
+  /** Same failing pair in every variant, with the given variant properties. */
+  function withProperties(
+    properties: Record<string, string>[],
+  ): ComponentSetSnapshot {
+    const base = fixture(
+      properties.map(() =>
+        surface("#FFFFFF", text({ fills: [solid("#999999")] })),
+      ),
+    );
+    return {
+      ...base,
+      variants: base.variants.map((v, i) => ({
+        ...v,
+        variantProperties: properties[i],
+      })),
+    };
+  }
+
+  it("does not evaluate a State=Disabled variant", () => {
+    // WCAG exempts inactive controls, so a faded disabled state is not a defect
+    // and reporting it fills the row with failures nobody can fix.
+    const result = checkHighContrast(withProperties([{ State: "Disabled" }]));
+    expect(result.status).toBe("not_applicable");
+    expect(result.note).toContain("every variant here is a disabled state");
+  });
+
+  it("does not evaluate a Disabled=True boolean variant", () => {
+    const result = checkHighContrast(withProperties([{ Disabled: "True" }]));
+    expect(result.status).toBe("not_applicable");
+  });
+
+  it("still evaluates a variant whose Disabled boolean is off", () => {
+    const result = checkHighContrast(withProperties([{ Disabled: "False" }]));
+    expect(result.status).toBe("fail");
+  });
+
+  it("evaluates the active variants and counts the disabled ones in the caveat", () => {
+    const result = checkHighContrast(
+      withProperties([
+        { State: "Default" },
+        { State: "Disabled" },
+        { State: "Disabled" },
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    // One failing layer, not three: the two disabled variants never ran.
+    expect(result.findings[0].count).toBe(1);
+    expect(result.note).toContain("2 disabled variants were not evaluated");
+    // The convention this depends on is stated rather than assumed silently.
+    expect(result.note).toContain('"Disabled" variant property');
+  });
+
+  it("says nothing about disabled variants when there are none", () => {
+    const result = checkHighContrast(withProperties([{ State: "Default" }]));
+    expect(result.note).not.toContain("disabled");
   });
 });
 

--- a/src/plugins/qa/checks/high-contrast.ts
+++ b/src/plugins/qa/checks/high-contrast.ts
@@ -417,9 +417,17 @@ function render(
 ): Rendered | "unresolved" | undefined {
   let text = own;
   let background: Rgba | undefined;
-  let label: string | undefined;
-  let contributors = 0;
+  /** The nearest ancestor fill that contributed, for naming the pair. */
+  let nearest: { rgba: Rgba; label: string } | undefined;
 
+  // The **whole** chain, with no early exit once the surface turns opaque.
+  // Reaching opacity is not the end of the story: an outer group can still fade
+  // the composite over whatever is beyond it, changing both pixels. White text
+  // on an opaque black surface inside a 50% wrapper over white is white on
+  // #808080 - 3.9:1, a fail - not the 21:1 that stopping at the black surface
+  // reports. Chains here are a handful of levels deep, so walking all of them
+  // costs nothing worth trading correctness for; past an opaque surface each
+  // further `layer` is a no-op anyway.
   for (const ancestor of candidate.ancestors) {
     const resolved = resolveColor(ancestor, mode, snapshot);
     if (resolved === "unresolved") return "unresolved";
@@ -431,8 +439,7 @@ function render(
       background = background
         ? layer(background, resolved.rgba)
         : resolved.rgba;
-      contributors += 1;
-      if (label === undefined) label = resolved.label;
+      if (nearest === undefined) nearest = resolved;
     }
 
     const groupOpacity = ancestor.opacity ?? 1;
@@ -445,16 +452,22 @@ function render(
         };
       }
     }
-
-    if (background && background.alpha >= OPAQUE) break;
   }
 
   if (!background || background.alpha < OPAQUE) return undefined;
-  return {
-    text,
-    background,
-    label: contributors === 1 ? (label ?? background.hex) : background.hex,
-  };
+
+  // The nearest fill's own name, but only when it is demonstrably the colour on
+  // screen: opaque on its own, and unchanged by everything outside it. Anything
+  // else is a composite that no single token describes, so the rendered hex is
+  // the honest label.
+  const named =
+    nearest !== undefined &&
+    nearest.rgba.alpha >= OPAQUE &&
+    nearest.rgba.hex === background.hex
+      ? nearest.label
+      : background.hex;
+
+  return { text, background, label: named };
 }
 
 /** A ratio as designers write it: "4.1", "21". Truncated, never rounded up. */

--- a/src/plugins/qa/checks/high-contrast.ts
+++ b/src/plugins/qa/checks/high-contrast.ts
@@ -21,7 +21,10 @@
  * **Alpha is composited, not skipped.** The Kido DS uses opacity in place of
  * absolute hex, so blanket-skipping translucent fills would skip a large share
  * of real surface. Paint opacity and node opacity both count, and only a chain
- * that never reaches opacity is skipped.
+ * that never reaches opacity is skipped. Node opacity is treated as what Figma
+ * makes it - a *group* property, fading a frame's fill and its children as one
+ * composite - see `render`, since applying it per layer instead invents
+ * failures on any component that fades a whole surface.
  *
  * **How far a colour is chased:** literal hex, bound variable (per mode, from
  * #17's resolution table), paint style, and a paint style whose paint is
@@ -55,7 +58,7 @@ import type {
   ThemeSnapshot,
 } from "../snapshot";
 import type { CheckResult, CheckStatus, Finding } from "../types";
-import { contrastRatio, layer, requiredRatio } from "../contrast";
+import { AA_NORMAL, contrastRatio, layer, requiredRatio } from "../contrast";
 import type { Rgba } from "../contrast";
 
 const TITLE = "High contrast (WCAG AA)";
@@ -107,10 +110,8 @@ interface Mode {
 /** A visible text layer with the ancestor chain that could back it. */
 interface Candidate {
   node: NodeSnapshot;
-  /** Accumulated opacity of the text layer itself (self x every ancestor). */
-  opacity: number;
-  /** Ancestors nearest-first, each with its own accumulated opacity. */
-  ancestors: { node: NodeSnapshot; opacity: number }[];
+  /** Ancestors nearest-first, up to the variant root. */
+  ancestors: NodeSnapshot[];
 }
 
 /**
@@ -120,6 +121,19 @@ interface Candidate {
  * which is a skip rather than a transparent layer.
  */
 type Resolved = { rgba: Rgba; label: string } | "unresolved" | undefined;
+
+/**
+ * The two rendered pixels a contrast ratio is measured between: one where the
+ * glyph is, one on the surface beside it. Both are folded through the same
+ * ancestor chain, so whatever an enclosing group does to one it does to the
+ * other.
+ */
+interface Rendered {
+  text: Rgba;
+  background: Rgba;
+  /** Display name of the nearest ancestor fill that contributed. */
+  label: string;
+}
 
 /** Colour pair failing in one mode, with every layer that hits it. */
 interface Failure {
@@ -137,7 +151,7 @@ interface Failure {
 export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
   const candidates: Candidate[] = [];
   for (const variant of snapshot.variants) {
-    collectCandidates(variant.tree, [], 1, candidates);
+    collectCandidates(variant.tree, [], candidates);
   }
 
   if (candidates.length === 0) {
@@ -169,51 +183,67 @@ export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
     }
 
     for (const mode of modes) {
-      const foreground = resolveColor(node, candidate.opacity, mode, snapshot);
-      if (foreground === undefined) {
+      const own = resolveColor(node, mode, snapshot);
+      if (own === undefined) {
         skip(node, "no-fill");
         break;
       }
-      if (foreground === "unresolved") {
+      if (own === "unresolved") {
         skip(node, "unresolved-colour");
         continue;
       }
 
-      const background = resolveBackground(candidate, mode, snapshot);
-      if (background === "unresolved") {
+      // The text layer's own opacity, applied here for the same reason
+      // `resolveColor` leaves it out: it is a group property, and the text is
+      // its own (leaf) group.
+      const selfOpacity = node.opacity ?? 1;
+      const start: Rgba =
+        selfOpacity === 1
+          ? own.rgba
+          : { hex: own.rgba.hex, alpha: own.rgba.alpha * selfOpacity };
+
+      const rendered = render(candidate, start, mode, snapshot);
+      if (rendered === "unresolved") {
         skip(node, "unresolved-colour");
         continue;
       }
-      if (background === undefined) {
+      if (rendered === undefined) {
         skip(node, "no-background");
         continue;
       }
 
-      // Translucent text has no colour of its own either: it is whatever shows
-      // through it, so it composites onto the background before measuring.
-      const surface: Rgba = { hex: background.rgba.hex, alpha: 1 };
-      const text = layer(foreground.rgba, surface);
-      const ratio = contrastRatio(text.hex, surface.hex);
+      const ratio = contrastRatio(rendered.text.hex, rendered.background.hex);
       const required = requiredRatio(node.fontSize, node.bold ?? false);
       if (ratio >= required) continue;
 
+      // Keyed on the **rendered** colours, not on the token names: two layers
+      // can quote the same token pair and still render differently (a 50%
+      // opacity on one of them), and merging those would report one ratio for
+      // two different pairs. Names are kept for display only.
       const key = JSON.stringify([
         mode.modeId,
-        foreground.label,
-        background.label,
-        required,
+        rendered.text.hex,
+        rendered.background.hex,
       ]);
       const existing = failures.get(key);
       if (existing) {
         existing.count += 1;
+        // One rendered pair is one row, so a group holding both normal and
+        // large text is described by its strictest member - the count covers
+        // the rest. Splitting on the threshold instead would put the same
+        // colour pair on two rows, which the ticket rules out.
+        if (required > existing.required) {
+          existing.required = required;
+          existing.large = false;
+        }
       } else {
         failures.set(key, {
           modeName: mode.name,
-          foreground: foreground.label,
-          background: background.label,
+          foreground: own.label,
+          background: rendered.label,
           ratio,
           required,
-          large: required < 4.5,
+          large: required < AA_NORMAL,
           nodeId: node.id,
           nodeName: node.name,
           count: 1,
@@ -242,9 +272,9 @@ export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
 }
 
 /**
- * Visible text layers, each carrying its ancestor chain and the product of
- * every enclosing node's opacity. Hidden layers and hidden subtrees are not
- * rendered, so they are not candidates at all - not even skipped ones.
+ * Visible text layers, each carrying its ancestor chain nearest-first. Hidden
+ * layers and hidden subtrees are not rendered, so they are not candidates at
+ * all - not even skipped ones.
  *
  * Nested instance interiors never appear here: the snapshot stops at instance
  * boundaries by design (#8 owns what is inside them), so text inside a nested
@@ -252,19 +282,17 @@ export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
  */
 function collectCandidates(
   node: NodeSnapshot,
-  ancestors: { node: NodeSnapshot; opacity: number }[],
-  inherited: number,
+  ancestors: NodeSnapshot[],
   out: Candidate[],
 ): void {
   if (!node.visible) return;
-  const opacity = inherited * (node.opacity ?? 1);
   if (node.type === "TEXT") {
-    out.push({ node, opacity, ancestors });
+    out.push({ node, ancestors });
     return;
   }
-  const chain = [{ node, opacity }, ...ancestors];
+  const chain = [node, ...ancestors];
   for (const child of node.children) {
-    collectCandidates(child, chain, opacity, out);
+    collectCandidates(child, chain, out);
   }
 }
 
@@ -299,7 +327,12 @@ function paintSource(
 
 /**
  * One node's own colour in one mode: its visible solid paints flattened
- * bottom-to-top, scaled by the node's accumulated opacity.
+ * bottom-to-top, at their paint opacity.
+ *
+ * Node opacity is deliberately **not** applied here. It is a group property -
+ * it fades the node's fill and its children together - so `render` applies it
+ * once at the group boundary. Folding it in here as well would double-count it
+ * for every ancestor fill.
  *
  * A non-solid visible paint (image, gradient) makes the node unresolvable
  * rather than transparent - there is no single colour to measure, and treating
@@ -307,7 +340,6 @@ function paintSource(
  */
 function resolveColor(
   node: NodeSnapshot,
-  opacity: number,
   mode: Mode,
   snapshot: ComponentSetSnapshot,
 ): Resolved {
@@ -340,7 +372,7 @@ function resolveColor(
     }
     if (!hex) return "unresolved";
 
-    const here: Rgba = { hex, alpha: alpha * opacity };
+    const here: Rgba = { hex, alpha };
     accumulated = accumulated ? layer(here, accumulated) : here;
     contributors += 1;
     if (label === undefined) label = name ?? hex;
@@ -356,42 +388,72 @@ function resolveColor(
 }
 
 /**
- * The opaque surface behind a text layer: ancestor fills composited outward
- * until the stack is opaque. Returns `undefined` when the variant root is
- * reached without ever getting there - the deliberate "not evaluated" case.
+ * The two pixels actually on screen: one where the glyph is, one on the surface
+ * beside it. Both fold through the same ancestor chain outward from the text.
+ *
+ * **Group opacity is why this is one walk rather than two.** A frame's opacity
+ * applies to the frame composited *as a group* - its own fill plus everything
+ * inside it - not to each layer independently. So a 50% frame holding black text
+ * on a white fill, over a black page, renders black text (black at 50% over
+ * black is still black) on #808080: 5.3:1, not the 2.6:1 you get by fading the
+ * text against an already-flattened background. Applying the opacity separately
+ * to text and surface double-counts it and invents failures.
+ *
+ * Hence the fold: layer inward-to-outward, and at each ancestor boundary
+ * multiply the accumulated alpha by that ancestor's opacity. Once an enclosing
+ * group is translucent nothing below can become opaque again, which is exactly
+ * right - the pair genuinely depends on what is behind the group.
+ *
+ * Returns `undefined` when the variant root is reached without the surface ever
+ * becoming opaque: the deliberate "not evaluated" case. The text pixel needs no
+ * separate check, since it can only be at least as opaque as the surface it is
+ * folded through.
  */
-function resolveBackground(
+function render(
   candidate: Candidate,
+  own: Rgba,
   mode: Mode,
   snapshot: ComponentSetSnapshot,
-): Resolved {
-  let accumulated: Rgba | undefined;
+): Rendered | "unresolved" | undefined {
+  let text = own;
+  let background: Rgba | undefined;
   let label: string | undefined;
   let contributors = 0;
 
   for (const ancestor of candidate.ancestors) {
-    const resolved = resolveColor(
-      ancestor.node,
-      ancestor.opacity,
-      mode,
-      snapshot,
-    );
+    const resolved = resolveColor(ancestor, mode, snapshot);
     if (resolved === "unresolved") return "unresolved";
-    // A node with no fill is simply transparent: keep walking outward.
-    if (resolved === undefined) continue;
 
-    accumulated = accumulated
-      ? layer(accumulated, resolved.rgba)
-      : resolved.rgba;
-    contributors += 1;
-    if (label === undefined) label = resolved.label;
-    if (accumulated.alpha >= OPAQUE) break;
+    // A node with no fill of its own still forms a group, so its opacity
+    // applies even though it contributes no colour.
+    if (resolved !== undefined) {
+      text = layer(text, resolved.rgba);
+      background = background
+        ? layer(background, resolved.rgba)
+        : resolved.rgba;
+      contributors += 1;
+      if (label === undefined) label = resolved.label;
+    }
+
+    const groupOpacity = ancestor.opacity ?? 1;
+    if (groupOpacity !== 1) {
+      text = { hex: text.hex, alpha: text.alpha * groupOpacity };
+      if (background) {
+        background = {
+          hex: background.hex,
+          alpha: background.alpha * groupOpacity,
+        };
+      }
+    }
+
+    if (background && background.alpha >= OPAQUE) break;
   }
 
-  if (!accumulated || accumulated.alpha < OPAQUE) return undefined;
+  if (!background || background.alpha < OPAQUE) return undefined;
   return {
-    rgba: accumulated,
-    label: contributors === 1 ? (label ?? accumulated.hex) : accumulated.hex,
+    text,
+    background,
+    label: contributors === 1 ? (label ?? background.hex) : background.hex,
   };
 }
 

--- a/src/plugins/qa/checks/high-contrast.ts
+++ b/src/plugins/qa/checks/high-contrast.ts
@@ -1,0 +1,484 @@
+/**
+ * #16 - High contrast (issue #103). Does every text layer clear WCAG AA against
+ * the background it is actually drawn on, in every theme mode?
+ *
+ * **Never guess the background.** The pairing is the nearest ancestor with a
+ * visible solid fill, composited outward until the stack is opaque. If nothing
+ * opaque is reached by the variant root, the layer is *not evaluated* - no
+ * assumed white, no assumed page colour. In a checklist a human still ticks
+ * through, a false negative is cheap and a false positive is expensive:
+ * inventing a background and failing the component against it is exactly the
+ * error that makes designers stop reading the row.
+ *
+ * Sibling geometry is deliberately out of scope: a chip over a hero image
+ * degrades to "not evaluated" rather than to a wrong answer, since deciding
+ * what is behind a layer would need absolute bounds and a z-order model.
+ *
+ * **"Not evaluated" is reported, never quietly green.** Every skipped layer
+ * lands in one low-severity tally finding, and any skip at all makes the row
+ * `warn` rather than `pass` - without that the row would lie by omission.
+ *
+ * **Alpha is composited, not skipped.** The Kido DS uses opacity in place of
+ * absolute hex, so blanket-skipping translucent fills would skip a large share
+ * of real surface. Paint opacity and node opacity both count, and only a chain
+ * that never reaches opacity is skipped.
+ *
+ * **How far a colour is chased:** literal hex, bound variable (per mode, from
+ * #17's resolution table), paint style, and a paint style whose paint is
+ * variable-bound. The `tokens` check accepts either a variable or a style, so
+ * resolving variables only would leave most rows unevaluated for an
+ * implementation-detail reason - and an unevaluated contrast check is worse
+ * than none, because the row still looks checked.
+ *
+ * Granularity is the layer, not the character range: mixed fills are not
+ * evaluated (picking "the first fill" would be confidently wrong), and a mixed
+ * font size is judged at its smallest, so the strictest applicable threshold
+ * wins.
+ *
+ * **AA, dual threshold, no warn tier**: 4.5:1 normally, 3:1 for large text
+ * (>= 24px, or >= 18.66px bold). AA is the standard, and a warn band for AAA
+ * would be noise. Invisible text needs no special case - it arrives as the
+ * ratio-1.0 extreme, which is why #17 leaves it here.
+ *
+ * Findings are one per **colour pair x mode** with an occurrence count (#100),
+ * naming tokens rather than hex wherever both sides are bound: the fix is one
+ * token pair, and names are what a designer can act on. Distinct pairs are
+ * never merged - `State=Disabled` legitimately has lower contrast than
+ * `Default`, so keying on anything but the pair would hide one behind the other.
+ */
+
+import type {
+  ColorStyleSnapshot,
+  ComponentSetSnapshot,
+  NodeSnapshot,
+  PaintSnapshot,
+  ThemeSnapshot,
+} from "../snapshot";
+import type { CheckResult, CheckStatus, Finding } from "../types";
+import { contrastRatio, layer, requiredRatio } from "../contrast";
+import type { Rgba } from "../contrast";
+
+const TITLE = "High contrast (WCAG AA)";
+
+/** Alpha at or above which a stack counts as opaque - rounding slack only. */
+const OPAQUE = 0.999;
+
+/**
+ * Why a text layer was not evaluated. One reason per layer, in this
+ * precedence order, so the tally's per-reason counts always sum to the total.
+ */
+type SkipReason =
+  | "mixed-fill"
+  | "no-fill"
+  | "unresolved-colour"
+  | "no-background";
+
+const SKIP_PHRASES: Record<SkipReason, { one: string; many: string }> = {
+  "mixed-fill": {
+    one: "uses per-character fills",
+    many: "use per-character fills",
+  },
+  "no-fill": {
+    one: "has no solid fill to measure",
+    many: "have no solid fill to measure",
+  },
+  "unresolved-colour": {
+    one: "has a colour that does not resolve in every mode",
+    many: "have colours that do not resolve in every mode",
+  },
+  "no-background": {
+    one: "had no opaque background behind it",
+    many: "had no opaque background behind them",
+  },
+};
+
+const SKIP_PRECEDENCE: readonly SkipReason[] = [
+  "mixed-fill",
+  "no-fill",
+  "unresolved-colour",
+  "no-background",
+];
+
+interface Mode {
+  modeId: string;
+  name: string;
+}
+
+/** A visible text layer with the ancestor chain that could back it. */
+interface Candidate {
+  node: NodeSnapshot;
+  /** Accumulated opacity of the text layer itself (self x every ancestor). */
+  opacity: number;
+  /** Ancestors nearest-first, each with its own accumulated opacity. */
+  ancestors: { node: NodeSnapshot; opacity: number }[];
+}
+
+/**
+ * A colour resolved for one node in one mode. `undefined` means "this node
+ * paints nothing" (a transparent ancestor, which the walk passes straight
+ * through); `"unresolved"` means a source was found but could not be resolved,
+ * which is a skip rather than a transparent layer.
+ */
+type Resolved = { rgba: Rgba; label: string } | "unresolved" | undefined;
+
+/** Colour pair failing in one mode, with every layer that hits it. */
+interface Failure {
+  modeName: string;
+  foreground: string;
+  background: string;
+  ratio: number;
+  required: number;
+  large: boolean;
+  nodeId: string;
+  nodeName: string;
+  count: number;
+}
+
+export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
+  const candidates: Candidate[] = [];
+  for (const variant of snapshot.variants) {
+    collectCandidates(variant.tree, [], 1, candidates);
+  }
+
+  if (candidates.length === 0) {
+    return {
+      checkId: "high-contrast",
+      title: TITLE,
+      status: "not_applicable",
+      findings: [],
+    };
+  }
+
+  const modes = evaluatedModes(snapshot.theme);
+  const failures = new Map<string, Failure>();
+  const skipped = new Map<string, SkipReason[]>();
+
+  const skip = (node: NodeSnapshot, reason: SkipReason) => {
+    const reasons = skipped.get(node.id);
+    if (reasons) reasons.push(reason);
+    else skipped.set(node.id, [reason]);
+  };
+
+  for (const candidate of candidates) {
+    const { node } = candidate;
+    // Mixed fills are mode-independent, so this is settled before any mode is
+    // considered - and settled once, not once per mode.
+    if (node.fillsMixed) {
+      skip(node, "mixed-fill");
+      continue;
+    }
+
+    for (const mode of modes) {
+      const foreground = resolveColor(node, candidate.opacity, mode, snapshot);
+      if (foreground === undefined) {
+        skip(node, "no-fill");
+        break;
+      }
+      if (foreground === "unresolved") {
+        skip(node, "unresolved-colour");
+        continue;
+      }
+
+      const background = resolveBackground(candidate, mode, snapshot);
+      if (background === "unresolved") {
+        skip(node, "unresolved-colour");
+        continue;
+      }
+      if (background === undefined) {
+        skip(node, "no-background");
+        continue;
+      }
+
+      // Translucent text has no colour of its own either: it is whatever shows
+      // through it, so it composites onto the background before measuring.
+      const surface: Rgba = { hex: background.rgba.hex, alpha: 1 };
+      const text = layer(foreground.rgba, surface);
+      const ratio = contrastRatio(text.hex, surface.hex);
+      const required = requiredRatio(node.fontSize, node.bold ?? false);
+      if (ratio >= required) continue;
+
+      const key = JSON.stringify([
+        mode.modeId,
+        foreground.label,
+        background.label,
+        required,
+      ]);
+      const existing = failures.get(key);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        failures.set(key, {
+          modeName: mode.name,
+          foreground: foreground.label,
+          background: background.label,
+          ratio,
+          required,
+          large: required < 4.5,
+          nodeId: node.id,
+          nodeName: node.name,
+          count: 1,
+        });
+      }
+    }
+  }
+
+  const findings = [...failures.values()]
+    .map(failureFinding)
+    .sort((a, b) => a.message.localeCompare(b.message));
+
+  const tally = skipTally(skipped, candidates);
+  if (tally) findings.push(tally);
+
+  const status: CheckStatus =
+    failures.size > 0 ? "fail" : skipped.size > 0 ? "warn" : "pass";
+
+  return {
+    checkId: "high-contrast",
+    title: TITLE,
+    status,
+    findings,
+    note: buildNote(snapshot.theme, modes),
+  };
+}
+
+/**
+ * Visible text layers, each carrying its ancestor chain and the product of
+ * every enclosing node's opacity. Hidden layers and hidden subtrees are not
+ * rendered, so they are not candidates at all - not even skipped ones.
+ *
+ * Nested instance interiors never appear here: the snapshot stops at instance
+ * boundaries by design (#8 owns what is inside them), so text inside a nested
+ * component is that component's own QA subject.
+ */
+function collectCandidates(
+  node: NodeSnapshot,
+  ancestors: { node: NodeSnapshot; opacity: number }[],
+  inherited: number,
+  out: Candidate[],
+): void {
+  if (!node.visible) return;
+  const opacity = inherited * (node.opacity ?? 1);
+  if (node.type === "TEXT") {
+    out.push({ node, opacity, ancestors });
+    return;
+  }
+  const chain = [{ node, opacity }, ...ancestors];
+  for (const child of node.children) {
+    collectCandidates(child, chain, opacity, out);
+  }
+}
+
+/**
+ * The modes to evaluate. Falls back to a single anonymous mode when there is no
+ * theme table, so a set painted in literal hex or styles is still checked -
+ * bound variables simply cannot resolve there and are skipped.
+ *
+ * Unlike #17 this accepts a single-mode collection: one mode is a perfectly
+ * good context to measure contrast in, even though it is not a theme.
+ */
+function evaluatedModes(theme: ThemeSnapshot | undefined): Mode[] {
+  if (theme && theme.modes.length > 0) return theme.modes;
+  return [{ modeId: "", name: "" }];
+}
+
+/** The paints backing a node, and the style name when they came from a style. */
+function paintSource(
+  node: NodeSnapshot,
+  snapshot: ComponentSetSnapshot,
+): { paints: PaintSnapshot[] | undefined; style?: ColorStyleSnapshot } {
+  const styleId = node.fillStyleId;
+  if (styleId && styleId !== "MIXED") {
+    const style = snapshot.colorStyles?.[styleId];
+    // A style the collector could not resolve falls back to the node's own
+    // fills, which Figma keeps in sync with the style: the name is lost, the
+    // colour is not.
+    if (style) return { paints: style.paints, style };
+  }
+  return { paints: node.fills };
+}
+
+/**
+ * One node's own colour in one mode: its visible solid paints flattened
+ * bottom-to-top, scaled by the node's accumulated opacity.
+ *
+ * A non-solid visible paint (image, gradient) makes the node unresolvable
+ * rather than transparent - there is no single colour to measure, and treating
+ * it as absent would silently pair the text with whatever is behind the image.
+ */
+function resolveColor(
+  node: NodeSnapshot,
+  opacity: number,
+  mode: Mode,
+  snapshot: ComponentSetSnapshot,
+): Resolved {
+  const { paints, style } = paintSource(node, snapshot);
+  if (!paints || paints.length === 0) return undefined;
+
+  let accumulated: Rgba | undefined;
+  let label: string | undefined;
+  let contributors = 0;
+
+  for (const paint of paints) {
+    if (!paint.visible) continue;
+    if (paint.type !== "SOLID") return "unresolved";
+
+    let hex = paint.hex;
+    let alpha = paint.opacity;
+    let name: string | undefined = style?.name;
+
+    if (paint.boundVariableId) {
+      const variable = snapshot.theme?.variables[paint.boundVariableId];
+      const resolution = variable?.byMode[mode.modeId];
+      if (!variable || !resolution?.ok || !resolution.hex) return "unresolved";
+      hex = resolution.hex;
+      // The variable's own alpha, not the paint's: binding a colour variable
+      // sets the paint opacity from it, so multiplying the two would square it.
+      alpha = resolution.alpha ?? 1;
+      // A bound variable names the colour more precisely than the style
+      // holding it does.
+      name = variable.name;
+    }
+    if (!hex) return "unresolved";
+
+    const here: Rgba = { hex, alpha: alpha * opacity };
+    accumulated = accumulated ? layer(here, accumulated) : here;
+    contributors += 1;
+    if (label === undefined) label = name ?? hex;
+  }
+
+  if (!accumulated) return undefined;
+  return {
+    rgba: accumulated,
+    // Once more than one paint contributes, no single token describes the
+    // result, so the composited hex is the honest label.
+    label: contributors === 1 ? (label ?? accumulated.hex) : accumulated.hex,
+  };
+}
+
+/**
+ * The opaque surface behind a text layer: ancestor fills composited outward
+ * until the stack is opaque. Returns `undefined` when the variant root is
+ * reached without ever getting there - the deliberate "not evaluated" case.
+ */
+function resolveBackground(
+  candidate: Candidate,
+  mode: Mode,
+  snapshot: ComponentSetSnapshot,
+): Resolved {
+  let accumulated: Rgba | undefined;
+  let label: string | undefined;
+  let contributors = 0;
+
+  for (const ancestor of candidate.ancestors) {
+    const resolved = resolveColor(
+      ancestor.node,
+      ancestor.opacity,
+      mode,
+      snapshot,
+    );
+    if (resolved === "unresolved") return "unresolved";
+    // A node with no fill is simply transparent: keep walking outward.
+    if (resolved === undefined) continue;
+
+    accumulated = accumulated
+      ? layer(accumulated, resolved.rgba)
+      : resolved.rgba;
+    contributors += 1;
+    if (label === undefined) label = resolved.label;
+    if (accumulated.alpha >= OPAQUE) break;
+  }
+
+  if (!accumulated || accumulated.alpha < OPAQUE) return undefined;
+  return {
+    rgba: accumulated,
+    label: contributors === 1 ? (label ?? accumulated.hex) : accumulated.hex,
+  };
+}
+
+/** A ratio as designers write it: "4.1", "21". Truncated, never rounded up. */
+function formatRatio(ratio: number): string {
+  const truncated = (Math.floor(ratio * 10) / 10).toFixed(1);
+  return truncated.endsWith(".0") ? truncated.slice(0, -2) : truncated;
+}
+
+function quoteColour(label: string): string {
+  // Hex is already unambiguous; a token name needs quoting to read as a name.
+  return label.startsWith("#") ? label : `"${label}"`;
+}
+
+function failureFinding(failure: Failure): Finding {
+  const where = failure.modeName ? ` in mode "${failure.modeName}"` : "";
+  const size = failure.large ? "large" : "normal";
+  return {
+    severity: "high",
+    nodeId: failure.nodeId,
+    nodeName: failure.nodeName,
+    message: `Text ${quoteColour(failure.foreground)} on ${quoteColour(
+      failure.background,
+    )} is ${formatRatio(failure.ratio)}:1${where}, below the WCAG AA minimum for ${size} text.`,
+    expected: `at least ${formatRatio(failure.required)}:1 (WCAG AA, ${size} text)`,
+    actual: `${formatRatio(failure.ratio)}:1`,
+    suggestedFix:
+      "Darken the text token or lighten the surface token for this pair; if the pairing is deliberate, it needs a documented exception.",
+    count: failure.count,
+  };
+}
+
+/**
+ * One low-severity finding covering every layer that was not evaluated.
+ * A layer can collect more than one reason across modes; the highest-precedence
+ * one is reported so the per-reason counts sum to the total.
+ */
+function skipTally(
+  skipped: Map<string, SkipReason[]>,
+  candidates: Candidate[],
+): Finding | undefined {
+  if (skipped.size === 0) return undefined;
+
+  const counts = new Map<SkipReason, number>();
+  for (const reasons of skipped.values()) {
+    const reason =
+      SKIP_PRECEDENCE.find((r) => reasons.includes(r)) ?? reasons[0];
+    counts.set(reason, (counts.get(reason) ?? 0) + 1);
+  }
+
+  const parts = [...counts.entries()]
+    .sort((a, b) => {
+      const byCount = b[1] - a[1];
+      if (byCount !== 0) return byCount;
+      return SKIP_PRECEDENCE.indexOf(a[0]) - SKIP_PRECEDENCE.indexOf(b[0]);
+    })
+    .map(
+      ([reason, count]) =>
+        `${count} ${count === 1 ? SKIP_PHRASES[reason].one : SKIP_PHRASES[reason].many}`,
+    );
+
+  const total = skipped.size;
+  const subject =
+    total === 1
+      ? "1 text layer was not evaluated for contrast"
+      : `${total} text layers were not evaluated for contrast`;
+  const first = candidates.find((c) => skipped.has(c.node.id))?.node;
+
+  return {
+    severity: "low",
+    nodeId: first?.id ?? "",
+    nodeName: first?.name ?? "",
+    message: `${subject}: ${parts.join(", ")}.`,
+    expected: "a resolvable text colour over an opaque background",
+    actual: "not enough resolvable colour information to measure",
+    suggestedFix:
+      "Check these layers by eye, or give the layer an explicit background so the pairing is unambiguous.",
+    count: total,
+  };
+}
+
+function buildNote(theme: ThemeSnapshot | undefined, modes: Mode[]): string {
+  const scope =
+    "Contrast is measured against the nearest ancestor with a solid fill, so sibling geometry and images behind a layer are not considered, and text is judged per layer rather than per character range.";
+  if (theme?.collectionName && modes.length > 0 && modes[0].modeId) {
+    const list = modes.map((m) => m.name).join(", ");
+    return `Evaluated collection "${theme.collectionName}" across ${modes.length} modes: ${list}. ${scope}`;
+  }
+  return `No theme modes were available, so contrast was measured once against the colours as they currently resolve. ${scope}`;
+}

--- a/src/plugins/qa/checks/high-contrast.ts
+++ b/src/plugins/qa/checks/high-contrast.ts
@@ -43,11 +43,20 @@
  * would be noise. Invisible text needs no special case - it arrives as the
  * ratio-1.0 extreme, which is why #17 leaves it here.
  *
+ * **Disabled variants are not evaluated at all.** WCAG 1.4.3 exempts inactive
+ * controls, so a faded disabled state is not a defect - and left in, those
+ * failures dominate the row while being both unfixable and correct. A row full
+ * of unfixable failures is one designers learn to skip.
+ *
  * Findings are one per **colour pair x mode** with an occurrence count (#100),
  * naming tokens rather than hex wherever both sides are bound: the fix is one
  * token pair, and names are what a designer can act on. Distinct pairs are
- * never merged - `State=Disabled` legitimately has lower contrast than
- * `Default`, so keying on anything but the pair would hide one behind the other.
+ * never merged - a hover surface and a default surface fail for different
+ * reasons, so keying on anything but the pair would hide one behind the other.
+ *
+ * Everything the row cannot speak for is in its `note`, including the
+ * `not_applicable` case: a row with no findings and no note is a blank row, and
+ * a reader cannot tell "found nothing to measure" from "broken" or "skipped".
  */
 
 import type {
@@ -161,17 +170,24 @@ interface Failure {
 }
 
 export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
+  const active = snapshot.variants.filter((v) => !isDisabledVariant(v));
+  const disabledCount = snapshot.variants.length - active.length;
+
   const candidates: Candidate[] = [];
-  for (const variant of snapshot.variants) {
+  for (const variant of active) {
     collectCandidates(variant.tree, [], candidates);
   }
 
   if (candidates.length === 0) {
+    // A `not_applicable` row renders with no findings, so without a note it is
+    // a blank row: the reader cannot tell a check that found nothing to measure
+    // from one that is broken or was skipped.
     return {
       checkId: "high-contrast",
       title: TITLE,
       status: "not_applicable",
       findings: [],
+      note: nothingToMeasureNote(snapshot, disabledCount),
     };
   }
 
@@ -282,7 +298,7 @@ export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
     title: TITLE,
     status,
     findings,
-    note: buildNote(snapshot.theme, modes),
+    note: buildNote(snapshot.theme, modes, disabledCount),
   };
 }
 
@@ -575,12 +591,57 @@ function skipTally(
   };
 }
 
-function buildNote(theme: ThemeSnapshot | undefined, modes: Mode[]): string {
+/**
+ * Whether this variant is an inactive control.
+ *
+ * WCAG 1.4.3 exempts "inactive user interface components" from contrast
+ * requirements: a disabled control is *meant* to read as faded, so failing it is
+ * reporting a defect that does not exist and cannot be fixed. Left in, disabled
+ * states dominate the row - three of the four failures on the first real set
+ * this ran against - and a row full of unfixable failures is one designers learn
+ * to skip, which costs more than the coverage is worth.
+ *
+ * Read from the variant properties, which is the only place the snapshot can see
+ * it: either a value of "Disabled" on any property (`State=Disabled`) or a
+ * boolean property named "Disabled" that is on. A set that spells it some other
+ * way will not be caught, and that is stated in the row's caveat rather than
+ * left as a silent assumption.
+ */
+function isDisabledVariant(variant: {
+  variantProperties: Record<string, string>;
+}): boolean {
+  return Object.entries(variant.variantProperties).some(([name, value]) => {
+    const v = value.trim().toLowerCase();
+    if (v === "disabled") return true;
+    return name.trim().toLowerCase() === "disabled" && v === "true";
+  });
+}
+
+/** Why a `not_applicable` row found nothing - never left blank. */
+function nothingToMeasureNote(
+  snapshot: ComponentSetSnapshot,
+  disabledCount: number,
+): string {
+  if (disabledCount > 0 && disabledCount === snapshot.variants.length) {
+    return `Nothing to measure: every variant here is a disabled state, and WCAG exempts inactive controls from contrast requirements.`;
+  }
+  return "Nothing to measure: this set has no text layers of its own. Text inside a nested instance belongs to that component and is checked when it is the subject, so a component assembled entirely from other components reports nothing here.";
+}
+
+function buildNote(
+  theme: ThemeSnapshot | undefined,
+  modes: Mode[],
+  disabledCount: number,
+): string {
   const scope =
     "Contrast is measured against the nearest ancestor with a solid fill, so sibling geometry and images behind a layer are not considered, and text is judged per layer rather than per character range.";
+  const disabled =
+    disabledCount > 0
+      ? ` ${disabledCount} disabled ${disabledCount === 1 ? "variant was" : "variants were"} not evaluated, since WCAG exempts inactive controls; that is recognised from a "Disabled" variant property, so a set naming it differently would still be measured.`
+      : "";
   if (theme?.collectionName && modes.length > 0 && modes[0].modeId) {
     const list = modes.map((m) => m.name).join(", ");
-    return `Evaluated collection "${theme.collectionName}" across ${modes.length} modes: ${list}. ${scope}`;
+    return `Evaluated collection "${theme.collectionName}" across ${modes.length} modes: ${list}. ${scope}${disabled}`;
   }
-  return `No theme modes were available, so contrast was measured once against the colours as they currently resolve. ${scope}`;
+  return `No theme modes were available, so contrast was measured once against the colours as they currently resolve. ${scope}${disabled}`;
 }

--- a/src/plugins/qa/checks/high-contrast.ts
+++ b/src/plugins/qa/checks/high-contrast.ts
@@ -73,6 +73,7 @@ const OPAQUE = 0.999;
 type SkipReason =
   | "mixed-fill"
   | "no-fill"
+  | "non-solid"
   | "unresolved-colour"
   | "no-background";
 
@@ -84,6 +85,10 @@ const SKIP_PHRASES: Record<SkipReason, { one: string; many: string }> = {
   "no-fill": {
     one: "has no solid fill to measure",
     many: "have no solid fill to measure",
+  },
+  "non-solid": {
+    one: "has a gradient or image in its colour chain",
+    many: "have a gradient or image in their colour chain",
   },
   "unresolved-colour": {
     one: "has a colour that does not resolve in every mode",
@@ -98,6 +103,7 @@ const SKIP_PHRASES: Record<SkipReason, { one: string; many: string }> = {
 const SKIP_PRECEDENCE: readonly SkipReason[] = [
   "mixed-fill",
   "no-fill",
+  "non-solid",
   "unresolved-colour",
   "no-background",
 ];
@@ -117,10 +123,16 @@ interface Candidate {
 /**
  * A colour resolved for one node in one mode. `undefined` means "this node
  * paints nothing" (a transparent ancestor, which the walk passes straight
- * through); `"unresolved"` means a source was found but could not be resolved,
- * which is a skip rather than a transparent layer.
+ * through). The two failures are kept apart because they are different defects
+ * to report: `"non-solid"` is a gradient or image, which has no single colour
+ * to measure, while `"unresolved"` is a variable or style that would not
+ * resolve.
  */
-type Resolved = { rgba: Rgba; label: string } | "unresolved" | undefined;
+type Resolved =
+  | { rgba: Rgba; label: string }
+  | "unresolved"
+  | "non-solid"
+  | undefined;
 
 /**
  * The two rendered pixels a contrast ratio is measured between: one where the
@@ -188,8 +200,8 @@ export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
         skip(node, "no-fill");
         break;
       }
-      if (own === "unresolved") {
-        skip(node, "unresolved-colour");
+      if (own === "non-solid" || own === "unresolved") {
+        skip(node, own === "non-solid" ? "non-solid" : "unresolved-colour");
         continue;
       }
 
@@ -203,8 +215,11 @@ export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
           : { hex: own.rgba.hex, alpha: own.rgba.alpha * selfOpacity };
 
       const rendered = render(candidate, start, mode, snapshot);
-      if (rendered === "unresolved") {
-        skip(node, "unresolved-colour");
+      if (rendered === "non-solid" || rendered === "unresolved") {
+        skip(
+          node,
+          rendered === "non-solid" ? "non-solid" : "unresolved-colour",
+        );
         continue;
       }
       if (rendered === undefined) {
@@ -352,7 +367,7 @@ function resolveColor(
 
   for (const paint of paints) {
     if (!paint.visible) continue;
-    if (paint.type !== "SOLID") return "unresolved";
+    if (paint.type !== "SOLID") return "non-solid";
 
     let hex = paint.hex;
     let alpha = paint.opacity;
@@ -414,7 +429,7 @@ function render(
   own: Rgba,
   mode: Mode,
   snapshot: ComponentSetSnapshot,
-): Rendered | "unresolved" | undefined {
+): Rendered | "unresolved" | "non-solid" | undefined {
   let text = own;
   let background: Rgba | undefined;
   /** The nearest ancestor fill that contributed, for naming the pair. */
@@ -429,17 +444,29 @@ function render(
   // costs nothing worth trading correctness for; past an opaque surface each
   // further `layer` is a no-op anyway.
   for (const ancestor of candidate.ancestors) {
-    const resolved = resolveColor(ancestor, mode, snapshot);
-    if (resolved === "unresolved") return "unresolved";
+    // A fill sitting entirely behind an already-opaque composite contributes
+    // nothing, so it is not resolved at all. That is not just an optimisation:
+    // an opaque card over a frame carrying a hero image would otherwise report
+    // "gradient or image, cannot measure" for a pairing that is in fact
+    // perfectly well defined. Group opacity below still applies - if it fades
+    // the composite back below opacity, the next ancestor's fill *is* resolved,
+    // and an image there genuinely does make the pair unmeasurable.
+    const hidden = background !== undefined && background.alpha >= OPAQUE;
 
-    // A node with no fill of its own still forms a group, so its opacity
-    // applies even though it contributes no colour.
-    if (resolved !== undefined) {
-      text = layer(text, resolved.rgba);
-      background = background
-        ? layer(background, resolved.rgba)
-        : resolved.rgba;
-      if (nearest === undefined) nearest = resolved;
+    if (!hidden) {
+      const resolved = resolveColor(ancestor, mode, snapshot);
+      if (resolved === "non-solid") return "non-solid";
+      if (resolved === "unresolved") return "unresolved";
+
+      // A node with no fill of its own still forms a group, so its opacity
+      // applies even though it contributes no colour.
+      if (resolved !== undefined) {
+        text = layer(text, resolved.rgba);
+        background = background
+          ? layer(background, resolved.rgba)
+          : resolved.rgba;
+        if (nearest === undefined) nearest = resolved;
+      }
     }
 
     const groupOpacity = ancestor.opacity ?? 1;

--- a/src/plugins/qa/checks/index.test.ts
+++ b/src/plugins/qa/checks/index.test.ts
@@ -36,12 +36,13 @@ const FIXTURE: ComponentSetSnapshot = {
 
 describe("check catalogue", () => {
   it("lists the 9 Tier 1 checks plus the Tier 2 checks, with unique ids", () => {
-    expect(CHECKS).toHaveLength(12);
-    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(12);
+    expect(CHECKS).toHaveLength(13);
+    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(13);
     // The static Tier 1 PRD sections (issue #76), then Tier 2 appended in
-    // shipping order: #14 (issue #99), #8 (issue #101), #17 (issue #102).
+    // shipping order: #14 (issue #99), #8 (issue #101), #17 (issue #102),
+    // #16 (issue #103).
     expect(CHECKS.map((c) => c.prdSection)).toEqual([
-      2, 4, 5, 9, 10, 11, 12, 13, 15, 14, 8, 17,
+      2, 4, 5, 9, 10, 11, 12, 13, 15, 14, 8, 17, 16,
     ]);
   });
 

--- a/src/plugins/qa/checks/index.ts
+++ b/src/plugins/qa/checks/index.ts
@@ -20,6 +20,7 @@ import { checkLayerNamingStructure } from "./layer-naming-structure";
 import { checkNestingDepth } from "./nesting-depth";
 import { checkAssetProvenance } from "./asset-provenance";
 import { checkThemes } from "./themes";
+import { checkHighContrast } from "./high-contrast";
 
 export type CheckFn = (snapshot: ComponentSetSnapshot) => CheckResult;
 
@@ -41,6 +42,7 @@ export const CHECK_REGISTRY: Partial<Record<CheckId, CheckFn>> = {
   "nesting-depth": checkNestingDepth,
   "asset-provenance": checkAssetProvenance,
   themes: checkThemes,
+  "high-contrast": checkHighContrast,
 };
 
 export interface RunOutcome {

--- a/src/plugins/qa/checks/themes.test.ts
+++ b/src/plugins/qa/checks/themes.test.ts
@@ -217,7 +217,7 @@ describe("checkThemes", () => {
     expect(result.findings[0].count).toBe(2);
   });
 
-  it("ignores variables the set does not actually use", () => {
+  it("reports nothing to judge when the table holds no variable the set binds", () => {
     // The probe may resolve a variable that only a style references; without a
     // usage in this set there is nothing to report against.
     const result = checkThemes(
@@ -237,7 +237,11 @@ describe("checkThemes", () => {
         }),
       ),
     );
-    expect(result.status).toBe("pass");
+    // The probe also resolves variables reached only through a shared fill
+    // style (for #16), so an unused entry must not be judged - and must not
+    // produce a `pass` either, which would claim a verification that never
+    // happened.
+    expect(result.status).toBe("not_applicable");
     expect(result.findings).toEqual([]);
   });
 

--- a/src/plugins/qa/checks/themes.ts
+++ b/src/plugins/qa/checks/themes.ts
@@ -45,12 +45,26 @@ export function checkThemes(snapshot: ComponentSetSnapshot): CheckResult {
   const theme = snapshot.theme;
 
   const unavailable = theme?.unavailableVariableIds ?? [];
+  const usage = collectVariableUsage(snapshot);
 
   // No probe table (no bound variables), or a single-mode collection, which is
   // not a theme: comparing one mode against itself reports nothing meaningful.
   // Bindings Figma could not load are the exception, since those are broken
   // regardless of how many modes exist.
-  if (!theme || (theme.modes.length < 2 && unavailable.length === 0)) {
+  //
+  // The table can also exist while holding nothing this set binds: #16 has the
+  // probe resolve variables reached only through a shared fill style. Those are
+  // not this component's bindings, so a set whose colour comes entirely from
+  // styles has nothing for *this* check to judge - reporting `pass` off the
+  // back of them would claim a verification that never happened.
+  const consumed = [...usage.keys()].some(
+    (id) => theme?.variables[id] !== undefined,
+  );
+  if (
+    !theme ||
+    (theme.modes.length < 2 && unavailable.length === 0) ||
+    (!consumed && unavailable.length === 0)
+  ) {
     return {
       checkId: "themes",
       title: TITLE,
@@ -59,7 +73,6 @@ export function checkThemes(snapshot: ComponentSetSnapshot): CheckResult {
     };
   }
 
-  const usage = collectVariableUsage(snapshot);
   const findings: Finding[] = [];
 
   // Reported once per variable rather than once per mode: a binding that cannot

--- a/src/plugins/qa/collector.ts
+++ b/src/plugins/qa/collector.ts
@@ -12,6 +12,7 @@
 
 import { toHex } from "./color";
 import type {
+  ColorStyleSnapshot,
   ComponentPropertySnapshot,
   PinnedAncestorSnapshot,
   ComponentSetSnapshot,
@@ -53,6 +54,30 @@ function snapshotPaints(
 
 function styleId(value: string | typeof figma.mixed): string {
   return value === figma.mixed ? "MIXED" : value;
+}
+
+/**
+ * Font size and boldness for #16's dual AA threshold.
+ *
+ * Ranges that differ are resolved to the **strictest** applicable answer: the
+ * smallest size used, and bold only when every range is bold. Both defaults run
+ * toward 4.5:1 rather than 3:1, so a mixed run can never be let off with the
+ * lenient large-text threshold on the strength of one heading inside it.
+ */
+function snapshotTextMetrics(node: TextNode): {
+  fontSize?: number;
+  bold: boolean;
+} {
+  const BOLD_WEIGHT = 700;
+  if (node.fontSize !== figma.mixed && node.fontWeight !== figma.mixed) {
+    return { fontSize: node.fontSize, bold: node.fontWeight >= BOLD_WEIGHT };
+  }
+  const segments = node.getStyledTextSegments(["fontSize", "fontWeight"]);
+  if (segments.length === 0) return { bold: false };
+  return {
+    fontSize: Math.min(...segments.map((s) => s.fontSize)),
+    bold: segments.every((s) => s.fontWeight >= BOLD_WEIGHT),
+  };
 }
 
 /**
@@ -140,9 +165,19 @@ function snapshotNode(node: SceneNode): NodeSnapshot {
     snap.children = node.children.map(snapshotNode);
   }
 
+  // Only when it is not 1, so fixtures and payloads stay terse. #16 composites
+  // this with paint opacity to measure contrast on translucent surfaces.
+  if ("opacity" in node && node.opacity !== 1) {
+    snap.opacity = node.opacity;
+  }
+
   if ("fills" in node) {
     const fills = snapshotPaints(node.fills);
     if (fills) snap.fills = fills;
+    // Recorded explicitly rather than left as an absent `fills`: #16 has to
+    // tell "mixed per character range, decline to measure" apart from "this
+    // node paints nothing".
+    else if (node.fills === figma.mixed) snap.fillsMixed = true;
     snap.fillStyleId = styleId(node.fillStyleId);
   }
   if ("strokes" in node) {
@@ -151,6 +186,9 @@ function snapshotNode(node: SceneNode): NodeSnapshot {
   }
   if (node.type === "TEXT") {
     snap.textStyleId = styleId(node.textStyleId);
+    const metrics = snapshotTextMetrics(node);
+    if (metrics.fontSize !== undefined) snap.fontSize = metrics.fontSize;
+    if (metrics.bold) snap.bold = true;
   }
   if ("effects" in node) {
     snap.effectCount = node.effects.length;
@@ -283,4 +321,50 @@ export function collectSnapshot(
     variants,
     ...(pinnedAncestors.length > 0 ? { pinnedAncestors } : {}),
   };
+}
+
+/** Every distinct, resolvable fill style id referenced in the snapshot. */
+function referencedFillStyleIds(snapshot: ComponentSetSnapshot): string[] {
+  const ids = new Set<string>();
+  const visit = (node: NodeSnapshot) => {
+    const id = node.fillStyleId;
+    // "" means unstyled and "MIXED" is not an id at all.
+    if (id && id !== "MIXED") ids.add(id);
+    for (const child of node.children) visit(child);
+  };
+  for (const variant of snapshot.variants) visit(variant.tree);
+  return [...ids];
+}
+
+/**
+ * Resolve the fill styles the set references into the snapshot's style table
+ * (#16, issue #103). A separate async pass rather than part of `collectSnapshot`
+ * so that stays synchronous, and memoized by style id so cost scales with
+ * distinct styles rather than with layers.
+ *
+ * Why the table exists at all when Figma keeps `node.fills` in sync with the
+ * style: the **name**. A contrast finding that says `"Text/Subtle" on
+ * "Surface/Card"` names the one token pair a designer changes, where a pair of
+ * hex values names nothing. The paints are captured too, so a style whose paint
+ * is variable-bound feeds the id straight into the per-mode probe.
+ *
+ * Reads only - no document mutation, so no ADR-0001 carve-out is involved here.
+ */
+export async function collectColorStyles(
+  snapshot: ComponentSetSnapshot,
+): Promise<Record<string, ColorStyleSnapshot> | undefined> {
+  const ids = referencedFillStyleIds(snapshot);
+  if (ids.length === 0) return undefined;
+
+  const styles: Record<string, ColorStyleSnapshot> = {};
+  for (const id of ids) {
+    const style = await figma.getStyleByIdAsync(id);
+    // A style that cannot be loaded (deleted, or a remote library that is
+    // unavailable) is simply left out: #16 then falls back to the node's own
+    // fills, losing the name but not the colour.
+    if (!style || style.type !== "PAINT") continue;
+    const paints = snapshotPaints((style as PaintStyle).paints);
+    if (paints) styles[id] = { name: style.name, paints };
+  }
+  return Object.keys(styles).length > 0 ? styles : undefined;
 }

--- a/src/plugins/qa/contrast.test.ts
+++ b/src/plugins/qa/contrast.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { contrastRatio, layer, requiredRatio } from "./contrast";
+
+describe("contrastRatio", () => {
+  it("is 21 for black on white", () => {
+    expect(contrastRatio("#000000", "#FFFFFF")).toBeCloseTo(21, 2);
+  });
+
+  it("is 1 for a colour against itself - the invisible-text extreme", () => {
+    expect(contrastRatio("#3366FF", "#3366FF")).toBeCloseTo(1, 5);
+  });
+
+  it("is symmetric", () => {
+    expect(contrastRatio("#767676", "#FFFFFF")).toBeCloseTo(
+      contrastRatio("#FFFFFF", "#767676"),
+      6,
+    );
+  });
+
+  it("matches the known WCAG boundary case #767676 on white", () => {
+    // The canonical "smallest grey that passes AA on white" - 4.54:1.
+    expect(contrastRatio("#767676", "#FFFFFF")).toBeCloseTo(4.54, 2);
+  });
+
+  it("is case-insensitive about hex digits", () => {
+    expect(contrastRatio("#aabbcc", "#FFFFFF")).toBeCloseTo(
+      contrastRatio("#AABBCC", "#FFFFFF"),
+      6,
+    );
+  });
+});
+
+describe("layer", () => {
+  const opaque = (hex: string) => ({ hex, alpha: 1 });
+
+  it("returns the top colour unchanged when it is opaque", () => {
+    expect(layer(opaque("#123456"), opaque("#FFFFFF"))).toEqual({
+      hex: "#123456",
+      alpha: 1,
+    });
+  });
+
+  it("returns the bottom colour when the top is fully transparent", () => {
+    expect(layer({ hex: "#123456", alpha: 0 }, opaque("#FFFFFF"))).toEqual({
+      hex: "#FFFFFF",
+      alpha: 1,
+    });
+  });
+
+  it("blends in sRGB space at 50%", () => {
+    // Figma composites in sRGB, so half black over white is #808080 (128),
+    // not the perceptual midpoint.
+    expect(layer({ hex: "#000000", alpha: 0.5 }, opaque("#FFFFFF"))).toEqual({
+      hex: "#808080",
+      alpha: 1,
+    });
+  });
+
+  it("accumulates alpha over a translucent backdrop without reaching opacity", () => {
+    // Two 50% layers cover 75%, still short of opaque - which is what tells the
+    // caller to keep walking up for another ancestor.
+    const result = layer(
+      { hex: "#000000", alpha: 0.5 },
+      { hex: "#000000", alpha: 0.5 },
+    );
+    expect(result.alpha).toBeCloseTo(0.75, 6);
+    expect(result.hex).toBe("#000000");
+  });
+
+  it("stays fully transparent when both layers are", () => {
+    const result = layer(
+      { hex: "#123456", alpha: 0 },
+      { hex: "#FFFFFF", alpha: 0 },
+    );
+    expect(result.alpha).toBe(0);
+  });
+});
+
+describe("requiredRatio", () => {
+  it("demands 4.5 for normal body text", () => {
+    expect(requiredRatio(16, false)).toBe(4.5);
+  });
+
+  it("demands 3 at 24px and above", () => {
+    expect(requiredRatio(24, false)).toBe(3);
+    expect(requiredRatio(32, false)).toBe(3);
+  });
+
+  it("demands 3 from 18.66px when bold", () => {
+    expect(requiredRatio(18.66, true)).toBe(3);
+    expect(requiredRatio(19, true)).toBe(3);
+  });
+
+  it("still demands 4.5 below 18.66px even when bold", () => {
+    expect(requiredRatio(18, true)).toBe(4.5);
+  });
+
+  it("demands 4.5 when the size is unknown - the stricter default", () => {
+    expect(requiredRatio(undefined, false)).toBe(4.5);
+  });
+});

--- a/src/plugins/qa/contrast.ts
+++ b/src/plugins/qa/contrast.ts
@@ -1,0 +1,130 @@
+/**
+ * WCAG contrast maths for #16 (issue #103). Pure, hex in / number out, so the
+ * whole of it is fixture-testable without the Figma API.
+ *
+ * Alpha compositing lives here rather than in the check because it is the same
+ * kind of thing: colour arithmetic with one correct answer. Figma composites in
+ * sRGB space (not linear light), so `compositeOver` interpolates the encoded
+ * channels - half black over white is #808080, which is what the file actually
+ * shows.
+ */
+
+/** WCAG AA for normal text. */
+const AA_NORMAL = 4.5;
+/** WCAG AA for large text. */
+const AA_LARGE = 3;
+/** "Large" in WCAG terms: 18pt, i.e. 24px. */
+const LARGE_PX = 24;
+/** "Large" for bold text: 14pt, i.e. 18.66px. */
+const LARGE_BOLD_PX = 18.66;
+
+interface Channels {
+  r: number;
+  g: number;
+  b: number;
+}
+
+/** Parse `#RRGGBB` into 0-255 channels. Returns null for anything malformed. */
+function parseHex(hex: string): Channels | null {
+  const match = /^#?([0-9a-f]{6})$/i.exec(hex.trim());
+  if (!match) return null;
+  const value = parseInt(match[1], 16);
+  return {
+    r: (value >> 16) & 0xff,
+    g: (value >> 8) & 0xff,
+    b: value & 0xff,
+  };
+}
+
+function toHexChannels({ r, g, b }: Channels): string {
+  const channel = (v: number) =>
+    Math.round(v).toString(16).padStart(2, "0").toUpperCase();
+  return `#${channel(r)}${channel(g)}${channel(b)}`;
+}
+
+/** WCAG relative luminance from 0-255 sRGB channels. */
+function relativeLuminance({ r, g, b }: Channels): number {
+  const linear = (v: number) => {
+    const c = v / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+/**
+ * WCAG contrast ratio between two opaque colours, 1 to 21.
+ *
+ * Both arguments must already be composited to opacity - a translucent colour
+ * has no contrast ratio of its own, only one against whatever shows through.
+ * Returns 1 (the no-contrast extreme, which #16 reports) if either hex is
+ * unparseable, so a malformed value can never read as a pass.
+ */
+export function contrastRatio(a: string, b: string): number {
+  const first = parseHex(a);
+  const second = parseHex(b);
+  if (!first || !second) return 1;
+  const lighter = Math.max(relativeLuminance(first), relativeLuminance(second));
+  const darker = Math.min(relativeLuminance(first), relativeLuminance(second));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** A colour with the alpha it is drawn at. */
+export interface Rgba {
+  hex: string;
+  /** 0-1, already including paint opacity and every enclosing node's opacity. */
+  alpha: number;
+}
+
+function clamp01(v: number): number {
+  return Math.min(1, Math.max(0, v));
+}
+
+/**
+ * Source-over compositing: `top` drawn onto `bottom`.
+ *
+ * The general (translucent-backdrop) form, not just blend-onto-opaque, because
+ * both places that need it stack an unknown number of translucent layers: the
+ * paint stack on one node, and the chain of ancestor backgrounds behind a text
+ * layer. Having one primitive for both means the walk outward is a fold - keep
+ * layering until the result is opaque, then stop.
+ */
+export function layer(top: Rgba, bottom: Rgba): Rgba {
+  const fg = parseHex(top.hex);
+  const bg = parseHex(bottom.hex);
+  const ta = clamp01(top.alpha);
+  const ba = clamp01(bottom.alpha);
+  if (!fg || !bg) return top;
+
+  const alpha = ta + ba * (1 - ta);
+  // A fully transparent result has no colour of its own; keeping the top hex
+  // avoids a division by zero and never reaches a ratio, since the caller only
+  // measures once alpha is 1.
+  if (alpha === 0) return { hex: top.hex, alpha: 0 };
+
+  const mix = (t: number, b: number) => (t * ta + b * ba * (1 - ta)) / alpha;
+  return {
+    hex: toHexChannels({
+      r: mix(fg.r, bg.r),
+      g: mix(fg.g, bg.g),
+      b: mix(fg.b, bg.b),
+    }),
+    alpha,
+  };
+}
+
+/**
+ * The AA ratio this text has to clear: 3:1 for large text, 4.5:1 otherwise.
+ *
+ * An unknown size falls to 4.5:1 deliberately - the stricter threshold is the
+ * safe default, since granting large-text leniency on a guess would let real
+ * failures through.
+ */
+export function requiredRatio(
+  fontSize: number | undefined,
+  bold: boolean,
+): number {
+  if (fontSize === undefined) return AA_NORMAL;
+  if (fontSize >= LARGE_PX) return AA_LARGE;
+  if (bold && fontSize >= LARGE_BOLD_PX) return AA_LARGE;
+  return AA_NORMAL;
+}

--- a/src/plugins/qa/contrast.ts
+++ b/src/plugins/qa/contrast.ts
@@ -10,7 +10,7 @@
  */
 
 /** WCAG AA for normal text. */
-const AA_NORMAL = 4.5;
+export const AA_NORMAL = 4.5;
 /** WCAG AA for large text. */
 const AA_LARGE = 3;
 /** "Large" in WCAG terms: 18pt, i.e. 24px. */

--- a/src/plugins/qa/operations.ts
+++ b/src/plugins/qa/operations.ts
@@ -4,12 +4,12 @@
 //
 // Single agent-facing surface: `tidy_qa_run`. Returns structured CheckResults
 // plus a 19-item ChecklistReport (PRD catalogue merge). The checks never touch
-// the component set; the one document write in a run is the #17 themes probe's
-// temporary frame (see theme-probe.ts and the ADR-0001 carve-out).
+// the component set; the one document write in a run is the per-mode resolution
+// probe's temporary frame (see theme-probe.ts and the ADR-0001 carve-out).
 
 import { ErrorCode, OperationError } from "../../shared/operations/errors";
 import { registerOperation } from "../../shared/operations/registry";
-import { collectSnapshot } from "./collector";
+import { collectColorStyles, collectSnapshot } from "./collector";
 import { runChecks, unknownCheckIds } from "./checks";
 import { buildChecklistReport } from "./report";
 import { probeThemeResolution } from "./theme-probe";
@@ -185,11 +185,20 @@ async function runQa(params: QaRunParams): Promise<{
   const { subject, origin } = await resolveTarget(params);
   const snapshot = collectSnapshot(subject);
 
-  // The #17 per-mode resolution probe is the one part of a QA run that touches
-  // the document (one temporary frame, removed in a `finally` - see
-  // theme-probe.ts and the ADR-0001 carve-out). Skipped entirely unless the
-  // themes check is actually going to run, so a filtered run stays inert.
-  if (willRun(params.checks, "themes")) {
+  // #16 resolves colours through paint styles as well as variables, since the
+  // `tokens` check accepts either. Resolved *before* the probe, deliberately: a
+  // style's paint can itself be variable-bound, and the probe reads the style
+  // table to decide which variables need a per-mode value.
+  const needsColour = willRun(params.checks, "high-contrast");
+  if (needsColour) {
+    snapshot.colorStyles = await collectColorStyles(snapshot);
+  }
+
+  // The per-mode resolution probe is the one part of a QA run that touches the
+  // document (one temporary frame, removed in a `finally` - see theme-probe.ts
+  // and the ADR-0001 carve-out). Skipped entirely unless a check that needs it
+  // is actually going to run, so a filtered run stays inert.
+  if (willRun(params.checks, "themes") || needsColour) {
     snapshot.theme = await probeThemeResolution(snapshot);
   }
 
@@ -219,7 +228,7 @@ registerOperation<QaRunParams, QaRunResult>(
     kind: "query",
     module: "qa",
     summary:
-      "Run the DS Component QA checklist against a component set. Target by nodeId or name/glob, or omit both to use the current selection. Returns CheckResults plus a 19-item checklist model. Read-only toward the target: it never modifies the component set. The themes check (#17) creates and removes one temporary off-canvas probe frame to resolve variables per theme mode - a documented carve-out from ADR-0001's read-only Query definition.",
+      "Run the DS Component QA checklist against a component set. Target by nodeId or name/glob, or omit both to use the current selection. Returns CheckResults plus a 19-item checklist model. Read-only toward the target: it never modifies the component set. The themes (#17) and high-contrast (#16) checks create and remove one temporary off-canvas probe frame to resolve variables per theme mode - a documented carve-out from ADR-0001's read-only Query definition.",
     paramsExample: { name: "Button" },
   },
   async (params) => {

--- a/src/plugins/qa/snapshot.ts
+++ b/src/plugins/qa/snapshot.ts
@@ -45,6 +45,15 @@ export interface NodeSnapshot {
   visible: boolean;
   width: number;
   height: number;
+  /**
+   * Node-level opacity, 0-1 (#16). Recorded only when it is not 1, so
+   * fixtures stay terse; absent means fully opaque.
+   *
+   * Separate from `PaintSnapshot.opacity`, and both apply: a 50% fill on a
+   * 50% frame is 25% of the surface behind it. #16 has to composite them to
+   * measure contrast on a DS that uses opacity in place of absolute hex.
+   */
+  opacity?: number;
 
   /**
    * Child trees. Empty for INSTANCE nodes by design — nested instance
@@ -103,6 +112,26 @@ export interface NodeSnapshot {
   strokeStyleId?: string;
   /** TEXT nodes: style id, "" when unstyled, "MIXED" for mixed ranges. */
   textStyleId?: string;
+  /**
+   * TEXT nodes: the fills differ per character range (#16). `fills` is absent
+   * in that case, and absent-because-mixed has to be told apart from
+   * absent-because-this-node-has-no-fills: picking "the first fill" of a
+   * mixed run would be a confidently wrong contrast answer, so #16 declines to
+   * evaluate the layer and counts it in the skipped tally instead.
+   */
+  fillsMixed?: boolean;
+  /**
+   * TEXT nodes: font size in px (#16 threshold). When ranges differ this is
+   * the **smallest** size used - the strictest applicable threshold, so a
+   * mixed run is judged on its worst case rather than on its heading.
+   */
+  fontSize?: number;
+  /**
+   * TEXT nodes: whether the text is bold, i.e. font weight >= 700 (#16).
+   * True only when *every* range is bold: the large-text threshold (3:1) is the
+   * lenient one, so a partially-bold run must not qualify for it.
+   */
+  bold?: boolean;
   effectCount?: number;
   effectStyleId?: string;
 
@@ -246,6 +275,26 @@ export interface ThemeSnapshot {
   unavailableVariableIds?: string[];
 }
 
+/**
+ * A paint style the set references, resolved once (#16).
+ *
+ * The `tokens` check accepts either a bound variable **or** a style, so both
+ * are live colour sources in real files. Resolving variables only would leave
+ * most contrast rows "not evaluated" for an implementation-detail reason, and
+ * an unevaluated contrast check is worse than none because the row still looks
+ * checked.
+ *
+ * A style's paint can itself be variable-bound, in which case its
+ * `boundVariableId` points into the per-mode table above - which is why the
+ * style table is resolved *before* the probe runs, so those variables are
+ * resolved per mode too.
+ */
+export interface ColorStyleSnapshot {
+  /** Style name, e.g. "Surface/Default" - preferred over hex in findings. */
+  name: string;
+  paints: PaintSnapshot[];
+}
+
 export interface ComponentSetSnapshot {
   id: string;
   name: string;
@@ -263,4 +312,10 @@ export interface ComponentSetSnapshot {
   pinnedAncestors?: PinnedAncestorSnapshot[];
   /** Per-mode variable resolution (#17). Absent when the probe didn't run. */
   theme?: ThemeSnapshot;
+  /**
+   * Fill styles referenced anywhere in the set, keyed by style id (#16).
+   * Memoized by the collector, so cost scales with distinct styles rather than
+   * with layers. Absent when the set references no fill styles.
+   */
+  colorStyles?: Record<string, ColorStyleSnapshot>;
 }

--- a/src/plugins/qa/theme-probe.ts
+++ b/src/plugins/qa/theme-probe.ts
@@ -30,7 +30,7 @@
  */
 
 import { toHex } from "./color";
-import { collectVariableUsage } from "./variable-usage";
+import { collectVariableUsage, colorStyleVariableIds } from "./variable-usage";
 import { selectPrimaryCollection } from "../../shared/theme-collection";
 import type { ModeCollectionFact } from "../../shared/theme-collection";
 import type {
@@ -64,18 +64,25 @@ export async function probeThemeResolution(
 ): Promise<ThemeSnapshot | undefined> {
   // Same traversal the check uses, so the two cannot disagree about which
   // variables the set consumes.
-  const variableIds = [...collectVariableUsage(snapshot).keys()];
-  if (variableIds.length === 0) return undefined;
+  const boundIds = [...collectVariableUsage(snapshot).keys()];
+  // Variables reached only through a fill style the set applies. Resolved
+  // alongside the rest because #16 needs their per-mode colour, but kept apart
+  // below: a style's broken binding is not a defect of the component that
+  // applied the style, so it must not become one of #17's findings.
+  const styleIds = colorStyleVariableIds(snapshot).filter(
+    (id) => !boundIds.includes(id),
+  );
+  if (boundIds.length === 0 && styleIds.length === 0) return undefined;
 
   // Memoized by id, so cost scales with unique ids rather than node count.
   const variables = new Map<string, Variable>();
   const unavailable: string[] = [];
-  for (const id of variableIds) {
+  for (const id of [...boundIds, ...styleIds]) {
     if (variables.has(id)) continue;
     const variable = await figma.variables.getVariableByIdAsync(id);
     if (variable) {
       variables.set(id, variable);
-    } else {
+    } else if (!styleIds.includes(id)) {
       // A binding Figma cannot load: a deleted variable, or a remote one whose
       // library is unavailable. That is precisely the broken-chain case #17
       // exists to catch, so the id is kept for the check to fail on.
@@ -90,8 +97,19 @@ export async function probeThemeResolution(
       : undefined;
   }
 
+  // Which collection counts as "the theme" is decided from the set's *own*
+  // bindings, never from variables reached through a style. Otherwise the answer
+  // would depend on which checks were requested: a `checks: ["themes"]` run
+  // resolves no style variables and could pick a different collection than a
+  // full run, leaving the two disagreeing about the same component. Style
+  // variables are only a fallback for a set that binds nothing directly, where
+  // no themes-only run has an answer to disagree with.
+  const decidingIds = boundIds.length > 0 ? boundIds : styleIds;
+  const deciding = new Set(decidingIds);
+
   const collections = new Map<string, VariableCollection>();
-  for (const variable of variables.values()) {
+  for (const [id, variable] of variables) {
+    if (!deciding.has(id)) continue;
     const collectionId = variable.variableCollectionId;
     if (collections.has(collectionId)) continue;
     const collection =

--- a/src/plugins/qa/theme-probe.ts
+++ b/src/plugins/qa/theme-probe.ts
@@ -89,12 +89,18 @@ export async function probeThemeResolution(
       unavailable.push(id);
     }
   }
-  if (variables.size === 0) {
-    // Nothing resolvable means no bound collection to call "the theme", so the
-    // modes are unknown. The dead bindings are still reported.
-    return unavailable.length > 0
+  // No modes to evaluate against, but the dead bindings still have to reach the
+  // check: dropping them let a set with one broken binding report `pass` on the
+  // strength of its remaining healthy variables.
+  const withoutModes = (): ThemeSnapshot | undefined =>
+    unavailable.length > 0
       ? { modes: [], variables: {}, unavailableVariableIds: unavailable }
       : undefined;
+
+  if (variables.size === 0) {
+    // Nothing resolvable means no bound collection to call "the theme", so the
+    // modes are unknown.
+    return withoutModes();
   }
 
   // Which collection counts as "the theme" is decided from the set's *own*
@@ -104,8 +110,16 @@ export async function probeThemeResolution(
   // full run, leaving the two disagreeing about the same component. Style
   // variables are only a fallback for a set that binds nothing directly, where
   // no themes-only run has an answer to disagree with.
-  const decidingIds = boundIds.length > 0 ? boundIds : styleIds;
-  const deciding = new Set(decidingIds);
+  // Only ids that actually *resolved* can decide it. Filtering on the raw
+  // `boundIds` instead would let a set whose every direct binding is broken pick
+  // an empty collection list and bail out, throwing away both the dead bindings
+  // #17 must fail on and the perfectly good style colours #16 could have used.
+  const resolvedBound = boundIds.filter((id) => variables.has(id));
+  const deciding = new Set(
+    resolvedBound.length > 0
+      ? resolvedBound
+      : styleIds.filter((id) => variables.has(id)),
+  );
 
   const collections = new Map<string, VariableCollection>();
   for (const [id, variable] of variables) {
@@ -126,10 +140,10 @@ export async function probeThemeResolution(
   // Same helper the generated documentation pages use, so QA and the docs
   // cannot disagree about what "the theme" is.
   const primary = selectPrimaryCollection(facts);
-  if (!primary) return undefined;
+  if (!primary) return withoutModes();
 
   const themeCollection = collections.get(primary.id);
-  if (!themeCollection) return undefined;
+  if (!themeCollection) return withoutModes();
 
   const resolved: Record<string, VariableResolutionSnapshot> = {};
   for (const [id, variable] of variables) {

--- a/src/plugins/qa/types.ts
+++ b/src/plugins/qa/types.ts
@@ -24,7 +24,8 @@ export type CheckId =
   | "preferred-values"
   | "nesting-depth"
   | "asset-provenance"
-  | "themes";
+  | "themes"
+  | "high-contrast";
 
 export interface Finding {
   severity: SeverityLevel;
@@ -106,6 +107,11 @@ export const CHECKS: readonly CheckDefinition[] = [
     id: "themes",
     prdSection: 17,
     title: "Themes (per-mode variable resolution)",
+  },
+  {
+    id: "high-contrast",
+    prdSection: 16,
+    title: "High contrast (WCAG AA)",
   },
 ];
 

--- a/src/plugins/qa/variable-usage.test.ts
+++ b/src/plugins/qa/variable-usage.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { collectVariableUsage, nodesPinning } from "./variable-usage";
+import {
+  collectVariableUsage,
+  colorStyleVariableIds,
+  nodesPinning,
+} from "./variable-usage";
 import type { ComponentSetSnapshot, NodeSnapshot } from "./snapshot";
 
 let seq = 0;
@@ -88,6 +92,69 @@ describe("collectVariableUsage", () => {
     expect(usage.get("v-label")?.count).toBe(1);
     expect(usage.get("v-label")?.nodeId).toBe("1:0");
     expect(usage.get("v-label")?.nodeName).toBe("Button");
+  });
+});
+
+describe("colorStyleVariableIds", () => {
+  it("collects variables bound inside the set's fill styles, deduped", () => {
+    const ids = colorStyleVariableIds(
+      fixture([[node()]], {
+        colorStyles: {
+          "S:a": {
+            name: "Surface/Card",
+            paints: [
+              {
+                type: "SOLID",
+                visible: true,
+                opacity: 1,
+                hex: "#FFFFFF",
+                boundVariableId: "v-surface",
+              },
+            ],
+          },
+          "S:b": {
+            name: "Surface/Card Alt",
+            paints: [
+              {
+                type: "SOLID",
+                visible: true,
+                opacity: 1,
+                hex: "#FFFFFF",
+                boundVariableId: "v-surface",
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect(ids).toEqual(["v-surface"]);
+  });
+
+  it("stays separate from the usage counts a set is answerable for", () => {
+    // A variable reached only through a shared style has no binding layer, so
+    // #17 must not raise a finding against a component that merely applied the
+    // style - which is why these ids never enter collectVariableUsage.
+    const snapshot = fixture([[node()]], {
+      colorStyles: {
+        "S:a": {
+          name: "Surface/Card",
+          paints: [
+            {
+              type: "SOLID",
+              visible: true,
+              opacity: 1,
+              hex: "#FFFFFF",
+              boundVariableId: "v-surface",
+            },
+          ],
+        },
+      },
+    });
+    expect(collectVariableUsage(snapshot).has("v-surface")).toBe(false);
+  });
+
+  it("is empty when the set references no fill styles", () => {
+    expect(colorStyleVariableIds(fixture([[node()]]))).toEqual([]);
   });
 });
 

--- a/src/plugins/qa/variable-usage.ts
+++ b/src/plugins/qa/variable-usage.ts
@@ -64,6 +64,28 @@ export function collectVariableUsage(
 }
 
 /**
+ * Variable ids referenced by the paints of the set's fill styles (#16).
+ *
+ * Deliberately **not** part of `collectVariableUsage`: these are not usages the
+ * set is answerable for. #17 reports a broken binding against the layer that
+ * binds it, and a variable reached only through a shared style has no such
+ * layer. They are collected separately so the probe still resolves them per
+ * mode - #16 needs their per-mode colour - without turning them into findings
+ * on a component that merely applied a style.
+ */
+export function colorStyleVariableIds(
+  snapshot: ComponentSetSnapshot,
+): string[] {
+  const ids = new Set<string>();
+  for (const style of Object.values(snapshot.colorStyles ?? {})) {
+    for (const paint of style.paints) {
+      if (paint.boundVariableId) ids.add(paint.boundVariableId);
+    }
+  }
+  return [...ids];
+}
+
+/**
  * Nodes pinning an explicit mode **for `collectionId`**. Only that collection
  * matters: a node pinning a density or unit mode says nothing about whether the
  * theme resolved correctly, so counting it would raise the #17 caveat on


### PR DESCRIPTION
Closes #103

Checklist item 16 becomes the check `high-contrast`, computing WCAG AA per text layer **per theme mode** on top of the resolution tables #102 introduced.

## What it does

- **Never guesses the background.** It is the nearest ancestor with a visible solid fill, composited outward until the stack is opaque. A chain that never reaches opacity means the layer is *not evaluated* - not measured against an assumed white.
- **"Not evaluated" is reported.** Every skipped layer lands in one low-severity tally finding, and any skip makes the row `warn` rather than `pass`.
- **Alpha is composited, not skipped.** Paint opacity and node opacity both count, since this DS uses opacity in place of absolute hex.
- **Colours resolve** through hex, bound variable, paint style, and a paint style whose paint is variable-bound.
- **AA dual threshold**: 4.5:1, or 3:1 at >= 24px / >= 18.66px bold. Invisible text needs no special case - it arrives as the ratio-1.0 extreme.
- **Findings key on colour pair x mode** with occurrence counts, naming tokens over hex. Distinct pairs are never merged.

## Structure

- `src/plugins/qa/contrast.ts` - luminance, ratio, and a general source-over `layer()`. One primitive that both the paint stack on a node and the ancestor background chain fold over.
- `src/plugins/qa/checks/high-contrast.ts` - the pure check.
- Snapshot gains node `opacity`, `fillsMixed`, `fontSize`, `bold`; the collector gains a memoized fill-style table (`collectColorStyles`). `figma.*` still lives in exactly two files.
- Wired into both QA operations, the default check set, the MCP `checks` filter list, PRD section 16, the canvas mapping table, and the ADR-0001 carve-out (which now covers two checks).

## Two judgement calls

**`warn` for unevaluated layers.** The issue says "no warn tier", which I read as being about contrast *bands* - no AAA warn band. `warn` is used for layers that could not be measured, matching what #17 already does for pinned modes. Without it the skip tally disappears: `report.ts` drops findings on any row that is not warn/fail, so a passing row with 9 unmeasured layers would have rendered fully green. That is the "lies by omission" failure the issue calls out.

**Two changes outside this ticket's scope**, both needed to keep #17 honest now that the probe serves two checks:

- The probe resolves variables reached only through a fill style, but picks the theme collection from the set's own bindings alone. Otherwise the collection chosen would depend on which checks were requested, and `checks: ["themes"]` could disagree with a full run about the same component.
- The `themes` check reports `not_applicable` when the table holds no variable the set actually binds, instead of `pass`. One existing test asserted the old `pass`; passing on the strength of variables belonging to a shared style claims a verification that never happened.

## Verification

`npm run typecheck`, `npm run lint` (0 errors), `npm run test` (462 passing), `npm run build` all clean.

New tests cover every case the issue asked for: passing pair, failing pair, large text passing at 3:1 that fails at 4.5:1, the 18.66px bold boundary, transparent chain skipped, semi-transparent text composited, semi-transparent background composited, node opacity, invisible text at ratio 1.0, MIXED fill skipped, mixed skip reasons rolled into one tally, same pair across variants collapsing to one counted finding, distinct pairs never merged, per-mode failure naming the mode, token names preferred over hex, and colours resolved through a plain and a variable-bound paint style.

## Needs a manual check

- [ ] **Requires a plugin rebuild and reload in Figma** (`npm run build`, then re-run the plugin) - the check is new plugin-thread code. The MCP server needs rebuilding too for the updated `checks` filter description.
- [x] **A 64-variant set inside the 60s operation timeout - verified end to end.** A full 13-check `tidy_qa_run` against the real 64-variant `Button` (4 variants x 2 sizes x 8 states, `2625:10445`) returned in **under 5 seconds**, including `collectColorStyles`, the probe, and every other check. The pure check alone is ~18ms.
- [ ] **Row 16 on a canvas checklist** - that the two-line title, the finding lines and the caveat read well, and that the caveat is not overlong now that rows 8, 16 and 17 all carry one.
- [ ] **A real failing pair**, to confirm the token names it quotes are the ones a designer recognises.

## Known limitation

Text inside nested instances is invisible to this check, the same boundary #17 has: the snapshot stops at instance boundaries by design, so a composite reports only what its own layers show.




