### PR TITLE
feat(mcp): automate QA items 7 and 19, grounded in the source interview

### DIFF
--- a/claude-plugin/commands/tidy-qa.md
+++ b/claude-plugin/commands/tidy-qa.md
@@ -24,8 +24,8 @@ Split `$ARGUMENTS` on whitespace into tokens, then classify each:
   `set-name-casing`, `prop-order`, `tokens`, `layer-naming-structure`,
   `grid-4px`, `interaction-hover-only`, `description`, `no-conflicts`,
   `preferred-values`, `nesting-depth`, `asset-provenance`, `themes`,
-  `high-contrast`. Collect these into the `checks` array (a filter - only these
-  checks run).
+  `high-contrast`, `responsive-bounds`, `documentation`. Collect these into
+  the `checks` array (a filter - only these checks run).
 - **Id** — a token matching `^\d+:\d+$` (e.g. `2625:10445`). Use as `nodeId`.
 - **Target name / glob** — every remaining token. Join them with spaces (names
   can contain spaces, e.g. `Button Icon`) and pass as `name`. A `*` makes it a
@@ -73,10 +73,14 @@ and is **idempotent**: re-running for the same target replaces its prior frame
 rather than duplicating it.
 
 The response is a small stub only:
-`{ frameId, target: { id, name }, counts: { pass, warn, fail, manual, notImplemented } }`.
+`{ frameId, target: { id, name }, counts: { pass, warn, fail, manual, notImplemented, partial } }`.
+`partial` counts automated rows that still need a human tick because the check
+covers only part of the item (currently #7 and #19). Those rows are also counted
+by their own status, so report them as outstanding work even when `manual` is 0.
 Report it directly — do not invent findings detail that isn't in the stub;
 tell the user to look at the frame on canvas (e.g. "Checklist for Button: 4
-pass, 3 warn, 1 fail, 10 manual — see the frame next to it on canvas.").
+pass, 3 warn, 1 fail, 10 manual, 2 partly manual - see the frame next to it on
+canvas.").
 
 ## Presenting the result
 

--- a/docs/prd-automated-qa.md
+++ b/docs/prd-automated-qa.md
@@ -4,6 +4,12 @@
 
 This document outlines the functional and structural requirements for an automated Quality Assurance (QA) plugin/tool designed to validate design components within a Design System library. The requirements are derived directly from the standard **DS Component QA Checklist** and the specific implementation heuristics discussed between Engineering (Dima) and Design (Shani).
 
+> **Provenance.** That discussion is transcribed and annotated in [`qa-source-interview.md`](qa-source-interview.md).
+> This PRD was written from it, and in several places states the requirement more firmly or more broadly than design actually asked for.
+> **Where the two disagree, the source document wins.**
+> Items with a known gap carry a `**Source:**` note below.
+> The full list is in that document's [*Where the PRD over-reads the source*](qa-source-interview.md#where-the-prd-over-reads-the-source) table, along with cross-cutting requirements this PRD never captured (descriptive per-item output, per-project item suppression, stage-2 visual evidence, the hand-QA'd reference component).
+
 ---
 
 ## Technical Architecture & Core Logic
@@ -24,6 +30,13 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * If the component perfectly mirrors Storybook, the plugin passes it. If structural differences exist, the plugin checks for the presence of the note component detailing why changes were made (e.g., absolute hex colors replaced with opacities, removed properties).
 * *Output:* Flag a warning if structural variations are detected without an accompanying documentation note on the frame.
 
+> **Source:** the paragraph above overstates the ask on both counts.
+> Comparing against Storybook is explicitly *not* this item's check - *"that's not something we check at this point"*, *"not something I expect the plugin to do, just to see that such a note exists"* - and Storybook comparison is out of phase 1 entirely.
+> The check is therefore **unconditional presence of the deviation note**, not presence-when-variation-detected.
+> The note is also **not a named component** (*"no, it's just [an element]"*); the shared explanation box is a plausible guess that was flagged as uncertain, so how the note is identified is the open question for this item.
+> Roughly half of projects have no Storybook at all, so this row needs to be switchable off per project.
+> See [source notes, item 1](qa-source-interview.md#1-storybook-alignment--note).
+
 
 
 ### 2. Components Naming Dev Alignment
@@ -32,6 +45,12 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * **Automated Plugin Action:**
 * Validate that the top-level Component Set name follows strict developer casing standards (e.g., **PascalCase** like `Button` or `NotificationTag`).
 * Flag any generic, lowercase, or space-separated component master names.
+
+> **Source:** `Button` with a capital B was cited as an *example of matching dev*, not as a request for a PascalCase rule.
+> Casing is a proxy that happens to be checkable without dev input, which is what shipped as `set-name-casing`.
+> The PRD also drops **half the item**: every **prop name** must match dev too, since `Start Icon` could equally be `Left Icon` and dev has already chosen.
+> That half needs the same Storybook/dev source as item 1 and inherits its phase-1 exclusion.
+> See [source notes, item 2](qa-source-interview.md#2-components-naming-dev-alignment).
 
 
 
@@ -42,6 +61,14 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * **Text Stress Test:** Programmatically inject a long text string into text layers to verify that auto-layout wraps, hugs, or truncates appropriately without clipping or overlapping bounds.
 * **Property Override Check:** Verify asset inheritance. For instance, when an icon variant is toggled inside a button, the plugin validates that the icon's color property correctly inherits the button's text token color rather than breaking or displaying an unlinked raw state.
 
+> **Source:** the icon/text colour rule is not an example.
+> It is a **standing DS invariant**, and it is the live failure this item was demonstrated on, which makes it the obvious first target.
+> Design's words: *"the icon's colour is always the text colour. It's always like that. It's an exception if it's not"*.
+> Design volunteered that the plugin can't infer it, so it belongs in **configuration**.
+> Long text is the other named must-check.
+> Unspecified and blocking: what "breaks" means (clipping? overflow? zero size?), and the combinatorial cost of *"all combinations"* on a large set.
+> See [source notes, item 3](qa-source-interview.md#3-check-all-the-props).
+
 
 
 ### 4. Prop Names Aligned to Consolidated Catalogue
@@ -50,6 +77,12 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * **Automated Plugin Action:**
 * Audit the sequence and naming of properties inside the component configuration.
 * Ensure strict alignment with the global catalog order (e.g., `Size` must always appear first, followed by `Variant`, then `State`, then optional boolean switches like `Has Icon`).
+
+> **Source:** the order is **not global**.
+> It is consistent *within a project*, and *"in each project they can decide on a slightly different order"*, so it has to be configurable.
+> Design works the same way everywhere in practice, so the shipped default is fine; a client insisting otherwise is the case to support.
+> This item is also *"not part of every QA"* - it was added for one project - which is another argument for the per-project suppression checkboxes.
+> See [source notes, item 4](qa-source-interview.md#4-prop-names-aligned-to-consolidated-catalogue).
 
 
 
@@ -72,6 +105,13 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * Locate matched pairs of desktop and mobile component sets on the canvas.
 * Verify that if a desktop component layer implements a certain typographic hierarchy (e.g., `Paragraph 2 Regular`), its corresponding mobile version automatically maps to the corresponding mobile typographic style (e.g., `Mobile/Paragraph 2 Regular`).
 
+> **Source:** the `Mobile/...` naming convention is **invented**; nothing in the call names one.
+> What was actually established: mobile is **always a separate component**, on the **same page**, so this check must *"review two components"* rather than one; and design was unsure the rule generalises at all (*"I just don't know if it's cross-cutting"*), while agreeing it definitely does on the dev side, where there is only one component.
+> Both unknowns are blocking: the **pairing rule** (which mobile set corresponds to which desktop set) and the **correspondence rule** (which mobile style answers a given desktop style) would each have to be configured or hand-seeded.
+> Framing worth keeping: the invariant is really **hierarchy**, and typography is just where it shows.
+> The failure it prevents is picking a level because of how it looks in one viewport rather than what it means.
+> See [source notes, item 6](qa-source-interview.md#6-typography-desktop--mobile-correlation).
+
 
 
 ### 7. Responsiveness (+ Min-Max Bounds)
@@ -81,6 +121,23 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * Simulate horizontal and vertical scaling on instances of the component.
 * Audit layout settings to ensure explicit `min-width`, `max-width`, `min-height`, or `max-height` constraints are populated where structurally required.
 * *Output:* Log a warning if a component collapses to 0px or lacks basic boundary parameters (e.g., *"Results: no min value found"*).
+
+> Shipped as check `responsive-bounds`: the **size-bounds half only**, and as advice rather than a defect.
+> Reports a component whose variant roots carry **none** of `minWidth`/`maxWidth`/`minHeight`/`maxHeight`, at `low` severity with status `warn`, since the requested output was literally *"note, there aren't any"*.
+>
+> Incompleteness is deliberately **not** reported.
+> Requiring all four bounds would put a finding on nearly every component, and a row that is always amber stops being read, which is the same reasoning behind #16's skip tally.
+> A component that sets any bound has been considered, so it passes, with the unset bounds named in `note` so the row stays descriptive without going red.
+>
+> One finding for the whole set with a `count`, not one per variant: variants share their bound configuration, so per-variant findings would repeat a single fact up to 64 times.
+>
+> Whether a root can hold bounds at all is decided by the **collector**, not by the root's own `layoutMode`.
+> Figma allows bounds on auto-layout frames *and their direct children*, so a `layoutMode: "NONE"` variant inside an auto-layout component set is a legitimate place for them; the collector records `boundsApplicable` because only it can see the parent.
+> A set where no root can carry bounds reports `not_applicable`.
+>
+> **Simulating resize is not attempted.**
+> "Doesn't break when resized" needs a definition of *breaks* and stays a human judgement, so the checklist row carries a `manualRemainder` and **keeps its tickbox alongside the status chip**.
+> A green chip here speaks only for the bounds; without the box it would stand for a resize test nobody performed.
 
 
 
@@ -111,6 +168,11 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * Verify they are legitimate library instances originating directly from the approved **Foundations Library**.
 * Flag copy-pasted raw vectors, unlinked SVG paths, or instances pointing to deprecated/legacy icon directories.
 
+> **Source:** design added one requirement unprompted.
+> **Which folder** assets must come from has to be **configurable**, because foundations folders go legacy and *"I want to make sure it isn't connected to legacy."*
+> She also put the raw-SVG case in perspective: it happens, but it's an anomaly (*"mostly it will be from the library"*), which is consistent with the shipped check being negative-detection-only.
+> See [source notes, item 8](qa-source-interview.md#8-icons--illustrations--logos-to-foundations).
+
 
 
 ### 9. Layer Naming + Structure
@@ -129,6 +191,13 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * Check all spatial dimensions: width, height, padding, item gaps, margins, and corner radiuses.
 * All absolute numerical values must be multiples of **4px** (with **2px** flags permitted strictly for micro-elements like borders or tight inline tags).
 * *Exception Logic:* Top-level container width/height bounds are exempt from absolute 4px matching *only* if their parameters are natively governed by "Hug contents" or "Fill container" constraints.
+
+> **Source:** the hug exemption is confirmed, and confirmed as being about the component's **own size** (text can be a little longer).
+> Two corrections.
+> 2px carries **no micro-element restriction** - *"spacing is always the 4 pixel grid, it can be 2. 2 is also fine, but apart from that it's always 4"*.
+> And **icon sizes** are missing from the PRD altogether: 16/24/32/48, plus 12, plus **14 sometimes**, which design suggested entering as a configured exception.
+> Everything here is advisory - *"it'll be a note with a recommendation, so if you think it's fine, it's fine."*
+> See [source notes, item 10](qa-source-interview.md#10-4px-grid-alignment).
 
 
 
@@ -149,6 +218,12 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * Read the Figma Component Description field.
 * Ensure it is populated and conforms to standard templates. It must include an **"Also known as:"** alias line (to aid designer search discovery) and documentation lookup keywords or links.
 
+> **Source:** the third element is specifically a **link to Storybook**; design corrected herself mid-sentence from "documentation" to "Storybook".
+> Since there usually is one and it's usually wanted, *"that can be the plugin's default."*
+> This is also the item she named as varying most from client to client, which is what prompted the hand-QA'd reference component idea.
+> Note the shipped `description` check does **not** verify the Storybook link, so this row is partially automated.
+> See [source notes, item 12](qa-source-interview.md#12-description-aka--misprint).
+
 
 
 ### 13. No Conflicts
@@ -157,6 +232,11 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * **Automated Plugin Action:**
 * Analyze the properties matrix of the entire component set.
 * Flag any duplicate variant definitions (e.g., accidentally configuring two distinct layout frames with the exact same properties such as `Size=Medium, Variant=Primary, State=Default`).
+
+> **Source:** "block compilation errors" oversells it.
+> Design's own verdict is *"this is pretty redundant"*, because Figma already surfaces conflicts natively in a component set.
+> It shipped on the grounds that automating it is free, not that it is valuable; worth knowing before defending the row.
+> See [source notes, item 13](qa-source-interview.md#13-no-conflicts).
 
 
 
@@ -171,6 +251,11 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * Evaluate the overall depth of the internal component layer architecture.
 * Count the total levels of nested component properties exposed to the parent panel. If property nesting depth exceeds a standard threshold (e.g., more than 2 deep), trigger an optimization suggestion to flatten or simplify the configuration.
 
+> **Source:** the threshold and the "recommend, don't fail" framing are design's own words (*"if there are more than two, maybe it recommends: note, this component is a bit too long, maybe consider reducing"*).
+> But she was counting **nested components** - the demo dropdown *"has two"* - not levels of property depth.
+> The motivation is symmetric: deep nesting hurts dev and design alike.
+> See [source notes, item 14](qa-source-interview.md#14-easy-to-use-nested-components).
+
 
 
 ### 15. Preferred (Instance Swapping)
@@ -179,6 +264,12 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * **Automated Plugin Action:**
 * For any exposed component instance swap property (such as an icon slot), check that **Preferred Values** are explicitly assigned.
 * For instance, a status tag component must limit its swappable icon property list to context-appropriate icons (e.g., checkmarks, error symbols, alerts) rather than exposing the entire global icon catalog.
+
+> **Source:** "must" is too strong.
+> This item is **optional and usually absent** - *"mostly it won't be there"*, *"it's not critical"* - and relevant mainly on components like status.
+> Design was unsure it was worth automating at all.
+> A failing row here should read as a suggestion, and an empty one as normal.
+> See [source notes, item 15](qa-source-interview.md#15-preferred-instance-swapping).
 
 
 
@@ -213,6 +304,12 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * Detect the background color token directly behind text layers inside the component variant frames.
 * Calculate the relative color contrast ratio between the text token and its immediate background layer to ensure compliance with WCAG AA guidelines.
 
+> **Source:** design's entire ask was *"just see that everything is readable."*
+> No standard, threshold, or methodology came from design.
+> WCAG AA, the dual thresholds, the background-compositing rules and the disabled-state exemption are all engineering decisions, which is why they carry their own rationale above.
+> Useful to know when a row is challenged: the *approach* is ours to revise, not a design requirement.
+> See [source notes, item 16](qa-source-interview.md#16-high-contrast-a11y).
+
 
 
 ### 17. Themes (Core / DNA / OldNews)
@@ -244,6 +341,13 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * **Automated Plugin Action:**
 * Verify the presentation canvas respects the official internal delivery template layout. Ensure structural headers, anatomy breakdowns, usage specs, and component frames are neatly sorted into their assigned regions.
 
+> **Source:** far lighter than this.
+> In full: the component page exists, there are **labels around the component**, and the page *"is arranged well."*
+> Headers, anatomy breakdowns, usage specs and assigned regions are all invented.
+> What "arranged well" means was never pinned down, so the tractable reading is **"are the expected labels present"**, which likely reduces to checking the `component-labels` module's output rather than matching a template.
+> Blocked on more than a definition, though: `ComponentSetSnapshot` stops at the component set and these labels are page siblings, so this is the first check that needs the collector's scope widened.
+> See [source notes, item 18](qa-source-interview.md#18-page-template).
+
 
 
 ### 19. Documentation
@@ -251,6 +355,22 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 * **Intent:** Confirm that no component ships to production without its corresponding implementation manual.
 * **Automated Plugin Action:**
 * Check for the presence of a dedicated text or linked reference block containing usage guidelines, code behavior expectations, and engineering specs. Components lacking a minimum threshold of instructional content will trigger a documentation warning flag.
+
+> Shipped as check `documentation`, and **deliberately unable to fail.**
+> Design's framing is that QA routinely runs *before* documentation exists, so an undocumented component is the normal mid-process state rather than a defect: a link present is `pass`, none is `not_applicable`.
+> Reporting absence as `warn` would make most runs amber for a non-problem.
+>
+> The signal is **Figma's own documentation-link field**, the only machine-readable "this is documented" marker the plugin API exposes.
+> Design described item 19 as a *stage*, not a field, so if their documentation lives elsewhere (a linked page; a Storybook URL in the description, which is #12's business) this check is looking in the wrong place.
+> Hence the `note` on both outcomes, so an empty row reads as "nothing found here" rather than as green.
+> **Worth confirming with design before treating the row as authoritative.**
+>
+> The row's blurb claims usage guidance, examples and properties are documented, which a link cannot establish, so a `pass` also emits a `manualRemainder` asking for the content review and **keeps the row's tickbox**.
+> Only on `pass`: with no documentation there is nothing to read, and asking for a review there would contradict treating absence as normal.
+>
+> **Source:** the "nothing ships without its manual" framing inverts the reality - *"many times we do QA before documentation, because it's often only a later stage."*
+> It is a yes/no item, with no "minimum threshold of instructional content" behind it.
+> See [source notes, item 19](qa-source-interview.md#19-documentation).
 
 
 Framelist design:

--- a/docs/prd-qa-canvas-checklist.md
+++ b/docs/prd-qa-canvas-checklist.md
@@ -4,6 +4,11 @@
 
 **Status:** proposed · **Tracking issue:** #90 · **Parent:** [`docs/prd-automated-qa.md`](prd-automated-qa.md) (the Tier-1 QA engine)
 
+> **Counts below are as-written (9 automated / 10 manual) and have since moved.**
+> Tier 2 added checks, and #7 and #19 landed after the source interview showed them to be narrow advisory checks.
+> The mapping table in §4 is kept current; for the live figure, `CHECKS` in [`src/plugins/qa/types.ts`](../src/plugins/qa/types.ts) is the source of truth.
+> Nothing else in this PRD's design depends on the number.
+
 ## 1. Summary
 
 Today `tidy_qa_run` (Tier 1, 9 checks) returns a large structured JSON report to
@@ -97,7 +102,7 @@ Three new pieces, plus one operation:
 | 4 | Prop Names Aligned to Catalogue | `prop-order` |
 | 5 | Tokens (Styles & Variables) | `tokens` |
 | 6 | Typography Desktop\|Mobile | manual |
-| 7 | Responsiveness (+ Min-Max) | manual |
+| 7 | Responsiveness (+ Min-Max) | `responsive-bounds` (bounds half only; row keeps a manual tick) |
 | 8 | Icons/Illustrations/Logos → Foundations | `asset-provenance` |
 | 9 | Layer Naming + Structure | `layer-naming-structure` |
 | 10 | 4px Grid Alignment | `grid-4px` |
@@ -109,7 +114,7 @@ Three new pieces, plus one operation:
 | 16 | High Contrast (A11y) | `high-contrast` |
 | 17 | Themes (Core/DNA/OldNews) | `themes` |
 | 18 | Page Template | manual |
-| 19 | Documentation | manual |
+| 19 | Documentation | `documentation` |
 
 ## 5. Operation contract
 
@@ -127,7 +132,7 @@ Three new pieces, plus one operation:
 
 **Returns (stub only)**
 ```
-{ frameId: string, target: { id, name }, counts: { pass, warn, fail, manual, notImplemented } }
+{ frameId: string, target: { id, name }, counts: { pass, warn, fail, manual, notImplemented, partial } }
 ```
 
 **Behaviour**
@@ -173,7 +178,13 @@ interface ChecklistReport {
   target: { id: string; name: string };
   generatedFor: { instanceId?: string };  // the instance the run started from
   items: ChecklistItem[];  // always 19, in PRD order
-  counts: Record<"pass" | "warn" | "fail" | "manual" | "notImplemented", number>;
+  // `partial` is an overlay, not a status: automated rows that still carry a
+  // manualRemainder. Counted in addition to their own status, so it is
+  // excluded from the sum to 19.
+  counts: Record<
+    "pass" | "warn" | "fail" | "manual" | "notImplemented" | "partial",
+    number
+  >;
 }
 ```
 

--- a/docs/qa-source-interview.md
+++ b/docs/qa-source-interview.md
@@ -1,0 +1,362 @@
+# QA checklist - source interview notes
+
+Primary-source record of the walkthrough call in which Shani Gurevich (design) took Dima (engineering) through the **DS Component QA Checklist** item by item, 2026-07-16.
+[`prd-automated-qa.md`](prd-automated-qa.md) was written _from_ this call; where the two disagree, **this document wins** and the PRD is wrong.
+
+Its purpose is to keep the design intent grounded when the checks get built and argued over.
+Several PRD items read as firmer, broader, or more machine-checkable than what was actually asked for.
+Those gaps are called out per item and collected in [§ Where the PRD over-reads the source](#where-the-prd-over-reads-the-source).
+
+Quotes are Shani's unless attributed to Dima, lightly trimmed for filler, with the Hebrew kept because the distinctions being drawn are often in the exact wording.
+
+---
+
+## Cross-cutting requirements
+
+These came up repeatedly and belong to no single item.
+None of them are in the PRD.
+
+### The QA workflow the artifact plugs into
+
+QA is done in a temporary section at the **end of the component's page**: one instance of the component, next to the checklist.
+It is ephemeral - _"it isn't kept; the moment QA is over it can be deleted, it can go to Archive."_
+Whoever runs QA goes over the list one item at a time, switching props by hand.
+
+This matches what [`prd-qa-canvas-checklist.md`](prd-qa-canvas-checklist.md) builds.
+Worth knowing that the frame is **disposable by design**: it does not need to survive, version, or reconcile with anything.
+
+### Output shape
+
+Shani's ask, in order of firmness:
+
+1. A **list with the title and the result** per item - _"איזה שהוא ליסט פשוט שיש בו את ה-title ו-and the result"_.
+2. The result must be **descriptive**, not just a tick.
+   In her words: _"descriptive שמסביר מה הוא מצא. מצא ש-note exist"_
+   Glossed: "descriptive, that explains what it found. Found that a note exists."
+3. Rendering it as the sticky-note artifact they already use is _convenient_ but not required, because they're used to it: _"לי זה נוח"_, "it's convenient for me".
+   And explicitly: _"זה לא חייב להיות פתק כזה."_
+4. A single big flag at the end is acceptable as well as, not instead of, the per-item results.
+
+Dima's argument for why descriptive matters, which she accepted: on an item like layer naming, a bare "no" leaves you re-checking everything yourself.
+
+### Stage 2: show the problem, don't just name it
+
+_"עוד רעיון מבחינת ה-output... נגיד יש לו בעיה עם ה-responsiveness - אז שיראה לי מה הבעיה."_
+For some findings the plugin should **show** the failing state, not describe it.
+Explicitly framed as a second phase: find all the problems first, present them nicely after.
+
+Responsiveness was her example, which is a hint about what item 7's output wants to be.
+
+### Per-project item suppression
+
+Roughly **half of projects have no Storybook at all** (built from scratch), and then item 1 and the Storybook half of item 2 are simply skipped: _"אפשר להגיד במחצית מהפרויקטים הם ככה, ואז בכלל אין עניין בדבר הזה."_
+Less robust design systems also skip the min/max part of item 7.
+
+Agreed conclusion: the plugin's settings should be **the checklist with checkboxes**, for turning off what doesn't apply to this project.
+
+### Human in the loop, always
+
+_"יכול להיות שאנחנו מגדירים שפה צריך human in the loop, וזה לא יכנס"_ - some items should be declared as human-only rather than half-automated.
+Dima: human in the loop exists regardless; halving the cycle time is already the win.
+
+Also agreed: this lands over **2-4 iterations** - build, run it, find what it misses, fix, repeat.
+
+### A hand-QA'd reference component
+
+Dima's proposal, twice, and not contested: QA **one component manually** and hand it to the plugin as the worked example, for everything that can't be inferred - prop order, what a description should contain.
+Shani's counter was narrower, not opposed: prop order specifically could just be a setting, since she works the same way across projects.
+
+### Storybook access is a real obstacle
+
+_"אף פעם לא היה לי גישה ל-Storybook שלא הייתה דרך private browser או דרך localhost"_ - she has **never** had Storybook access that wasn't localhost or a private browser, and localhost has to be started from the terminal each time.
+Dima noted an agent can run that itself, given approval.
+Shani: _"אם אפשר לעשות את זה, זה נראה לי מאוד value-pack"_ - because Storybook to Figma round-tripping is the single most repetitive part of QA: _"Storybook והלוך חזרה, Storybook והלוך חזרה."_
+
+---
+
+## Per-item notes
+
+### 1. Storybook Alignment + Note
+
+The project ran **backwards**; components were matched _to_ Storybook: _"לקחת מה-Storybook וללכת לפי הדיזיין שיש שם."_
+Match means **visually and in props**, and _"בדיוק אותם ה-props-ים"_ - exactly the same prop names.
+
+**But that comparison is explicitly not this item's check.**
+Twice:
+
+> _"זה לא משהו שנבדוק בנקודה הזאת."_ - "that's not something we check at this point."
+>
+> _"זה לא משהו שאני מצפה שהפלאגין יעשה, פשוט לראות שיש note כזה."_ - "that's not something I expect the plugin to do - just to see that such a note exists."
+
+The item's actual content is **the note**.
+She always adds a note listing what was changed relative to Storybook, because she wants the dev side to update accordingly: _"אם ביצעת איזה שהם שינויים מה-Storybook, אז אני מציינת את זה. כי אני ארצה גם שצד הפיתוח עדכן את זה."_
+The residual manual check is only that nothing present in Storybook was plain missed.
+
+The note has **no name and is not a special component** - _"לא, זה סתם"_ - "no, it's just [an element]."
+Dima guessed it's always the shared explanation-box component since they reuse components; Shani agreed _("נכון")_ but immediately flagged that they need to sort out what the plugin can and can't do here, because it _isn't_ certain.
+
+Storybook comparison is out of the first phase outright: _"השוואה ל-Storybook זה יכול לגמרי לא להיות ב-phase 1."_
+
+**Implications for the check.**
+The automatable core is small and well-defined: _does a note exist on the page/frame?_
+Everything about detecting deviations from Storybook is out of scope for now.
+The open question is what identifies the note - a specific component key would make this trivial and is probably true in practice, but was not confirmed.
+
+### 2. Components Naming Dev Alignment
+
+Two halves, and the PRD only implements the first:
+
+1. The set name matches what dev has - _"ה-naming של הקומפוננט, שקוראים לו Button עם B גדולה, זה באמת מה שגם קורה בצד הפיתוח."_
+2. **Every prop name too**, because `Start Icon` could equally be called `Left Icon`, and dev has already picked one: _"וגם לעבור על כל השמות של ה-props, ולראות שזה תמיד אותם השמות"_
+   Confirmed as the point of the item when Dima asked: _"שהשם ושהשמות של ה-props אותו דבר, זה נקודה ספציפית רק על זה."_
+
+Framing: _"שים לב רגע לקטלוג של ה-naming שייצרת"_ - pay attention to the naming catalogue you produced.
+
+**Implications.**
+`Button` with a capital B was an _example of matching dev_, not a request for a PascalCase rule.
+The shipped `set-name-casing` check is a proxy for half of this item that happens to be checkable without dev input.
+The prop-name half needs the same Storybook/dev source as item 1 and inherits its phase-1 exclusion.
+
+### 3. Check All the Props
+
+_"זה הכי טכני בעולם"_ - the most mechanical item there is.
+Cycle the props, ideally **all combinations** _("אולי הוא יכול לעבור גם על הכל, לעשות קומבינציות של הכל")_, and see nothing breaks.
+
+Two specifics:
+
+- **Long text, always.** _"נקודה שצריך לשים לב אליה תמיד זה באמת לנסות לשים טקסט ארוך, ולראות שהוא מגיב טוב, שהוא לא נשבר."_
+- **Icon colour follows text colour.**
+  She found a live failure mid-call: adding an icon produced an icon whose colour didn't match the label.
+  Stated as a standing DS rule rather than a one-off, meaning always, and an exception if not: _"שצבע של האייקון תמיד צבע של ה-text. זה תמיד ככה. זה חריג אם זה לא ככה."_
+
+She volunteered that the plugin can't know the icon rule by itself; Dima's answer was that it goes into the instructions.
+
+**Implications.**
+The icon/text colour rule is a **configured DS invariant**, and it is the concrete failure this item was demonstrated on, so it is a good first target.
+"All combinations" is combinatorial on a large set, so what "breaks" means needs defining before this is buildable.
+
+### 4. Prop Names Aligned to Consolidated Catalogue
+
+**About order, not names**, despite the title: _"זה קשור לסדר של ה-props, שנגיד variant הוא תמיד לפני state, ו-size הוא תמיד ראשון."_
+
+Scope is consistent within a project, but the order itself is per-project: _"בכל הקומפוננטות בפרויקט. צריך להיות אותו סדר. אבל בכל פרויקט הם יכולים להחליט על סדר קצת אחר"_
+Later softened: she works the same way everywhere, so a setting only matters when a client insists.
+
+Also: _"זה לא יהיה בכל QA"_ - it isn't part of every QA; she'd added it for this project specifically.
+
+Dima proposed renaming it prop order / prop naming consistency; agreed.
+
+### 5. Tokens (Styles & Variables)
+
+_"לראות שהכל מחובר לטוקנים"_, enumerated: gap, padding, corner radius, all colours, and text bound to a **style**.
+Effects too - _"אם יש אפקטים, אז גם שהם מחוברים ל-style. שלא יהיה סתם אפקט"_.
+
+One nuance in her phrasing: _"אם זה על hug, אז זה מחובר"_ - hug and token-binding are treated as alternatives for a dimension, which is the same exemption that shows up explicitly under item 10.
+
+### 6. Typography Desktop | Mobile Correlation
+
+She opened by ruling it out and reversed within the same exchange:
+
+> _"זה משהו ייחודי. זה לא משהו שאפשר להכניס..."_
+>
+> then: _"למעשה יכול להיות אחלה, להוסיף את זה."_
+
+The rule: if desktop picks `paragraph 2 regular`, mobile uses the corresponding one _("אז גם במובייל...")_.
+She was unsure it generalises - _"אני פשוט לא יודעת אם זה כזה רוחבי"_ - but on the dev side it definitely does, because dev has one component: _"אצל פיתוח תכלס זה כן רוחבי, כי פיתוח זה תמיד צריך להיות אותו דבר."_
+
+Structural facts that constrain the check:
+
+- Mobile is **always a separate component** - _"המובייל הוא תמיד הוא קומפוננטה נפרדת"_.
+- It sits on the **same page** (confirmed: _"כן, באותו עמוד"_).
+- So this check needs to **review two components together**: _"זה פשוט דורש אבל review, שתי קומפוננטות."_
+
+Dima's reframe, unanswered but worth keeping: the invariant isn't really typography, it's **hierarchy** - typography is just where it's visible.
+The failure mode it prevents is picking a level because of how it looks in one viewport rather than what it means.
+
+**Implications.**
+The hard part is **pairing** desktop and mobile sets and **corresponding** styles across them.
+Neither was specified, and the PRD's `Mobile/Paragraph 2 Regular` naming convention is an invention (see below).
+Pairing rule and style-correspondence rule are the two things to settle before building; both probably need to be configurable or hand-seeded.
+
+### 7. Responsiveness (+ Min-Max)
+
+Resize it and see nothing breaks.
+The specific thing to look at is **min and max width and height**: if there are none, recommend having them - _"יכול להיות output של כאילו: שים לב, אין"_ - "output like: note, there aren't any."
+Because it's recommended for components generally.
+
+Explicitly soft: _"בפרויקטים שה-DS-ים הם פחות רובסטיים כמו פה, אז אנחנו לא תמיד נכנסים לזה. אבל זה יהיה נחמד. אולי."_
+
+**Implications.**
+This is an **advisory** item: "note, there's no min-width" is the desired output, not a failure.
+It is also the item she picked when suggesting the plugin should _show_ the broken state visually (see cross-cutting above).
+
+### 8. Icons / Illustrations / Logos to Foundations
+
+Icons should come from the icons / foundations folder.
+The requirement she added unprompted: **which folder** has to be configurable, because foundations folders go **legacy** - _"לפעמים יש לתיקיות foundations שהם legacy, ואני רוצה לוודא שזה לא מחובר ל-legacy."_
+
+A pasted raw SVG does happen but is an anomaly, not the norm: _"יש מקרים שזה יהיה SVG שהוא לא קומפוננטה, אז זה חריג, שמישהו לא שים לב"_ and _"לרוב זה כן יהיה מ-library."_
+
+This is consistent with the shipped `asset-provenance` check being negative-detection-only and deferring the approved-key manifest.
+
+### 9. Layer Naming + Structure
+
+Open the layers panel and look for a `Frame 208`.
+Two things:
+
+- **No redundant frames**, first and emphasised.
+  Her example: if these three siblings were wrapped in a frame, that wrapper would be redundant.
+  Dima's sharper version, agreed: _"wrapper שמקיף wrapper, זה בטוח מיותר."_
+- **Uniform naming**: text is _usually_ called `label`.
+  _"משהו שאנחנו מנסים שה-layer naming יהיה אחיד."_
+
+Severity, in her words: _"לא סופר קריטי"_ - not super critical; just look over how it's built.
+
+### 10. 4px Grid Alignment
+
+Dima asked directly for the exception cases.
+Answers:
+
+- **Hug means the grid doesn't apply**, and specifically to the component's own size: _"אם הדבר הוא ב-hug, אז זה בטוח לא מעניין אותי ה-pixel grid... מבחינת האורך של הקומפוננטה"_ - because the text may be a little longer.
+- **Spacing and padding are always on the grid**, with 2 allowed: _"ה-spacing זה תמיד יהיה 4 pixel grid, זה יכול להיות 2. 2 זה גם בסדר, אבל חוץ מזה זה תמיד 4."_
+- **Icon sizes:** 16/24/32/48 confirmed, _plus_ 12, and _"זה יכול להיות גם 14 לפעמים"_ - 14 sometimes, which she suggested entering as a configured exception.
+
+Dima's framing, uncontested: it's a recommendation either way - _"זה יהיה פתק עם המלצה, אז אוקיי, אם אתם חושבים שזה בסדר, אז זה בסדר."_
+
+### 11. Interaction (Hover Only)
+
+**Only** `while hovering`, and the reason is concrete: a `pressed` state in the library collides with the real prototype in the design file - _"ברגע שעושים ל-pressed, אז זה מתנגש עם ה-prototype האמיתי בסוף בקובץ עיצוב."_
+
+The check is existence: _"לבוא ולראות שזה בכלל קיים."_
+
+### 12. Description (AKA + Misprint)
+
+_"לרוב ה-description שאנחנו עושים הוא תמיד כזה 'also known as' ו-misprint."_
+
+Varies by client, and the variation is a **link to Storybook** - she corrected herself mid-sentence from "documentation" to "Storybook".
+Since there usually is a Storybook and it's usually wanted, _"זה יכול להיות ה-default של הפלאגין."_
+
+She flagged the description as the item that varies most from client to client, which is what prompted Dima's hand-QA'd-reference-component idea.
+
+### 13. No Conflicts
+
+_"זה די מיותר"_ - pretty redundant, because Figma surfaces conflicts natively in a component set.
+Dima's position, which is why it shipped anyway: if it's automatable, why not.
+
+Worth remembering when this row's value is questioned: **design already considers it redundant**, so it costs nothing and adds nothing.
+
+### 14. Easy to Use (Nested Components)
+
+Check there aren't too many nested components.
+Demonstrated on the Agent pack dropdown, which has two.
+
+Her proposed rule is the one that shipped: _"אם יש יותר משתיים, אז אולי הוא ימליץ לך: שים לב, קומפוננטה הזאת קצת ארוכה מדי, אולי תשקול להוריד"_ - over two, recommend reducing.
+**A recommendation, in both her wording and Dima's.**
+
+Motivation is symmetric: Dima raised the dev-side pain of deep nesting from AppsFlyer; Shani added it hurts the design side too, _"כי זה באמת משפיע על ה-easy to use."_
+
+### 15. Preferred (Instance Swapping)
+
+**Optional, and usually absent.**
+_"זה אופציונלי... לרוב לא יהיה את זה"_ - relevant mainly on components like status, where the swappable icon should be limited to check mark, double check mark and similar.
+Closing verdict: _"זה לא קריטי."_
+
+She was unsure it was worth automating at all: _"נראה לי זה משהו שאפשר לעשות איתו משהו או לא."_
+
+### 16. High Contrast (A11y)
+
+The whole of what she asked for: _"פשוט לראות... שהכל קריא"_ - just see that everything is readable.
+Dima named it as contrast/accessibility; she agreed.
+
+No thresholds, standard, or methodology came from design.
+Everything specific in the shipped `high-contrast` check is an engineering decision, which is why it carries its own long rationale in the PRD.
+
+### 17. Themes (Core / DNA / OldNews)
+
+_"כל הרעיון של לבדוק את ה-modes"_ - for every mode the component has (in this file, DNA and OldNews), see that it works and **looks good**, in all of them.
+
+Note that the ask is visual - "looks good" - while the shipped check covers resolution integrity only.
+That is a deliberate narrowing, documented in the PRD, not a misreading.
+
+### 18. Page Template
+
+_"זה קשור לעמוד עצמו - רגע לראות שהוא מסודר, שיש לי עמוד קומפוננטה ושיש לי label-ים סביב הקומפוננטה, לראות שזה מסודר טוב."_
+
+So: the component page exists, labels are present around the component, the page is tidy.
+
+**Implications.**
+Notably lighter than the PRD's version.
+Nothing was said about headers, anatomy breakdowns, usage specs, or assigned regions.
+What "arranged well" means was never pinned down, and the labels are presumably the `component-labels` module's output, which would make the checkable part "are the expected labels present", not "does the layout match a template."
+
+### 19. Documentation
+
+Yes/no.
+And usually **not yet applicable**: _"הרבה פעמים אנחנו נעשה QA לפני דוקומנטציה, כי זה הרבה פעמים גם שלב אחרי רק."_
+
+**Implications.**
+The common case is that documentation doesn't exist at QA time and its absence is **not a defect**.
+A `not_applicable` or advisory result is the right default; a failing row here would be noise on most runs.
+
+---
+
+## Where the PRD over-reads the source
+
+Each of these is in [`prd-automated-qa.md`](prd-automated-qa.md) but not in the call.
+Most inflate a soft or narrow ask into a firm, broad one.
+
+| PRD | Source |
+|---|---|
+| **1** - "the plugin checks for the presence of the note" _when_ "structural differences exist"; "Flag a warning if structural variations are detected without an accompanying documentation note" | Detecting structural variation vs Storybook is exactly what she scoped out, twice. The check is unconditional: does a note exist. |
+| **1** - an "Explanation Box / 'Changes from SB' note component" | _"לא, זה סתם"_ - the note isn't a named component. The shared explanation box is Dima's guess, agreed to but flagged as uncertain. |
+| **2** - "strict developer casing standards (e.g. **PascalCase**)"; "Flag any generic, lowercase, or space-separated" names | `Button` with a capital B was an example of _matching dev_, not a casing rule. Casing is a checkable proxy, not the requirement. |
+| **2** - silent on prop names | Half the item is that **prop names** match dev (`Start Icon` vs `Left Icon`). Missing from the PRD entirely. |
+| **4** - a fixed global order: `Size`, `Variant`, `State`, then booleans | "variant before state, size first" - but the order is **per-project configurable**, and the item isn't part of every QA. |
+| **6** - desktop `Paragraph 2 Regular` maps to `Mobile/Paragraph 2 Regular` | That naming convention appears nowhere in the call. What was said: mobile is a separate component on the same page, so the check needs to review two components, and she doubted the rule is universal. |
+| **7** - "Log a warning if a component collapses to 0px" | Not mentioned. The ask is the min/max **recommendation** ("note, there aren't any"), and it's routinely skipped on less robust design systems. |
+| **10** - "2px flags permitted strictly for micro-elements like borders or tight inline tags" | 2 is simply an accepted spacing value. No micro-element restriction was stated. |
+| **10** - silent on icon sizes | 16/24/32/48, **plus 12, plus 14 as a configured exception**. |
+| **13** - "Block compilation errors before pushing updates" | Design's own verdict is _"זה די מיותר"_; Figma already surfaces it. Kept because it's free, not because it's valuable. |
+| **14** - "trigger an optimization suggestion" is right, but "Count the total levels of nested component **properties** exposed to the parent panel" | She counted **nested components** (the dropdown "has two"), not property depth. |
+| **15** - silent on priority | Optional, usually absent, _"לא קריטי"_ - and she doubted it was worth automating. |
+| **18** - "structural headers, anatomy breakdowns, usage specs, and component frames neatly sorted into their assigned regions" | Page exists, labels around the component, tidy. Nothing else. |
+| **19** - "no component ships to production without its manual"; "minimum threshold of instructional content" | QA usually runs **before** documentation exists, so absent docs are normally not a finding. |
+| - | The PRD omits all of [§ Cross-cutting requirements](#cross-cutting-requirements): the disposable QA section, descriptive per-item output, stage-2 visual evidence, per-project suppression checkboxes, and the hand-QA'd reference component. |
+
+## Tier 3 candidates, ranked by what the source actually supports
+
+The six items that were still `tier: null` in [`checklist-catalogue.ts`](../src/plugins/qa/checklist-catalogue.ts) when this document was written.
+
+| Item | Status | Buildable core | Missing before it can be built |
+|---|---|---|---|
+| **19** Documentation | **shipped** `documentation` | Presence of a docs link, `pass` or `not_applicable` | Confirm with design that Figma's documentation-link field is where their docs live |
+| **7** Responsiveness | **shipped** `responsive-bounds` | Are min/max width/height set, as advice | Nothing. "Doesn't break on resize" is the harder, separable half, and stays a manual tick on the row |
+| **18** Page Template | blocked | Are the expected labels present around the component | The snapshot is **set-scoped** and the labels are page siblings, so this needs the collector's scope widened, plus a definition of "tidy" |
+| **3** Check All the Props | open | Icon colour equals text colour, as a configured invariant | A definition of "breaks"; combinatorial cost on large sets |
+| **1** Storybook Alignment + Note | **deferred** (2026-07-27) | Does a deviation note exist on the page | Deferred by decision: all Storybook-dependent work is parked, which also covers the prop-name half of item 2 |
+| **6** Typography Desktop\|Mobile | blocked | Style correspondence across a desktop/mobile pair | Both the pairing rule and the correspondence rule; nothing in the call specifies either |
+
+Note that none of these were pure snapshot checks.
+`documentationLinks` and the four `min/max` fields both had to be added to the collector first.
+Item 18 is the sharp version of that problem: `ComponentSetSnapshot` deliberately stops at the component set, and item 18 is the first check that needs to see the page around it.
+
+### Partial automation is the norm, not the exception
+
+Reading the source against what shipped shows several rows where a check covers only part of its item.
+Item 7 is the one modelled explicitly so far, via a `manualRemainder` on the check result: the row keeps a tickable box next to its status chip, because a green chip standing for an unperformed resize test is a false pass.
+
+Item 19 is modelled the same way, for a different reason: the row claims usage guidance, examples and properties are documented, while the check only reads Figma's documentation-link field.
+A link is evidence that documentation exists, never that its content is adequate.
+
+The remainder belongs to the **check**, not to the catalogue entry, because whether work remains can depend on what the check found.
+Item 19 asks for a content review only when a link exists; with no documentation there is nothing to read, and a static per-item string put "read the documentation" on the row precisely when there was none.
+Item 7's is unconditional by contrast, since a set being unable to hold bounds says nothing about whether it survives a resize.
+
+The report also counts these rows separately, as `counts.partial`.
+Without that, a run could report "0 manual" while rows 7 and 19 still had unticked boxes on the canvas.
+
+The same treatment is owed to at least these, all pre-existing:
+
+- **Item 2** - `set-name-casing` checks casing only; matching dev's **prop names** is untouched.
+- **Item 17** - `themes` covers resolution integrity; the ask was visual, "looks good in all modes".
+- **Item 12** - `description` checks the also-known-as line and misprint marker; the **Storybook link** she described is not verified.

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -279,7 +279,7 @@ export const CATALOGUE: CatalogueEntry[] = [
         .array(z.string())
         .optional()
         .describe(
-          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth, asset-provenance, themes, high-contrast.",
+          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth, asset-provenance, themes, high-contrast, responsive-bounds, documentation.",
         ),
     },
     timeoutMs: 60_000,

--- a/src/plugins/qa/checklist-catalogue.test.ts
+++ b/src/plugins/qa/checklist-catalogue.test.ts
@@ -30,7 +30,12 @@ const PRD_ITEMS: ReadonlyArray<{
     checkId: "tokens",
   },
   { n: 6, title: "Typography Desktop|Mobile", tier: null },
-  { n: 7, title: "Responsiveness (+ Min-Max)", tier: null },
+  {
+    n: 7,
+    title: "Responsiveness (+ Min-Max)",
+    tier: 2,
+    checkId: "responsive-bounds",
+  },
   {
     n: 8,
     title: "Icons/Illustrations/Logos → Foundations",
@@ -82,7 +87,12 @@ const PRD_ITEMS: ReadonlyArray<{
     checkId: "themes",
   },
   { n: 18, title: "Page Template", tier: null },
-  { n: 19, title: "Documentation", tier: null },
+  {
+    n: 19,
+    title: "Documentation",
+    tier: 2,
+    checkId: "documentation",
+  },
 ];
 
 describe("CHECKLIST_CATALOGUE", () => {
@@ -115,8 +125,8 @@ describe("CHECKLIST_CATALOGUE", () => {
 
   it("gives every automated item a unique checkId, tiered 1 or 2", () => {
     const automated = CHECKLIST_CATALOGUE.filter((item) => item.checkId);
-    expect(automated).toHaveLength(13);
-    expect(new Set(automated.map((item) => item.checkId)).size).toBe(13);
+    expect(automated).toHaveLength(15);
+    expect(new Set(automated.map((item) => item.checkId)).size).toBe(15);
     for (const item of automated) {
       expect(item.tier === 1 || item.tier === 2).toBe(true);
     }

--- a/src/plugins/qa/checklist-catalogue.ts
+++ b/src/plugins/qa/checklist-catalogue.ts
@@ -2,6 +2,10 @@
  * Static 19-item DS Component QA Checklist catalogue (issue #91).
  * Single source mapping PRD sections to engine check ids.
  *
+ * PRD: `docs/prd-automated-qa.md`. What design actually asked for, item by item,
+ * is in `docs/qa-source-interview.md`. Consult it before widening a check or
+ * rewording a blurb, since the PRD overstates several items.
+ *
  * Titles mostly track the PRD wording so the generated artifact matches the
  * printed checklist designers tick by hand; item 14 deliberately diverges
  * ("Easy to Use" named a goal, not the thing being measured). Every item also
@@ -29,7 +33,10 @@ export const CHECKLIST_CATALOGUE: readonly CatalogueItem[] = [
     n: 1,
     title: "Storybook Alignment + Note",
     tier: null,
-    blurb: "Variants and props match the Storybook implementation.",
+    // Per the source interview the *note* is what gets ticked here, not the
+    // comparison; design explicitly scoped Storybook diffing out of this item.
+    blurb:
+      "A note records any deliberate deviations from the Storybook implementation.",
   },
   {
     n: 2,
@@ -67,8 +74,12 @@ export const CHECKLIST_CATALOGUE: readonly CatalogueItem[] = [
   {
     n: 7,
     title: "Responsiveness (+ Min-Max)",
-    tier: null,
-    blurb: "Resizing behaves under auto-layout, honouring min/max widths.",
+    tier: 2,
+    checkId: "responsive-bounds",
+    // Only the size-bounds half is automated; the check emits a
+    // `manualRemainder` so the row keeps its tickbox for the resize test.
+    blurb:
+      "Resizing behaves under auto-layout, with min/max bounds where they apply.",
   },
   {
     n: 8,
@@ -151,7 +162,12 @@ export const CHECKLIST_CATALOGUE: readonly CatalogueItem[] = [
   {
     n: 19,
     title: "Documentation",
-    tier: null,
+    tier: 2,
+    checkId: "documentation",
+    // This blurb claims something about the documentation's *content*, which
+    // the check cannot see - it reads Figma's documentation-link field. The
+    // check emits a `manualRemainder` asking for the content review, but only
+    // when a link exists; with no documentation there is nothing to review.
     blurb: "Usage guidance, do/don't examples and properties are documented.",
   },
 ];

--- a/src/plugins/qa/checks/documentation.test.ts
+++ b/src/plugins/qa/checks/documentation.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { checkDocumentation } from "./documentation";
+import type { ComponentSetSnapshot } from "../snapshot";
+
+function fixture(documentationLinks?: string[]): ComponentSetSnapshot {
+  return {
+    id: "1:1",
+    name: "Button",
+    type: "COMPONENT_SET",
+    description: "",
+    ...(documentationLinks ? { documentationLinks } : {}),
+    propertyNames: [],
+    properties: [],
+    variants: [],
+  };
+}
+
+describe("checkDocumentation (#19)", () => {
+  it("passes when a documentation link is set, and names it", () => {
+    const result = checkDocumentation(
+      fixture(["https://storybook.example/button"]),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+    expect(result.note).toContain("https://storybook.example/button");
+  });
+
+  it("reports not_applicable, never a failure, when there is no link", () => {
+    const result = checkDocumentation(fixture());
+    expect(result.status).toBe("not_applicable");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("treats an empty link list the same as an absent one", () => {
+    expect(checkDocumentation(fixture([])).status).toBe("not_applicable");
+  });
+
+  it("explains what was looked for, so an empty row isn't read as broken", () => {
+    // Design described item 19 as a stage, not a field; if their docs live
+    // somewhere other than Figma's link field this note is what reveals it.
+    const note = checkDocumentation(fixture()).note ?? "";
+    expect(note).toMatch(/documentation-link field/);
+    expect(note).toMatch(/before documentation/);
+  });
+
+  it("lists every link when more than one is set", () => {
+    const result = checkDocumentation(
+      fixture(["https://a.example", "https://b.example"]),
+    );
+    expect(result.note).toContain("https://a.example");
+    expect(result.note).toContain("https://b.example");
+  });
+
+  // The regression: a static per-item remainder put "Read the documentation"
+  // and an unticked box on the row precisely when there was no documentation,
+  // contradicting the whole point of not treating absence as a defect.
+  it("asks for no content review when there is no documentation", () => {
+    for (const fx of [fixture(), fixture([])]) {
+      const result = checkDocumentation(fx);
+      expect(result.status).toBe("not_applicable");
+      expect(result.manualRemainder).toBeUndefined();
+    }
+  });
+
+  it("asks for a content review once a link exists", () => {
+    // The row claims usage guidance and properties are documented, which a link
+    // alone cannot establish.
+    const result = checkDocumentation(fixture(["https://storybook.example"]));
+    expect(result.status).toBe("pass");
+    expect(result.manualRemainder).toMatch(/covers usage/);
+  });
+
+  it("reports under the right check id and title", () => {
+    const result = checkDocumentation(fixture());
+    expect(result.checkId).toBe("documentation");
+    expect(result.title).toBe("Documentation");
+  });
+});

--- a/src/plugins/qa/checks/documentation.ts
+++ b/src/plugins/qa/checks/documentation.ts
@@ -1,0 +1,63 @@
+/**
+ * #19 - documentation. A yes/no item, and deliberately one that cannot fail.
+ *
+ * Design's framing is that QA routinely runs *before* documentation exists
+ * ("many times we do QA before documentation, because it's often only a later
+ * stage" - docs/qa-source-interview.md#19-documentation), so an undocumented
+ * component is the normal mid-process state, not a defect. Reporting it as
+ * `fail`, or even `warn`, would put an amber row on most runs and teach the
+ * designer to skip it, the same failure mode #16 avoids with its skip tally.
+ *
+ * So: links present → `pass`; none → `not_applicable` with a note saying what
+ * was looked for. The row stops being a manual tick either way, which is the
+ * whole ask.
+ *
+ * A `manualRemainder` rides along **only on `pass`**. The row's blurb claims
+ * something about the documentation's *content*, which this check cannot see, so
+ * a link needs a human to confirm it actually covers usage and properties. With
+ * no documentation there is nothing to read, and asking for a content review
+ * there would contradict the whole point of not treating absence as a defect.
+ *
+ * **The signal is Figma's own documentation-link field**, the only
+ * machine-readable "this component is documented" marker the plugin API
+ * exposes. Design described item 19 as a stage rather than a field, so if their
+ * documentation lives somewhere else (a linked page, a Storybook URL in the
+ * description, which is #12's business), this check is looking in the wrong
+ * place and the note is what makes that visible rather than silently green.
+ */
+
+import type { ComponentSetSnapshot } from "../snapshot";
+import type { CheckResult } from "../types";
+
+const TITLE = "Documentation";
+
+export function checkDocumentation(
+  snapshot: ComponentSetSnapshot,
+): CheckResult {
+  const links = snapshot.documentationLinks ?? [];
+
+  if (links.length === 0) {
+    return {
+      checkId: "documentation",
+      title: TITLE,
+      status: "not_applicable",
+      findings: [],
+      note:
+        "No documentation link is set on this component. QA commonly runs " +
+        "before documentation, so this is not reported as a defect. Only " +
+        "Figma's documentation-link field is checked. Documentation held " +
+        "elsewhere would not be seen here.",
+    };
+  }
+
+  return {
+    checkId: "documentation",
+    title: TITLE,
+    status: "pass",
+    findings: [],
+    note: `Documentation link set: ${links.join(", ")}.`,
+    manualRemainder:
+      "Read the documentation and confirm it covers usage, examples and " +
+      "properties. Only the presence of a link is checked automatically.",
+  };
+}

--- a/src/plugins/qa/checks/index.test.ts
+++ b/src/plugins/qa/checks/index.test.ts
@@ -36,13 +36,15 @@ const FIXTURE: ComponentSetSnapshot = {
 
 describe("check catalogue", () => {
   it("lists the 9 Tier 1 checks plus the Tier 2 checks, with unique ids", () => {
-    expect(CHECKS).toHaveLength(13);
-    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(13);
+    expect(CHECKS).toHaveLength(15);
+    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(15);
     // The static Tier 1 PRD sections (issue #76), then Tier 2 appended in
     // shipping order: #14 (issue #99), #8 (issue #101), #17 (issue #102),
-    // #16 (issue #103).
+    // #16 (issue #103), then #7 and #19: the two items the source interview
+    // showed were narrow advisory checks rather than the broad ones the PRD
+    // described (docs/qa-source-interview.md).
     expect(CHECKS.map((c) => c.prdSection)).toEqual([
-      2, 4, 5, 9, 10, 11, 12, 13, 15, 14, 8, 17, 16,
+      2, 4, 5, 9, 10, 11, 12, 13, 15, 14, 8, 17, 16, 7, 19,
     ]);
   });
 

--- a/src/plugins/qa/checks/index.ts
+++ b/src/plugins/qa/checks/index.ts
@@ -21,6 +21,8 @@ import { checkNestingDepth } from "./nesting-depth";
 import { checkAssetProvenance } from "./asset-provenance";
 import { checkThemes } from "./themes";
 import { checkHighContrast } from "./high-contrast";
+import { checkResponsiveBounds } from "./responsive-bounds";
+import { checkDocumentation } from "./documentation";
 
 export type CheckFn = (snapshot: ComponentSetSnapshot) => CheckResult;
 
@@ -43,6 +45,8 @@ export const CHECK_REGISTRY: Partial<Record<CheckId, CheckFn>> = {
   "asset-provenance": checkAssetProvenance,
   themes: checkThemes,
   "high-contrast": checkHighContrast,
+  "responsive-bounds": checkResponsiveBounds,
+  documentation: checkDocumentation,
 };
 
 export interface RunOutcome {

--- a/src/plugins/qa/checks/responsive-bounds.test.ts
+++ b/src/plugins/qa/checks/responsive-bounds.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import { checkResponsiveBounds } from "./responsive-bounds";
+import type {
+  ComponentSetSnapshot,
+  NodeSnapshot,
+  VariantSnapshot,
+} from "../snapshot";
+
+type Bounds = Pick<
+  NodeSnapshot,
+  "minWidth" | "maxWidth" | "minHeight" | "maxHeight"
+>;
+
+function root(
+  id: string,
+  boundsApplicable: boolean,
+  bounds: Bounds = {},
+): NodeSnapshot {
+  return {
+    id,
+    name: `Variant ${id}`,
+    type: "COMPONENT",
+    visible: true,
+    width: 100,
+    height: 40,
+    children: [],
+    ...(boundsApplicable ? { boundsApplicable: true } : {}),
+    ...bounds,
+  };
+}
+
+function fixture(roots: NodeSnapshot[]): ComponentSetSnapshot {
+  const variants: VariantSnapshot[] = roots.map((tree) => ({
+    id: tree.id,
+    name: tree.name,
+    variantProperties: {},
+    tree,
+  }));
+  return {
+    id: "1:1",
+    name: "Button",
+    type: "COMPONENT_SET",
+    description: "",
+    propertyNames: [],
+    properties: [],
+    variants,
+  };
+}
+
+describe("checkResponsiveBounds (#7)", () => {
+  it("warns, never fails, when no bound at all is set", () => {
+    const result = checkResponsiveBounds(fixture([root("1", true)]));
+    expect(result.status).toBe("warn");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe("low");
+  });
+
+  it("passes when any single bound is set, since completeness is not required", () => {
+    // Requiring all four would put a finding on nearly every component, which
+    // is how a checklist row stops being read.
+    for (const bound of [
+      { minWidth: 120 },
+      { maxWidth: 320 },
+      { minHeight: 32 },
+      { maxHeight: 80 },
+    ]) {
+      const result = checkResponsiveBounds(fixture([root("1", true, bound)]));
+      expect(result.status).toBe("pass");
+      expect(result.findings).toEqual([]);
+    }
+  });
+
+  it("still names the unset bounds on a passing row", () => {
+    const result = checkResponsiveBounds(
+      fixture([root("1", true, { minWidth: 120 })]),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.note).toContain("maxWidth");
+    expect(result.note).toContain("minHeight");
+    expect(result.note).toContain("maxHeight");
+    expect(result.note).not.toContain("minWidth,");
+  });
+
+  it("omits the note when every bound is set somewhere in the set", () => {
+    const result = checkResponsiveBounds(
+      fixture([
+        root("1", true, { minWidth: 120, maxWidth: 320 }),
+        root("2", true, { minHeight: 32, maxHeight: 80 }),
+      ]),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.note).toBeUndefined();
+  });
+
+  it("collapses the whole set into one finding, carrying the count", () => {
+    // Variants share their bound configuration, so per-variant findings would
+    // repeat one fact once per variant.
+    const result = checkResponsiveBounds(
+      fixture([root("1", true), root("2", true), root("3", true)]),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(3);
+    expect(result.findings[0].message).toContain("3 of 3");
+  });
+
+  it("counts only the unbounded roots when the set is mixed", () => {
+    const result = checkResponsiveBounds(
+      fixture([root("1", true, { minWidth: 120 }), root("2", true)]),
+    );
+    expect(result.status).toBe("warn");
+    expect(result.findings[0].count).toBe(1);
+    expect(result.findings[0].nodeId).toBe("2");
+  });
+
+  it("evaluates a root the collector marked applicable regardless of its own layout", () => {
+    // Bounds are settable on an auto-layout frame's direct children too, so a
+    // layoutMode "NONE" variant inside an auto-layout set must not be skipped.
+    // The collector owns that judgement; the check must honour it.
+    const nonAutoLayoutChildOfAutoLayoutSet: NodeSnapshot = {
+      ...root("1", true),
+      layoutMode: "NONE",
+    };
+    const result = checkResponsiveBounds(
+      fixture([nonAutoLayoutChildOfAutoLayoutSet]),
+    );
+    expect(result.status).toBe("warn");
+    expect(result.findings[0].count).toBe(1);
+  });
+
+  it("is not_applicable when no root can carry bounds", () => {
+    // Warning here would ask for something the file cannot express.
+    const result = checkResponsiveBounds(
+      fixture([root("1", false), root("2", false)]),
+    );
+    expect(result.status).toBe("not_applicable");
+    expect(result.findings).toEqual([]);
+    expect(result.note).toContain("auto-layout");
+  });
+
+  it("ignores roots that cannot carry bounds rather than counting them unbounded", () => {
+    const result = checkResponsiveBounds(
+      fixture([root("1", true, { minWidth: 120 }), root("2", false)]),
+    );
+    expect(result.status).toBe("pass");
+  });
+
+  it("is not_applicable for a set with no variants at all", () => {
+    expect(checkResponsiveBounds(fixture([])).status).toBe("not_applicable");
+  });
+
+  it("always leaves the resize test outstanding, on every outcome", () => {
+    // Unlike #19's remainder this is unconditional: that a set cannot hold
+    // bounds says nothing about whether it survives being resized.
+    const cases = [
+      fixture([root("1", true)]), // warn
+      fixture([root("1", true, { minWidth: 120 })]), // pass
+      fixture([root("1", false)]), // not_applicable
+    ];
+    for (const fx of cases) {
+      expect(checkResponsiveBounds(fx).manualRemainder).toMatch(/[Rr]esize/);
+    }
+  });
+
+  it("reports under the right check id and title", () => {
+    const result = checkResponsiveBounds(fixture([root("1", true)]));
+    expect(result.checkId).toBe("responsive-bounds");
+    expect(result.title).toBe("Responsiveness (size bounds)");
+  });
+});

--- a/src/plugins/qa/checks/responsive-bounds.ts
+++ b/src/plugins/qa/checks/responsive-bounds.ts
@@ -1,0 +1,127 @@
+/**
+ * #7 - responsiveness, size-bounds half only.
+ *
+ * Design's ask is narrow and explicitly advisory: look at min/max width and
+ * height, and if there are none, *recommend* having them - the requested
+ * output is literally "note, there aren't any".
+ * It is also routinely skipped ("in projects where the design systems are less
+ * robust, like here, we don't always go into it").
+ * See docs/qa-source-interview.md#7-responsiveness--min-max.
+ *
+ * So this never fails; the worst status is `warn` at `low` severity.
+ * The other half of item 7 - actually resizing a variant and judging whether it
+ * breaks - needs a definition of "breaks" and is deliberately not attempted
+ * here, which is why every result carries a `manualRemainder` so the row keeps
+ * its tickbox: a green chip here must not stand for the resize test.
+ *
+ * **Absence of *all four* bounds is the reported case, not incompleteness.**
+ * Requiring every bound on every component would put four findings on nearly
+ * every set, which is how a row stops being read.
+ * A component that sets some bounds has clearly been considered, so it passes -
+ * with the unset ones named in `note`, keeping the row descriptive without
+ * making it amber.
+ *
+ * Only **variant roots** are examined, since the item is about the component's
+ * own resize behaviour.
+ * Whether a root can hold bounds at all comes from the collector's
+ * `boundsApplicable`, not from the root's own `layoutMode`: Figma allows bounds
+ * on auto-layout frames *and their direct children*, so a `layoutMode: "NONE"`
+ * variant inside an auto-layout component set is still a legitimate place for
+ * them and must not be silently skipped.
+ */
+
+import type { ComponentSetSnapshot, NodeSnapshot } from "../snapshot";
+import type { CheckResult, Finding } from "../types";
+
+const TITLE = "Responsiveness (size bounds)";
+
+/**
+ * Unconditional, unlike #19's: resize behaviour is owed on every outcome,
+ * including `not_applicable`. That a set cannot hold bounds says nothing about
+ * whether it survives being resized.
+ */
+const RESIZE_REMAINDER =
+  "Resize the component and confirm nothing breaks. Only min/max bounds are " +
+  "checked automatically.";
+
+const BOUNDS = ["minWidth", "maxWidth", "minHeight", "maxHeight"] as const;
+
+type BoundKey = (typeof BOUNDS)[number];
+
+function boundsSetOn(root: NodeSnapshot): BoundKey[] {
+  return BOUNDS.filter((key) => root[key] !== undefined);
+}
+
+export function checkResponsiveBounds(
+  snapshot: ComponentSetSnapshot,
+): CheckResult {
+  const roots = snapshot.variants
+    .map((variant) => variant.tree)
+    .filter((root) => root.boundsApplicable === true);
+
+  if (roots.length === 0) {
+    return {
+      checkId: "responsive-bounds",
+      title: TITLE,
+      status: "not_applicable",
+      findings: [],
+      note:
+        "Figma cannot hold min/max width or height on this component: no " +
+        "variant root is an auto-layout frame or a direct child of one.",
+      manualRemainder: RESIZE_REMAINDER,
+    };
+  }
+
+  const unbounded = roots.filter((root) => boundsSetOn(root).length === 0);
+
+  // Which bounds nothing in the set sets - reported either way, so a passing
+  // row still says what is unset instead of just going green.
+  const neverSet = BOUNDS.filter((key) =>
+    roots.every((root) => root[key] === undefined),
+  );
+  const unsetNote =
+    neverSet.length > 0
+      ? `Not set anywhere in the set: ${neverSet.join(", ")}.`
+      : undefined;
+
+  if (unbounded.length === 0) {
+    return {
+      checkId: "responsive-bounds",
+      title: TITLE,
+      status: "pass",
+      findings: [],
+      ...(unsetNote ? { note: unsetNote } : {}),
+      manualRemainder: RESIZE_REMAINDER,
+    };
+  }
+
+  // One finding for the whole set rather than one per variant: variants of a
+  // component share their bound configuration, so per-variant findings would
+  // repeat a single fact up to 64 times.
+  const finding: Finding = {
+    severity: "low",
+    nodeId: unbounded[0].id,
+    nodeName: unbounded[0].name,
+    message:
+      `No min/max width or height is set on ${unbounded.length} of ` +
+      `${roots.length} variant root(s). Bounds are recommended so the ` +
+      `component cannot be resized past what it was designed for.`,
+    expected: "at least one of minWidth, maxWidth, minHeight, maxHeight",
+    actual: "none set",
+    suggestedFix:
+      "Set the bounds that apply on the component's auto-layout frame, or " +
+      "skip this row if the project doesn't use size bounds.",
+    count: unbounded.length,
+  };
+
+  return {
+    checkId: "responsive-bounds",
+    title: TITLE,
+    status: "warn",
+    findings: [finding],
+    note:
+      "Advisory only: design treats size bounds as a recommendation, and " +
+      "skips them on less robust design systems.",
+    manualRemainder: RESIZE_REMAINDER,
+  };
+}

--- a/src/plugins/qa/collector.ts
+++ b/src/plugins/qa/collector.ts
@@ -128,6 +128,19 @@ function collectPinnedAncestors(
   return pinned;
 }
 
+/**
+ * Whether a node is an auto-layout frame, which is what makes size bounds
+ * settable on it *and on its direct children* (#7).
+ */
+function isAutoLayoutFrame(node: BaseNode | null | undefined): boolean {
+  return (
+    node != null &&
+    "layoutMode" in node &&
+    node.layoutMode !== "NONE" &&
+    node.layoutMode !== undefined
+  );
+}
+
 function snapshotNode(node: SceneNode): NodeSnapshot {
   const snap: NodeSnapshot = {
     id: node.id,
@@ -206,6 +219,21 @@ function snapshotNode(node: SceneNode): NodeSnapshot {
   if ("layoutSizingHorizontal" in node) {
     snap.layoutSizingHorizontal = node.layoutSizingHorizontal;
     snap.layoutSizingVertical = node.layoutSizingVertical;
+  }
+  // Auto-layout size bounds (#7). Figma uses null for "unset", and #7 reports
+  // exactly that absence, so an unset bound is left off the snapshot rather
+  // than carried as null.
+  if ("minWidth" in node) {
+    if (node.minWidth !== null) snap.minWidth = node.minWidth;
+    if (node.maxWidth !== null) snap.maxWidth = node.maxWidth;
+    if (node.minHeight !== null) snap.minHeight = node.minHeight;
+    if (node.maxHeight !== null) snap.maxHeight = node.maxHeight;
+    // Read from the parent as well: bounds are settable on an auto-layout
+    // frame's direct children too, so a non-auto-layout variant inside an
+    // auto-layout component set is still a legitimate place for them.
+    if (isAutoLayoutFrame(node) || isAutoLayoutFrame(node.parent)) {
+      snap.boundsApplicable = true;
+    }
   }
   if ("cornerRadius" in node) {
     snap.cornerRadius =
@@ -311,11 +339,14 @@ export function collectSnapshot(
 
   const pinnedAncestors = collectPinnedAncestors(subject);
 
+  const documentationLinks = subject.documentationLinks.map((link) => link.uri);
+
   return {
     id: subject.id,
     name: subject.name,
     type: subject.type,
     description: subject.description,
+    ...(documentationLinks.length > 0 ? { documentationLinks } : {}),
     propertyNames: properties.map((p) => p.name),
     properties,
     variants,

--- a/src/plugins/qa/render/renderChecklist.ts
+++ b/src/plugins/qa/render/renderChecklist.ts
@@ -152,7 +152,12 @@ function checkbox(): FrameNode {
 }
 
 function summaryLine(counts: ChecklistReport["counts"]): string {
-  return `${counts.pass} pass · ${counts.warn} warn · ${counts.fail} fail · ${counts.manual} manual · ${counts.notImplemented} pending`;
+  const base = `${counts.pass} pass · ${counts.warn} warn · ${counts.fail} fail · ${counts.manual} manual · ${counts.notImplemented} pending`;
+  // Partial rows carry an unticked box despite having a status chip, so a
+  // summary that omitted them could read "0 manual" with work still to do.
+  return counts.partial > 0
+    ? `${base} · ${counts.partial} partly manual`
+    : base;
 }
 
 const SEVERITY_COLOR: Record<SeverityLevel, string> = {
@@ -289,10 +294,40 @@ export async function renderChecklist(
     if (item.automated) {
       const style = statusStyle(item.status);
       row.appendChild(statusChip(style.label, style.hex));
+      // A partially automated row keeps its box: the chip speaks only for the
+      // half the engine checked, so dropping the box would let a green chip
+      // stand for work nobody did.
+      if (item.manualRemainder) {
+        row.appendChild(checkbox());
+      }
     } else {
       row.appendChild(checkbox());
     }
     itemBlock.appendChild(row);
+
+    // What the engine did NOT cover on a partially automated row, spelled out
+    // next to the box it left unticked.
+    if (item.manualRemainder) {
+      const remainderBlock = buildAutoLayoutFrame(
+        `item-${item.n}-manual-remainder`,
+        "VERTICAL",
+        0,
+        0,
+        0,
+      );
+      remainderBlock.layoutAlign = "STRETCH";
+      remainderBlock.paddingLeft = DETAIL_INDENT;
+      const remainderText = text(
+        `Still manual: ${item.manualRemainder}`,
+        11,
+        FONT_REGULAR,
+        MUTED,
+      );
+      remainderBlock.appendChild(remainderText);
+      remainderText.textAutoResize = "HEIGHT";
+      remainderText.layoutSizingHorizontal = "FILL";
+      itemBlock.appendChild(remainderBlock);
+    }
 
     // A check's caveat (#8: library origin is unverifiable in-plugin) renders
     // even on a passing row — that is exactly where the reader needs to know

--- a/src/plugins/qa/report.test.ts
+++ b/src/plugins/qa/report.test.ts
@@ -17,9 +17,19 @@ function result(
   checkId: CheckResult["checkId"],
   status: CheckResult["status"],
   findings: Finding[] = [],
+  manualRemainder?: string,
 ): CheckResult {
-  return { checkId, title: checkId, status, findings };
+  return {
+    checkId,
+    title: checkId,
+    status,
+    findings,
+    ...(manualRemainder ? { manualRemainder } : {}),
+  };
 }
+
+/** Stand-in for whatever copy a partially-automated check emits. */
+const REMAINDER = "Confirm the half this check cannot see.";
 
 describe("buildChecklistReport", () => {
   it("returns exactly 19 rows in PRD order", () => {
@@ -208,6 +218,7 @@ describe("buildChecklistReport", () => {
       fail: 1,
       manual: manualCount,
       notImplemented: 1,
+      partial: 0,
     });
     expect(notRunCount).toBeGreaterThan(0);
     // not_run is intentionally absent from counts (PRD §6).
@@ -220,5 +231,98 @@ describe("buildChecklistReport", () => {
         report.counts.notImplemented +
         notRunCount,
     ).toBe(19);
+    // partial is an overlay, not a status: excluded from the sum on purpose.
+    expect(report.counts.partial).toBe(0);
+  });
+
+  describe("partially automated rows", () => {
+    // A partial row would otherwise render a bare status chip while the half the
+    // check cannot see had never been performed.
+    it("forwards the check's remainder onto its row", () => {
+      const report = buildChecklistReport({
+        target: TARGET,
+        results: [result("responsive-bounds", "pass", [], REMAINDER)],
+        notImplemented: [],
+      });
+      const item = report.items.find((i) => i.n === 7);
+      expect(item?.status).toBe("pass");
+      expect(item?.automated).toBe(true);
+      expect(item?.manualRemainder).toBe(REMAINDER);
+      expect(report.counts.partial).toBe(1);
+    });
+
+    it("forwards it regardless of the engine status", () => {
+      for (const status of ["warn", "fail", "not_applicable"] as const) {
+        const report = buildChecklistReport({
+          target: TARGET,
+          results: [result("responsive-bounds", status, [], REMAINDER)],
+          notImplemented: [],
+        });
+        expect(report.items.find((i) => i.n === 7)?.manualRemainder).toBe(
+          REMAINDER,
+        );
+      }
+    });
+
+    it("leaves a row alone when its check reports no remainder", () => {
+      const report = buildChecklistReport({
+        target: TARGET,
+        results: [result("no-conflicts", "pass")],
+        notImplemented: [],
+      });
+      expect(
+        report.items.find((i) => i.n === 13)?.manualRemainder,
+      ).toBeUndefined();
+      expect(report.counts.partial).toBe(0);
+    });
+
+    it("counts partial rows on top of their status, never instead of it", () => {
+      const report = buildChecklistReport({
+        target: TARGET,
+        results: [
+          result("responsive-bounds", "warn", [finding()], REMAINDER),
+          result("documentation", "pass", [], REMAINDER),
+          result("no-conflicts", "pass"),
+        ],
+        notImplemented: [],
+      });
+      // Both partial rows keep their own verdict...
+      expect(report.counts.pass).toBe(2);
+      expect(report.counts.warn).toBe(1);
+      // ...and are additionally tallied as partly manual.
+      expect(report.counts.partial).toBe(2);
+    });
+
+    it("records no remainder for a row whose check never ran", () => {
+      // Nothing about the row was established, and its not_run /
+      // not_implemented chip already says the whole row is open.
+      const report = buildChecklistReport({
+        target: TARGET,
+        results: [result("tokens", "pass")],
+        notImplemented: ["documentation"],
+      });
+      expect(report.items.find((i) => i.n === 7)?.status).toBe("not_run");
+      expect(
+        report.items.find((i) => i.n === 7)?.manualRemainder,
+      ).toBeUndefined();
+      expect(report.items.find((i) => i.n === 19)?.status).toBe(
+        "not_implemented",
+      );
+      expect(
+        report.items.find((i) => i.n === 19)?.manualRemainder,
+      ).toBeUndefined();
+      expect(report.counts.partial).toBe(0);
+    });
+
+    it("reports partial work even when nothing is fully manual", () => {
+      // The regression this guards: a summary reading "0 manual" while a row
+      // still has an unticked box.
+      const report = buildChecklistReport({
+        target: TARGET,
+        results: [result("documentation", "pass", [], REMAINDER)],
+        notImplemented: [],
+      });
+      expect(report.counts.partial).toBeGreaterThan(0);
+    });
   });
 });

--- a/src/plugins/qa/report.ts
+++ b/src/plugins/qa/report.ts
@@ -23,7 +23,14 @@ export interface BuildChecklistReportInput {
 }
 
 function emptyCounts(): ChecklistReport["counts"] {
-  return { pass: 0, warn: 0, fail: 0, manual: 0, notImplemented: 0 };
+  return {
+    pass: 0,
+    warn: 0,
+    fail: 0,
+    manual: 0,
+    notImplemented: 0,
+    partial: 0,
+  };
 }
 
 /**
@@ -45,6 +52,10 @@ export function buildChecklistReport(
   const items: ChecklistItem[] = CHECKLIST_CATALOGUE.map((entry) => {
     const automated = entry.checkId !== undefined;
     let status: ItemStatus;
+    // Outstanding human work, as reported by the check itself. A row whose
+    // check didn't run has none recorded: nothing about it was established, and
+    // its not_run / not_implemented chip already says the whole row is open.
+    let manualRemainder: string | undefined;
     let findings: Finding[] = [];
     // Unlike findings, a note survives a `pass` — a caveat only matters
     // precisely when the check passed on partial evidence (#8).
@@ -64,6 +75,7 @@ export function buildChecklistReport(
         findings =
           status === "warn" || status === "fail" ? engine.findings : [];
         note = engine.note;
+        manualRemainder = engine.manualRemainder;
       } else if (notImplemented.has(entry.checkId)) {
         status = "not_implemented";
       } else {
@@ -91,6 +103,12 @@ export function buildChecklistReport(
       // intentionally omitted from counts (so counts.pass stays honest).
     }
 
+    // Counted on top of the status above, never instead of it: the row has both
+    // an engine verdict and outstanding human work.
+    if (manualRemainder) {
+      counts.partial += 1;
+    }
+
     return {
       n: entry.n,
       title: entry.title,
@@ -98,6 +116,7 @@ export function buildChecklistReport(
       tier: entry.tier,
       checkId: entry.checkId,
       automated,
+      ...(manualRemainder ? { manualRemainder } : {}),
       status,
       findings,
       ...(note ? { note } : {}),

--- a/src/plugins/qa/snapshot.ts
+++ b/src/plugins/qa/snapshot.ts
@@ -148,6 +148,27 @@ export interface NodeSnapshot {
   cornerRadius?: number | "MIXED";
   strokeWeight?: number | "MIXED";
 
+  /**
+   * Auto-layout size bounds (#7). Figma reports `null` for "no bound", and
+   * these are recorded only when actually set, so absent here means unset in
+   * the file, which is precisely what the check reports on.
+   */
+  minWidth?: number;
+  maxWidth?: number;
+  minHeight?: number;
+  maxHeight?: number;
+  /**
+   * Whether Figma would accept a size bound on this node at all (#7).
+   * Bounds are settable on auto-layout frames **and on their direct
+   * children**, so this cannot be inferred from the node's own `layoutMode`:
+   * a `layoutMode: "NONE"` variant inside an auto-layout component set can
+   * carry bounds perfectly well. The collector owns the answer because only it
+   * can see the parent; absent means bounds are not settable here, and #7
+   * reports `not_applicable` rather than asking for something the file cannot
+   * express.
+   */
+  boundsApplicable?: boolean;
+
   /** Fields on this node bound to variables, e.g. ["paddingLeft", "itemSpacing"]. */
   boundVariableKeys?: string[];
   /**
@@ -301,6 +322,12 @@ export interface ComponentSetSnapshot {
   /** Standalone components (no variants) are valid QA subjects too. */
   type: "COMPONENT_SET" | "COMPONENT";
   description: string;
+  /**
+   * URIs from the component's Figma documentation-link field (#19). Absent
+   * when there are none, the common case, since QA routinely runs before
+   * documentation exists.
+   */
+  documentationLinks?: string[];
   /** Component property names in declaration order (#4). */
   propertyNames: string[];
   properties: ComponentPropertySnapshot[];

--- a/src/plugins/qa/types.ts
+++ b/src/plugins/qa/types.ts
@@ -25,7 +25,9 @@ export type CheckId =
   | "nesting-depth"
   | "asset-provenance"
   | "themes"
-  | "high-contrast";
+  | "high-contrast"
+  | "responsive-bounds"
+  | "documentation";
 
 export interface Finding {
   severity: SeverityLevel;
@@ -57,6 +59,17 @@ export interface CheckResult {
    * the checklist reads as a stronger guarantee than it is.
    */
   note?: string;
+  /**
+   * Human work this check leaves behind, when it covers only part of its
+   * checklist item. The checklist row then carries a status chip **and** keeps a
+   * tickable box, so a green chip cannot stand for the half nobody performed.
+   *
+   * The check owns this rather than the catalogue because whether work remains
+   * can depend on what the check found: #19 asks for a content review only when
+   * a documentation link actually exists, and has nothing to review when it
+   * reports `not_applicable`. A static per-item string got that case wrong.
+   */
+  manualRemainder?: string;
 }
 
 export interface CheckDefinition {
@@ -113,6 +126,16 @@ export const CHECKS: readonly CheckDefinition[] = [
     prdSection: 16,
     title: "High contrast (WCAG AA)",
   },
+  {
+    id: "responsive-bounds",
+    prdSection: 7,
+    title: "Responsiveness (size bounds)",
+  },
+  {
+    id: "documentation",
+    prdSection: 19,
+    title: "Documentation",
+  },
 ];
 
 export function getCheck(id: string): CheckDefinition | undefined {
@@ -136,6 +159,13 @@ export interface ChecklistItem {
   tier: 1 | 2 | null;
   checkId?: CheckId;
   automated: boolean;
+  /**
+   * What a human must still check on this row, forwarded from the backing
+   * check's `manualRemainder`. Present means the row is *partially* automated:
+   * it carries a status chip AND keeps a tickable box, because a green chip that
+   * silently stood for the unchecked half would be a false pass.
+   */
+  manualRemainder?: string;
   status: ItemStatus;
   /**
    * Engine findings; empty for everything except warn / fail (manual, pass,
@@ -150,8 +180,18 @@ export interface ChecklistReport {
   target: { id: string; name: string };
   generatedFor: { instanceId?: string };
   items: ChecklistItem[];
+  /**
+   * Row tallies. `pass`/`warn`/`fail`/`manual`/`notImplemented` are mutually
+   * exclusive statuses and sum (with `not_applicable` and `not_run`) to 19.
+   *
+   * `partial` is **not** a status: it is an overlay counting automated rows that
+   * still carry a `manualRemainder`, and every such row is *also* counted by its
+   * own status. Without it a report could read "0 manual" while rows 7 and 19
+   * had unticked boxes on the canvas, so it is deliberately excluded from the
+   * sum rather than folded into `manual`.
+   */
   counts: Record<
-    "pass" | "warn" | "fail" | "manual" | "notImplemented",
+    "pass" | "warn" | "fail" | "manual" | "notImplemented" | "partial",
     number
   >;
 }


### PR DESCRIPTION
Two parts: a primary-source record of the interview the QA PRD was written from, and the two checklist items that record showed were tractable.

## Why

`docs/prd-automated-qa.md` was written from a walkthrough call with design, and comparing the two shows the PRD drifted, consistently toward sounding firmer and more machine-checkable than what was actually asked for. That matters most for the items still unautomated, since they are the ones being specified next.

## The source document

`docs/qa-source-interview.md` is now the primary source: per-item notes with the Hebrew quotes kept, because most of the distinctions live in the exact wording. Where it and the PRD disagree, it wins.

It also captures requirements the PRD has nowhere: the disposable QA section at the end of the page, **descriptive** per-item output (*"a list with the title and the result... descriptive, that explains what it found"*), stage-2 visual evidence, per-project item suppression (~half of projects have no Storybook at all), and the hand-QA'd reference component.

The PRD gets a provenance header and per-item `Source:` notes. Highlights:

- **Item 1** - the PRD has the plugin flagging structural variations vs Storybook and hunting a *"Changes from SB" note component*. Design ruled out both: the comparison twice (*"not something I expect the plugin to do, just to see that such a note exists"*), and the note is *"just"* an element with no name.
- **Item 19** is inverted; QA usually runs *before* documentation, so absence is not a defect.
- **Item 18** is far lighter than documented; headers, anatomy breakdowns and "assigned regions" are invented.
- **Item 6**'s `Mobile/Paragraph 2 Regular` convention appears nowhere in the call.
- **Item 10** omits icon sizes entirely: 16/24/32/48, plus 12, plus **14 as an accepted exception**.
- **Items 13 and 15** are *"pretty redundant"* and *"not critical"* in design's own words, and **item 16**'s entire ask was *"just see that everything is readable"*, so every WCAG specific is ours to revise rather than a design requirement.

## The two checks

Both advisory, matching how design described them.

**`responsive-bounds` (#7)** - size-bounds half only. Warns at `low` severity when variant roots carry none of `minWidth`/`maxWidth`/`minHeight`/`maxHeight`.

- **Incompleteness is not reported.** Requiring all four would put a finding on nearly every component, and an always-amber row stops being read, the same reasoning behind `high-contrast`'s skip tally. Any bound set means `pass`, with the unset ones named in `note` so the row stays descriptive.
- One finding per set carrying `count`, not one per variant: variants share bound configuration, so per-variant findings would repeat one fact up to 64 times.
- **Applicability is decided by the collector, not by the root's own `layoutMode`.** Figma allows bounds on auto-layout frames *and their direct children*, so a `layoutMode: "NONE"` variant inside an auto-layout component set is a legitimate place for them; `boundsApplicable` is collected because only the collector can see the parent.
- Simulating resize is **not** attempted; "breaks" is undefined and stays a human call.

**`documentation` (#19)** - cannot fail by design. Link present means `pass`, none means `not_applicable`. Reporting absence as `warn` would make most runs amber for a non-problem.

Neither was a pure snapshot check: `documentationLinks`, the four min/max fields and `boundsApplicable` all had to be added to the collector.

## Partial automation is now modelled explicitly

Both new rows automate only part of their checklist item. `CheckResult` gains `manualRemainder`: such a row renders its status chip **and keeps a tickable box**, plus a "Still manual:" line naming what is left.

- **Item 7** does not simulate resize, so a green chip must not stand for a resize test nobody performed.
- **Item 19**'s row claims usage guidance, examples and properties are documented, while the check only reads Figma's documentation-link field. A link is evidence that documentation exists, never that its content is adequate.

The remainder belongs to the **check**, not the catalogue entry, because whether work remains can depend on what the check found. Item 19 asks for a content review only when a link exists - with no documentation there is nothing to read, so a static per-item string would put "read the documentation" on the row precisely when there was none. Item 7's is unconditional by contrast, since a set being unable to hold bounds says nothing about whether it survives a resize.

Those rows are also tallied as **`counts.partial`**, surfaced in the canvas summary line and in the `tidy_qa_build_checklist` stub. It is an overlay rather than a status, so each row is still counted by its own verdict; without it a report reads "0 manual" while rows carry unticked boxes. Rows whose check never ran carry no remainder, since nothing about them was established and their not_run / not_implemented chip already says the whole row is open.

The source doc notes three pre-existing rows that deserve the same treatment and do not get it here: **item 2** (`set-name-casing` checks casing, not dev prop names), **item 17** (`themes` covers resolution, but the ask was visual), and **item 12** (`description` does not verify the Storybook link).

## Needs design confirmation before the row is authoritative

`documentation` uses **Figma's documentation-link field**, the only machine-readable "this is documented" marker the plugin API exposes. Design described item 19 as a *stage*, not a field, so if their docs live in a linked page or as the Storybook URL in the description (item 12's business), this is looking in the wrong place. It says so in `note` on both outcomes rather than reading as green.

## Scope left out, deliberately

- **Item 1** deferred with all Storybook-dependent work, which also covers the prop-name half of item 2.
- **Item 18** needs the collector's scope widened past the component set: `ComponentSetSnapshot` stops at the set, and the labels design described are page siblings. Plus "arranged well" is undefined.
- **Item 3**'s icon-colour invariant needs the runtime-config surface first.

## Known gaps, tracked not fixed

- **Per-project suppression does not exist yet.** The source is explicit that less robust design systems skip item 7, and `runChecks` runs the whole catalogue by default. `responsive-bounds` is deliberately quiet (advisory, `low`, and only when *no* bound is set, with "Advisory only" in its note), but projects that never use bounds will see the row until suppression lands.
- **`isOnGrid` rejects 14**, so any 14px icon fails `grid-4px` today on both width and height, against a size design explicitly accepts. Needs the same config surface.
- **Adding a check touches six surfaces** (`CheckId`, `CHECKS`, `CHECK_REGISTRY`, `CHECKLIST_CATALOGUE`, the MCP catalogue text, and the command doc). A single declarative manifest could derive most of them; worth its own PR rather than bundling it here.

## Verification

15 of 19 items automated (was 13). 499 tests pass, 34 new. `typecheck` clean, `format:check` clean, no new lint warnings, `build` and `build:plugin` green including the bundled-server smoke test.


