### PR TITLE
feat(mcp): check per-variant property wiring for QA item 3

### DIFF
--- a/claude-plugin/commands/tidy-qa.md
+++ b/claude-plugin/commands/tidy-qa.md
@@ -24,7 +24,8 @@ Split `$ARGUMENTS` on whitespace into tokens, then classify each:
   `set-name-casing`, `prop-order`, `tokens`, `layer-naming-structure`,
   `grid-4px`, `interaction-hover-only`, `description`, `no-conflicts`,
   `preferred-values`, `nesting-depth`, `asset-provenance`, `themes`,
-  `high-contrast`, `responsive-bounds`, `documentation`. Collect these into
+  `high-contrast`, `responsive-bounds`, `documentation`,
+  `variant-property-bindings`. Collect these into
   the `checks` array (a filter - only these checks run).
 - **Id** — a token matching `^\d+:\d+$` (e.g. `2625:10445`). Use as `nodeId`.
 - **Target name / glob** — every remaining token. Join them with spaces (names

--- a/docs/prd-automated-qa.md
+++ b/docs/prd-automated-qa.md
@@ -69,6 +69,19 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 > Unspecified and blocking: what "breaks" means (clipping? overflow? zero size?), and the combinatorial cost of *"all combinations"* on a large set.
 > See [source notes, item 3](qa-source-interview.md#3-check-all-the-props).
 
+> **Shipped as check `variant-property-bindings`: property *wiring*, not appearance.**
+> Neither the PRD nor the source names the failure this item most often hides, because it is a Figma modelling artifact rather than a design mistake.
+> A boolean property's **definition** lives on the component set, so its toggle appears in the panel for every variant the moment it is created, while its **binding** lives on one layer inside one variant and does not propagate when variants are added or duplicated.
+> The result is a toggle that is present, looks identical to a working one, and does nothing - with no error and no visual difference, in a state that is hidden by default because booleans default to off.
+> Twelve variants and two booleans is twenty-four bindings, which nobody verifies by hand.
+>
+> That is fully structural, so the check is a pure snapshot check across **every** variant: no clone, no resize, no render.
+> It reports partial wiring, a property bound nowhere at all, and a binding whose target layer disagrees with the rest of the set - the shape a crossed binding takes, and the case a "did toggling change anything" test passes.
+> Two of those three use the set as its own oracle rather than any naming heuristic: the layer to bind is identified by name from the variants that *are* wired, and an odd target is one the majority contradicts.
+>
+> The rest of the item - cycling combinations, long text, and the icon/text colour invariant - stays a tick on the row via an unconditional `manualRemainder`.
+> Correct wiring says nothing about whether the states it exposes render correctly.
+
 
 
 ### 4. Prop Names Aligned to Consolidated Catalogue

--- a/docs/prd-qa-canvas-checklist.md
+++ b/docs/prd-qa-canvas-checklist.md
@@ -98,7 +98,7 @@ Three new pieces, plus one operation:
 |------|------|--------------|
 | 1 | Storybook Alignment + Note | manual |
 | 2 | Components Naming Dev Alignment | `set-name-casing` |
-| 3 | Check All the Props | manual |
+| 3 | Check All the Props | `variant-property-bindings` (wiring only; row keeps a manual tick) |
 | 4 | Prop Names Aligned to Catalogue | `prop-order` |
 | 5 | Tokens (Styles & Variables) | `tokens` |
 | 6 | Typography Desktop\|Mobile | manual |

--- a/docs/qa-source-interview.md
+++ b/docs/qa-source-interview.md
@@ -332,13 +332,29 @@ The six items that were still `tier: null` in [`checklist-catalogue.ts`](../src/
 | **19** Documentation | **shipped** `documentation` | Presence of a docs link, `pass` or `not_applicable` | Confirm with design that Figma's documentation-link field is where their docs live |
 | **7** Responsiveness | **shipped** `responsive-bounds` | Are min/max width/height set, as advice | Nothing. "Doesn't break on resize" is the harder, separable half, and stays a manual tick on the row |
 | **18** Page Template | blocked | Are the expected labels present around the component | The snapshot is **set-scoped** and the labels are page siblings, so this needs the collector's scope widened, plus a definition of "tidy" |
-| **3** Check All the Props | open | Icon colour equals text colour, as a configured invariant | A definition of "breaks"; combinatorial cost on large sets |
+| **3** Check All the Props | **shipped** `variant-property-bindings` | Is every property actually *wired* in every variant | Nothing, for the wiring half. The icon/text colour invariant and long-text stress still need a definition of "breaks" and stay a manual tick |
 | **1** Storybook Alignment + Note | **deferred** (2026-07-27) | Does a deviation note exist on the page | Deferred by decision: all Storybook-dependent work is parked, which also covers the prop-name half of item 2 |
 | **6** Typography Desktop\|Mobile | blocked | Style correspondence across a desktop/mobile pair | Both the pairing rule and the correspondence rule; nothing in the call specifies either |
 
 Note that none of these were pure snapshot checks.
-`documentationLinks` and the four `min/max` fields both had to be added to the collector first.
+`documentationLinks`, the four `min/max` fields and `propertyReferences` all had to be added to the collector first.
 Item 18 is the sharp version of that problem: `ComponentSetSnapshot` deliberately stops at the component set, and item 18 is the first check that needs to see the page around it.
+
+### The Figma modelling artifact behind item 3
+
+The interview describes item 3 as cycling props and seeing nothing breaks, which reads as a dynamic check, and that is how it was filed.
+The failure the item most often hides turned out to be structural, and it is nowhere in the call because it is an artifact of how Figma models properties rather than anything a designer would think to describe.
+
+A boolean property's **definition** lives on the component set, so its toggle appears in the properties panel for every variant the moment it is created.
+Its **binding** lives on one layer inside one variant, and does not propagate when variants are added or duplicated.
+So a set ships where `Show Left Icon` is wired on Primary and silently missed on Ghost: the toggle is there, looks identical to a working one, and does nothing.
+Figma raises no error and draws no distinction, and booleans default to off, so the evidence sits in a state nobody looks at.
+Twelve variants and two booleans is twenty-four bindings.
+
+Checking that by hand means twenty-four select-toggle-untoggle cycles, so in practice it is never checked, and it surfaces in a consumer's file weeks later rather than in the library.
+
+The lesson worth keeping is that the source describes the **workflow** faithfully and cannot be expected to describe the **tool's** failure modes.
+Reading item 3 only as written would have produced a render harness and left the actual defect in place.
 
 ### Partial automation is the norm, not the exception
 
@@ -352,8 +368,11 @@ The remainder belongs to the **check**, not to the catalogue entry, because whet
 Item 19 asks for a content review only when a link exists; with no documentation there is nothing to read, and a static per-item string put "read the documentation" on the row precisely when there was none.
 Item 7's is unconditional by contrast, since a set being unable to hold bounds says nothing about whether it survives a resize.
 
+Item 3 is the third, and unconditional like item 7's: the check establishes that every property is wired, while the item asks for combinations cycled, long text always, and icon colour following text colour.
+Correct wiring says nothing about whether the states it exposes render correctly, so the tick is owed on every outcome.
+
 The report also counts these rows separately, as `counts.partial`.
-Without that, a run could report "0 manual" while rows 7 and 19 still had unticked boxes on the canvas.
+Without that, a run could report "0 manual" while rows 3, 7 and 19 still had unticked boxes on the canvas.
 
 The same treatment is owed to at least these, all pre-existing:
 

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -279,7 +279,7 @@ export const CATALOGUE: CatalogueEntry[] = [
         .array(z.string())
         .optional()
         .describe(
-          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth, asset-provenance, themes, high-contrast, responsive-bounds, documentation.",
+          "Optional check-id filter (e.g. ['tokens', 'grid-4px']). Defaults to the full catalogue: set-name-casing, prop-order, tokens, layer-naming-structure, grid-4px, interaction-hover-only, description, no-conflicts, preferred-values, nesting-depth, asset-provenance, themes, high-contrast, responsive-bounds, documentation, variant-property-bindings.",
         ),
     },
     timeoutMs: 60_000,

--- a/src/plugins/qa/checklist-catalogue.test.ts
+++ b/src/plugins/qa/checklist-catalogue.test.ts
@@ -16,7 +16,12 @@ const PRD_ITEMS: ReadonlyArray<{
     tier: 1,
     checkId: "set-name-casing",
   },
-  { n: 3, title: "Check All the Props", tier: null },
+  {
+    n: 3,
+    title: "Check All the Props",
+    tier: 1,
+    checkId: "variant-property-bindings",
+  },
   {
     n: 4,
     title: "Prop Names Aligned to Catalogue",
@@ -125,8 +130,8 @@ describe("CHECKLIST_CATALOGUE", () => {
 
   it("gives every automated item a unique checkId, tiered 1 or 2", () => {
     const automated = CHECKLIST_CATALOGUE.filter((item) => item.checkId);
-    expect(automated).toHaveLength(15);
-    expect(new Set(automated.map((item) => item.checkId)).size).toBe(15);
+    expect(automated).toHaveLength(16);
+    expect(new Set(automated.map((item) => item.checkId)).size).toBe(16);
     for (const item of automated) {
       expect(item.tier === 1 || item.tier === 2).toBe(true);
     }

--- a/src/plugins/qa/checklist-catalogue.ts
+++ b/src/plugins/qa/checklist-catalogue.ts
@@ -48,7 +48,17 @@ export const CHECKLIST_CATALOGUE: readonly CatalogueItem[] = [
   {
     n: 3,
     title: "Check All the Props",
-    tier: null,
+    tier: 1,
+    checkId: "variant-property-bindings",
+    // The automated core is *wiring*, not appearance: Figma defines a boolean
+    // property on the set but binds it per variant, so a toggle can appear in
+    // the panel for a variant that has no binding and does nothing. That is
+    // structural, hence a Tier 1 snapshot check.
+    //
+    // This blurb states the item, which is wider than the check: design asked
+    // for all combinations cycled, long text always, and icon colour following
+    // text colour. The check emits an unconditional `manualRemainder` for that
+    // rest, so the row keeps a tickbox next to its chip.
     blurb: "Every property combination renders correctly across the set.",
   },
   {

--- a/src/plugins/qa/checks/index.test.ts
+++ b/src/plugins/qa/checks/index.test.ts
@@ -13,8 +13,8 @@ const FIXTURE: ComponentSetSnapshot = {
   description: "",
   propertyNames: ["Size", "State"],
   properties: [
-    { name: "Size", type: "VARIANT" },
-    { name: "State", type: "VARIANT" },
+    { name: "Size", key: "Size", type: "VARIANT" },
+    { name: "State", key: "State", type: "VARIANT" },
   ],
   variants: [
     {
@@ -36,15 +36,17 @@ const FIXTURE: ComponentSetSnapshot = {
 
 describe("check catalogue", () => {
   it("lists the 9 Tier 1 checks plus the Tier 2 checks, with unique ids", () => {
-    expect(CHECKS).toHaveLength(15);
-    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(15);
+    expect(CHECKS).toHaveLength(16);
+    expect(new Set(CHECKS.map((c) => c.id)).size).toBe(16);
     // The static Tier 1 PRD sections (issue #76), then Tier 2 appended in
     // shipping order: #14 (issue #99), #8 (issue #101), #17 (issue #102),
     // #16 (issue #103), then #7 and #19: the two items the source interview
     // showed were narrow advisory checks rather than the broad ones the PRD
-    // described (docs/qa-source-interview.md).
+    // described (docs/qa-source-interview.md). #3 lands last: its automatable
+    // core turned out to be per-variant property *wiring*, which is structural
+    // and so Tier 1 shaped, not the dynamic test it was filed as.
     expect(CHECKS.map((c) => c.prdSection)).toEqual([
-      2, 4, 5, 9, 10, 11, 12, 13, 15, 14, 8, 17, 16, 7, 19,
+      2, 4, 5, 9, 10, 11, 12, 13, 15, 14, 8, 17, 16, 7, 19, 3,
     ]);
   });
 

--- a/src/plugins/qa/checks/index.ts
+++ b/src/plugins/qa/checks/index.ts
@@ -23,6 +23,7 @@ import { checkThemes } from "./themes";
 import { checkHighContrast } from "./high-contrast";
 import { checkResponsiveBounds } from "./responsive-bounds";
 import { checkDocumentation } from "./documentation";
+import { checkVariantPropertyBindings } from "./variant-property-bindings";
 
 export type CheckFn = (snapshot: ComponentSetSnapshot) => CheckResult;
 
@@ -47,6 +48,7 @@ export const CHECK_REGISTRY: Partial<Record<CheckId, CheckFn>> = {
   "high-contrast": checkHighContrast,
   "responsive-bounds": checkResponsiveBounds,
   documentation: checkDocumentation,
+  "variant-property-bindings": checkVariantPropertyBindings,
 };
 
 export interface RunOutcome {

--- a/src/plugins/qa/checks/preferred-values.test.ts
+++ b/src/plugins/qa/checks/preferred-values.test.ts
@@ -27,8 +27,13 @@ describe("checkPreferredValues", () => {
   it("passes when every INSTANCE_SWAP prop has populated preferred values", () => {
     const result = checkPreferredValues(
       fixture([
-        { name: "Icon", type: "INSTANCE_SWAP", preferredValuesCount: 3 },
-        { name: "Size", type: "VARIANT" },
+        {
+          name: "Icon",
+          key: "Icon#1:2",
+          type: "INSTANCE_SWAP",
+          preferredValuesCount: 3,
+        },
+        { name: "Size", key: "Size", type: "VARIANT" },
       ]),
     );
     expect(result).toEqual({
@@ -42,7 +47,12 @@ describe("checkPreferredValues", () => {
   it("warns when an INSTANCE_SWAP prop has an empty preferred values list", () => {
     const result = checkPreferredValues(
       fixture([
-        { name: "Icon", type: "INSTANCE_SWAP", preferredValuesCount: 0 },
+        {
+          name: "Icon",
+          key: "Icon#1:2",
+          type: "INSTANCE_SWAP",
+          preferredValuesCount: 0,
+        },
       ]),
     );
     expect(result.status).toBe("warn");
@@ -56,8 +66,8 @@ describe("checkPreferredValues", () => {
   it("is not_applicable when the set exposes no INSTANCE_SWAP props", () => {
     const result = checkPreferredValues(
       fixture([
-        { name: "Size", type: "VARIANT" },
-        { name: "Disabled", type: "BOOLEAN" },
+        { name: "Size", key: "Size", type: "VARIANT" },
+        { name: "Disabled", key: "Disabled#3:4", type: "BOOLEAN" },
       ]),
     );
     expect(result).toEqual({

--- a/src/plugins/qa/checks/prop-order.test.ts
+++ b/src/plugins/qa/checks/prop-order.test.ts
@@ -13,7 +13,11 @@ function fixture(propertyNames: string[]): ComponentSetSnapshot {
     type: "COMPONENT_SET",
     description: "",
     propertyNames,
-    properties: propertyNames.map((name) => ({ name, type: "VARIANT" })),
+    properties: propertyNames.map((name) => ({
+      name,
+      key: name,
+      type: "VARIANT",
+    })),
     variants: [],
   };
 }

--- a/src/plugins/qa/checks/variant-property-bindings.test.ts
+++ b/src/plugins/qa/checks/variant-property-bindings.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, expect } from "vitest";
+import { checkVariantPropertyBindings } from "./variant-property-bindings";
+import type {
+  ComponentPropertySnapshot,
+  ComponentSetSnapshot,
+  NodeSnapshot,
+  VariantSnapshot,
+} from "../snapshot";
+
+const SHOW_LEFT = "Show Left Icon#1:2";
+const SHOW_RIGHT = "Show Right Icon#3:4";
+
+function node(
+  name: string,
+  overrides: Partial<NodeSnapshot> = {},
+): NodeSnapshot {
+  return {
+    id: `n-${name}`,
+    name,
+    type: "FRAME",
+    visible: true,
+    width: 24,
+    height: 24,
+    children: [],
+    ...overrides,
+  };
+}
+
+/** A layer bound to a property via its visibility, i.e. a wired boolean. */
+function bound(name: string, key: string, visible = false): NodeSnapshot {
+  return node(name, { visible, propertyReferences: { visible: key } });
+}
+
+function variant(
+  variantProperties: Record<string, string>,
+  children: NodeSnapshot[],
+): VariantSnapshot {
+  const label = Object.values(variantProperties).join("-") || "solo";
+  return {
+    id: `v-${label}`,
+    name: label,
+    variantProperties,
+    tree: node(label, { id: `v-${label}`, type: "COMPONENT", children }),
+  };
+}
+
+function prop(
+  name: string,
+  key: string,
+  type = "BOOLEAN",
+): ComponentPropertySnapshot {
+  return { name, key, type };
+}
+
+function fixture(
+  properties: ComponentPropertySnapshot[],
+  variants: VariantSnapshot[],
+): ComponentSetSnapshot {
+  return {
+    id: "1:1",
+    name: "Button",
+    type: "COMPONENT_SET",
+    description: "",
+    propertyNames: properties.map((p) => p.name),
+    properties,
+    variants,
+  };
+}
+
+describe("checkVariantPropertyBindings (#3)", () => {
+  it("passes when every bindable property is wired in every variant", () => {
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [
+          variant({ Variant: "Primary" }, [bound("icon-left", SHOW_LEFT)]),
+          variant({ Variant: "Ghost" }, [bound("icon-left", SHOW_LEFT)]),
+        ],
+      ),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("fails and names every variant where the property is unwired", () => {
+    // The defect: Figma puts the definition on the set so the toggle shows on
+    // all three, but only Primary carries a binding.
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [
+          variant({ Variant: "Primary" }, [bound("icon-left", SHOW_LEFT)]),
+          variant({ Variant: "Ghost" }, [node("icon-left")]),
+          variant({ Variant: "Danger" }, [node("icon-left")]),
+        ],
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].severity).toBe("high");
+    expect(result.findings[0].count).toBe(2);
+    expect(result.findings[0].message).toContain("2 of 3");
+    expect(result.findings[0].message).toContain("Variant=Ghost");
+    expect(result.findings[0].message).toContain("Variant=Danger");
+  });
+
+  it("names the unbound layer to fix, and anchors the finding to it", () => {
+    // Variants get duplicated, so the layer survives while the binding is lost.
+    // Pointing at that layer is the difference between a correct finding and a
+    // useful one.
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [
+          variant({ Variant: "Primary" }, [bound("icon-left", SHOW_LEFT)]),
+          variant({ Variant: "Ghost" }, [node("icon-left")]),
+        ],
+      ),
+    );
+    expect(result.findings[0].message).toContain(
+      '"icon-left" is present and unbound',
+    );
+    expect(result.findings[0].nodeName).toBe("icon-left");
+  });
+
+  it("calls out an unbound layer left visible, which cannot be switched off", () => {
+    // The nastier shape of the same defect: it looks correct at rest, and the
+    // icon shows regardless of the toggle.
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [
+          variant({ Variant: "Primary" }, [bound("icon-left", SHOW_LEFT)]),
+          variant({ Variant: "Ghost" }, [node("icon-left", { visible: true })]),
+        ],
+      ),
+    );
+    expect(result.findings[0].message).toContain("cannot be switched off");
+  });
+
+  it("stays silent about a stuck layer when the unbound layer is hidden", () => {
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [
+          variant({ Variant: "Primary" }, [bound("icon-left", SHOW_LEFT)]),
+          variant({ Variant: "Ghost" }, [
+            node("icon-left", { visible: false }),
+          ]),
+        ],
+      ),
+    );
+    expect(result.findings[0].message).not.toContain("cannot be switched off");
+  });
+
+  it("finds bindings at any depth, not just on direct children", () => {
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [
+          variant({ Variant: "Primary" }, [
+            node("content", { children: [bound("icon-left", SHOW_LEFT)] }),
+          ]),
+          variant({ Variant: "Ghost" }, [
+            node("content", { children: [bound("icon-left", SHOW_LEFT)] }),
+          ]),
+        ],
+      ),
+    );
+    expect(result.status).toBe("pass");
+  });
+
+  it("fails a property bound to no layer in any variant", () => {
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [
+          variant({ Variant: "Primary" }, [node("icon-left")]),
+          variant({ Variant: "Ghost" }, [node("icon-left")]),
+        ],
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toContain("bound to no layer in any");
+  });
+
+  it("reports each property separately", () => {
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [
+          prop("Show Left Icon", SHOW_LEFT),
+          prop("Show Right Icon", SHOW_RIGHT),
+        ],
+        [
+          variant({ Variant: "Primary" }, [
+            bound("icon-left", SHOW_LEFT),
+            bound("icon-right", SHOW_RIGHT),
+          ]),
+          variant({ Variant: "Ghost" }, [
+            node("icon-left"),
+            node("icon-right"),
+          ]),
+        ],
+      ),
+    );
+    expect(result.findings).toHaveLength(2);
+    expect(result.findings.map((f) => f.expected)).toEqual([
+      '"Show Left Icon" bound in every variant',
+      '"Show Right Icon" bound in every variant',
+    ]);
+  });
+
+  it("joins on the suffixed key, not the display name", () => {
+    // A binding referencing a *different* property that happens to strip to a
+    // similar name must not count as wiring this one.
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [variant({ Variant: "Primary" }, [bound("icon-left", SHOW_RIGHT)])],
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].message).toContain("bound to no layer in any");
+  });
+
+  it("covers instance-swap properties, which bind via mainComponent", () => {
+    const swap = prop("Icon", "Icon#5:6", "INSTANCE_SWAP");
+    const wiredSwap = node("icon", {
+      type: "INSTANCE",
+      propertyReferences: { mainComponent: "Icon#5:6" },
+    });
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [swap],
+        [
+          variant({ Size: "Small" }, [wiredSwap]),
+          variant({ Size: "Large" }, [node("icon", { type: "INSTANCE" })]),
+        ],
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].count).toBe(1);
+  });
+
+  it("covers text properties, which bind via characters", () => {
+    const text = prop("Label", "Label#7:8", "TEXT");
+    const wiredText = node("label", {
+      type: "TEXT",
+      propertyReferences: { characters: "Label#7:8" },
+    });
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [text],
+        [
+          variant({ Size: "Small" }, [wiredText]),
+          variant({ Size: "Large" }, [node("label", { type: "TEXT" })]),
+        ],
+      ),
+    );
+    expect(result.status).toBe("fail");
+  });
+
+  it("ignores variant properties, which carry no layer binding", () => {
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Size", "Size", "VARIANT")],
+        [variant({ Size: "Small" }, []), variant({ Size: "Large" }, [])],
+      ),
+    );
+    expect(result.status).toBe("not_applicable");
+    expect(result.note).toContain("nothing to wire");
+  });
+
+  it("is not_applicable for a set with no bindable properties at all", () => {
+    const result = checkVariantPropertyBindings(
+      fixture([], [variant({ Size: "Small" }, [])]),
+    );
+    expect(result.status).toBe("not_applicable");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("still catches a dead property on a standalone component", () => {
+    // One variant means partial wiring is impossible, but a property bound to
+    // nothing is still a toggle that does nothing.
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [variant({}, [node("icon")])],
+      ),
+    );
+    expect(result.status).toBe("fail");
+  });
+
+  describe("odd binding target", () => {
+    function withTargets(names: string[]): ComponentSetSnapshot {
+      return fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        names.map((layerName, i) =>
+          variant({ Variant: `V${i}` }, [bound(layerName, SHOW_LEFT)]),
+        ),
+      );
+    }
+
+    it("warns when one variant binds a differently-named layer than the rest", () => {
+      const result = checkVariantPropertyBindings(
+        withTargets(["icon-left", "icon-left", "icon-left", "icon-right"]),
+      );
+      expect(result.status).toBe("warn");
+      expect(result.findings).toHaveLength(1);
+      expect(result.findings[0].severity).toBe("medium");
+      expect(result.findings[0].message).toContain("crossed binding");
+      expect(result.findings[0].message).toContain("Variant=V3");
+      expect(result.findings[0].count).toBe(1);
+    });
+
+    it("stays quiet without a clear majority, since there is no convention to violate", () => {
+      const result = checkVariantPropertyBindings(
+        withTargets(["icon-left", "icon-left", "icon-right", "icon-right"]),
+      );
+      expect(result.status).toBe("pass");
+    });
+
+    it("stays quiet on small sets, where a majority means little", () => {
+      const result = checkVariantPropertyBindings(
+        withTargets(["icon-left", "icon-right"]),
+      );
+      expect(result.status).toBe("pass");
+    });
+
+    it("stays quiet when a property legitimately drives several layers", () => {
+      const multi = fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [
+          variant({ Variant: "A" }, [
+            bound("icon-left", SHOW_LEFT),
+            bound("spacer", SHOW_LEFT),
+          ]),
+          variant({ Variant: "B" }, [bound("icon-left", SHOW_LEFT)]),
+          variant({ Variant: "C" }, [bound("icon-left", SHOW_LEFT)]),
+        ],
+      );
+      expect(checkVariantPropertyBindings(multi).status).toBe("pass");
+    });
+
+    it("does not soften a wiring failure to warn", () => {
+      const result = checkVariantPropertyBindings(
+        fixture(
+          [prop("Show Left Icon", SHOW_LEFT)],
+          [
+            variant({ Variant: "A" }, [bound("icon-left", SHOW_LEFT)]),
+            variant({ Variant: "B" }, [bound("icon-left", SHOW_LEFT)]),
+            variant({ Variant: "C" }, [bound("icon-right", SHOW_LEFT)]),
+            variant({ Variant: "D" }, [node("icon-left")]),
+          ],
+        ),
+      );
+      expect(result.status).toBe("fail");
+      expect(result.findings).toHaveLength(2);
+    });
+  });
+
+  it("summarises rather than listing every variant on a large set", () => {
+    const variants = Array.from({ length: 12 }, (_, i) =>
+      variant({ Variant: `V${i}` }, [node("icon-left")]),
+    );
+    variants[0] = variant({ Variant: "V0" }, [bound("icon-left", SHOW_LEFT)]);
+    const result = checkVariantPropertyBindings(
+      fixture([prop("Show Left Icon", SHOW_LEFT)], variants),
+    );
+    expect(result.findings[0].count).toBe(11);
+    expect(result.findings[0].message).toContain("and 5 more");
+  });
+
+  it("always leaves the render checks outstanding, on every outcome", () => {
+    // Item 3 asks for combinations cycled, long text, and icon colour matching
+    // text colour. Wiring integrity says nothing about any of that, so - like
+    // #7's remainder and unlike #19's - this is owed on every outcome.
+    const wired = bound("icon-left", SHOW_LEFT);
+    const cases = [
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [variant({ Variant: "Primary" }, [wired])],
+      ), // pass
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [
+          variant({ Variant: "Primary" }, [wired]),
+          variant({ Variant: "Ghost" }, [node("icon-left")]),
+        ],
+      ), // fail
+      fixture([prop("Size", "Size", "VARIANT")], [variant({ Size: "S" }, [])]), // not_applicable
+    ];
+    for (const fx of cases) {
+      expect(checkVariantPropertyBindings(fx).manualRemainder).toMatch(
+        /long text/,
+      );
+    }
+  });
+
+  it("reports under the right check id and title", () => {
+    const result = checkVariantPropertyBindings(
+      fixture(
+        [prop("Show Left Icon", SHOW_LEFT)],
+        [variant({ Variant: "Primary" }, [bound("icon-left", SHOW_LEFT)])],
+      ),
+    );
+    expect(result.checkId).toBe("variant-property-bindings");
+    expect(result.title).toBe("Property bindings across variants");
+  });
+});

--- a/src/plugins/qa/checks/variant-property-bindings.test.ts
+++ b/src/plugins/qa/checks/variant-property-bindings.test.ts
@@ -170,6 +170,90 @@ describe("checkVariantPropertyBindings (#3)", () => {
     expect(result.status).toBe("pass");
   });
 
+  describe("lost binding versus a state with no such content", () => {
+    it("warns, not fails, when the layer is absent from the unwired variants", () => {
+      // A real 64-variant Button: every state=loading variant swaps its label
+      // and icons for a spinner, so there is no layer to bind and nothing the
+      // author can fix. Failing here turned a correct component red.
+      const result = checkVariantPropertyBindings(
+        fixture(
+          [prop("Show Left Icon", SHOW_LEFT)],
+          [
+            variant({ State: "Default" }, [bound("icon-left", SHOW_LEFT)]),
+            variant({ State: "Loading" }, [node("spinner")]),
+          ],
+        ),
+      );
+      expect(result.status).toBe("warn");
+      expect(result.findings).toHaveLength(1);
+      expect(result.findings[0].severity).toBe("medium");
+      expect(result.findings[0].message).toContain("has no target in 1 of 2");
+      expect(result.findings[0].message).toContain("deliberately drop");
+      expect(result.findings[0].count).toBe(1);
+    });
+
+    it("does not offer a layer to bind when there is none", () => {
+      const result = checkVariantPropertyBindings(
+        fixture(
+          [prop("Show Left Icon", SHOW_LEFT)],
+          [
+            variant({ State: "Default" }, [bound("icon-left", SHOW_LEFT)]),
+            variant({ State: "Loading" }, [node("spinner")]),
+          ],
+        ),
+      );
+      expect(result.findings[0].message).not.toContain("the layer to bind");
+      expect(result.findings[0].suggestedFix).toContain("nothing to fix");
+    });
+
+    it("still fails when at least one unwired variant kept the layer", () => {
+      // A mix means a binding really was lost somewhere, so the defect stands.
+      const result = checkVariantPropertyBindings(
+        fixture(
+          [prop("Show Left Icon", SHOW_LEFT)],
+          [
+            variant({ State: "Default" }, [bound("icon-left", SHOW_LEFT)]),
+            variant({ State: "Loading" }, [node("spinner")]),
+            variant({ State: "Hover" }, [node("icon-left")]),
+          ],
+        ),
+      );
+      expect(result.status).toBe("fail");
+      expect(result.findings[0].severity).toBe("high");
+      expect(result.findings[0].message).toContain("the layer to bind");
+      // Both unwired variants are still reported, only one is the fix location.
+      expect(result.findings[0].count).toBe(2);
+      expect(result.findings[0].message).toContain("2 of 3");
+    });
+
+    it("keeps a genuine defect on one property from being masked by another", () => {
+      const result = checkVariantPropertyBindings(
+        fixture(
+          [
+            prop("Show Left Icon", SHOW_LEFT),
+            prop("Label", "Label#9:9", "TEXT"),
+          ],
+          [
+            variant({ State: "Default" }, [
+              bound("icon-left", SHOW_LEFT),
+              node("label", {
+                type: "TEXT",
+                propertyReferences: { characters: "Label#9:9" },
+              }),
+            ]),
+            // No icon layer (fine), but the label survived unbound (a defect).
+            variant({ State: "Loading" }, [node("label", { type: "TEXT" })]),
+          ],
+        ),
+      );
+      expect(result.status).toBe("fail");
+      expect(result.findings.map((f) => f.severity)).toEqual([
+        "medium",
+        "high",
+      ]);
+    });
+  });
+
   it("fails a property bound to no layer in any variant", () => {
     const result = checkVariantPropertyBindings(
       fixture(

--- a/src/plugins/qa/checks/variant-property-bindings.test.ts
+++ b/src/plugins/qa/checks/variant-property-bindings.test.ts
@@ -241,6 +241,11 @@ describe("checkVariantPropertyBindings (#3)", () => {
     );
     expect(result.status).toBe("fail");
     expect(result.findings[0].count).toBe(1);
+    // The unbound instance is visible, but an instance-swap property drives
+    // `mainComponent`: the layer is supposed to be visible, so the stuck-visible
+    // diagnosis would be nonsense here.
+    expect(result.findings[0].message).not.toContain("cannot be switched off");
+    expect(result.findings[0].message).toContain("that is the layer to bind");
   });
 
   it("covers text properties, which bind via characters", () => {
@@ -259,6 +264,10 @@ describe("checkVariantPropertyBindings (#3)", () => {
       ),
     );
     expect(result.status).toBe("fail");
+    // A visible unbound text layer is the normal case: the label renders, it
+    // just cannot be overridden. Nothing is stuck on.
+    expect(result.findings[0].message).not.toContain("cannot be switched off");
+    expect(result.findings[0].message).toContain("that is the layer to bind");
   });
 
   it("ignores variant properties, which carry no layer binding", () => {

--- a/src/plugins/qa/checks/variant-property-bindings.ts
+++ b/src/plugins/qa/checks/variant-property-bindings.ts
@@ -162,7 +162,15 @@ function partialWiringFinding(
 
   // An unbound layer left visible is the nastier shape of the same defect: the
   // icon is always on and cannot be switched off, and it looks correct at rest.
-  const stuckVisible = candidates.filter((c) => c.layer?.visible === true);
+  //
+  // BOOLEAN properties only. A visible unbound layer says nothing at all for a
+  // TEXT or INSTANCE_SWAP property - those drive `characters` and
+  // `mainComponent`, so their layer is *supposed* to be visible and the only
+  // defect is that its content cannot be overridden.
+  const stuckVisible =
+    referenceKey === "visible"
+      ? candidates.filter((c) => c.layer?.visible === true)
+      : [];
 
   const fixLocation = firstWithLayer
     ? ` Layer "${firstWithLayer.layer?.name}" is present and unbound in ` +

--- a/src/plugins/qa/checks/variant-property-bindings.ts
+++ b/src/plugins/qa/checks/variant-property-bindings.ts
@@ -35,10 +35,12 @@
  * set-level bindings are expressible. So a missing binding here is a real
  * missing binding, not a blind spot.
  *
- * **The set is its own oracle.** Two of the three findings work by comparing
- * variants against each other rather than against a rule we invented:
- * the layer to fix is identified by name from the variants that *are* wired,
- * and an odd binding target is one that disagrees with the rest of the set.
+ * **The set is its own oracle.** The findings work by comparing variants against
+ * each other rather than against a rule we invented:
+ * the layer to fix is identified by name from the variants that *are* wired, an
+ * odd binding target is one that disagrees with the rest of the set, and whether
+ * unwired variants are a lost binding or a state that simply has no such content
+ * is decided by whether that layer exists there at all.
  * That keeps the check free of naming heuristics - it never guesses that
  * `icon-left` ought to belong to `Show Left Icon`, it only observes that eleven
  * variants agree and one does not.
@@ -141,12 +143,37 @@ function candidateLayer(
   );
 }
 
+/**
+ * Whether unwired variants are a *lost binding* or simply a *state without that
+ * content*, and the finding either way.
+ *
+ * The distinction is drawn from evidence the check already has rather than from
+ * any guess about intent: does the layer the wired variants bind even exist in
+ * the unwired ones?
+ *
+ * - **Present, unbound.** The variant was duplicated, the layer came along and
+ *   the binding did not. A defect, and the layer is the fix location.
+ * - **Absent everywhere.** Those variants deliberately omit that content - a
+ *   `state=loading` button that swaps its label and icons for a spinner is the
+ *   canonical case. The property still misleads, because Figma keeps its
+ *   definition on the set and shows the control regardless, but the component
+ *   author has nothing to bind and nothing to fix.
+ *
+ * Reporting the second as a defect turned a correct 64-variant Button red for
+ * behaviour that was intended, which is how a row stops being read.
+ */
+interface WiringFinding {
+  finding: Finding;
+  /** False when the property simply has no target in those variants. */
+  isDefect: boolean;
+}
+
 function partialWiringFinding(
   property: ComponentPropertySnapshot,
   wired: VariantBinding[],
   unwired: VariantBinding[],
   referenceKey: string,
-): Finding {
+): WiringFinding {
   const boundNames = new Set(
     wired.flatMap((entry) => entry.nodes.map((node) => node.name)),
   );
@@ -172,10 +199,40 @@ function partialWiringFinding(
       ? candidates.filter((c) => c.layer?.visible === true)
       : [];
 
-  const fixLocation = firstWithLayer
-    ? ` Layer "${firstWithLayer.layer?.name}" is present and unbound in ` +
-      `${candidates.filter((c) => c.layer).length} of them - that is the layer to bind.`
-    : "";
+  const total = wired.length + unwired.length;
+  const where = listVariants(unwired.map((entry) => entry.label));
+
+  // No layer to bind anywhere: those variants have no such content, so there is
+  // nothing the author can wire. Reported, because the panel still shows a
+  // control that does nothing, but not as their defect.
+  if (!firstWithLayer) {
+    return {
+      isDefect: false,
+      finding: {
+        severity: "medium",
+        nodeId: anchor.id,
+        nodeName: anchor.name,
+        message:
+          `"${property.name}" has no target in ${unwired.length} of ${total} ` +
+          `variants: ${where}. None of the layers the other ${wired.length} ` +
+          `bind is present there, so the property shows in the panel for these ` +
+          `variants and changes nothing. Expected when those variants ` +
+          `deliberately drop that content - a loading state with no label - and ` +
+          `a defect when they do not.`,
+        expected: `a bound target in every variant, or none of this content missing`,
+        actual: `no target in ${unwired.length} of ${total}`,
+        suggestedFix:
+          `Confirm the listed variants are meant to omit this content. If they ` +
+          `are, there is nothing to fix: Figma keeps the property definition on ` +
+          `the set, so the control appears whether or not a variant can use it.`,
+        count: unwired.length,
+      },
+    };
+  }
+
+  const fixLocation =
+    ` Layer "${firstWithLayer.layer?.name}" is present and unbound in ` +
+    `${candidates.filter((c) => c.layer).length} of them - that is the layer to bind.`;
 
   const stuckNote =
     stuckVisible.length > 0
@@ -184,21 +241,22 @@ function partialWiringFinding(
       : "";
 
   return {
-    severity: "high",
-    nodeId: anchor.id,
-    nodeName: anchor.name,
-    message:
-      `"${property.name}" is not wired in ${unwired.length} of ` +
-      `${wired.length + unwired.length} variants: ` +
-      `${listVariants(unwired.map((entry) => entry.label))}. ` +
-      `The property appears in the panel for these variants but changes ` +
-      `nothing.${fixLocation}${stuckNote}`,
-    expected: `"${property.name}" bound in every variant`,
-    actual: `bound in ${wired.length}, missing in ${unwired.length}`,
-    suggestedFix:
-      `Select the layer in each listed variant and bind it to ` +
-      `"${property.name}".`,
-    count: unwired.length,
+    isDefect: true,
+    finding: {
+      severity: "high",
+      nodeId: anchor.id,
+      nodeName: anchor.name,
+      message:
+        `"${property.name}" is not wired in ${unwired.length} of ${total} ` +
+        `variants: ${where}. The property appears in the panel for these ` +
+        `variants but changes nothing.${fixLocation}${stuckNote}`,
+      expected: `"${property.name}" bound in every variant`,
+      actual: `bound in ${wired.length}, missing in ${unwired.length}`,
+      suggestedFix:
+        `Select the layer in each listed variant and bind it to ` +
+        `"${property.name}".`,
+      count: unwired.length,
+    },
   };
 }
 
@@ -317,10 +375,14 @@ export function checkVariantPropertyBindings(
     }
 
     if (unwired.length > 0) {
-      findings.push(
-        partialWiringFinding(property, wired, unwired, referenceKey),
+      const { finding, isDefect } = partialWiringFinding(
+        property,
+        wired,
+        unwired,
+        referenceKey,
       );
-      hasFail = true;
+      findings.push(finding);
+      if (isDefect) hasFail = true;
     }
 
     const odd = oddTargetFinding(property, wired);

--- a/src/plugins/qa/checks/variant-property-bindings.ts
+++ b/src/plugins/qa/checks/variant-property-bindings.ts
@@ -1,0 +1,344 @@
+/**
+ * #3 - Check All the Props: is every component property actually **wired** in
+ * every variant?
+ *
+ * Figma splits a component property into two parts that live in different
+ * places. The *definition* sits on the component set, so the toggle appears in
+ * the properties panel for every variant the moment it is created. The
+ * *binding* sits on one layer inside one variant, as
+ * `componentPropertyReferences`, and it does **not** propagate when variants are
+ * added or duplicated.
+ *
+ * So a set ships where `Show Left Icon` is wired on Primary and silently missed
+ * on Ghost. The designer selects Ghost, sees an identical-looking toggle, flips
+ * it, and nothing happens. Figma shows no error and draws no distinction
+ * between a wired toggle and a decorative one, because the panel renders the
+ * definition and knows nothing about this variant's binding.
+ *
+ * Three properties of the defect make it survive review:
+ * booleans default to off, so the evidence is hidden in the state everyone
+ * looks at; two booleans across twelve variants is twenty-four bindings, which
+ * nobody verifies by hand; and it surfaces in a consumer's file weeks later,
+ * not in the library.
+ *
+ * **This is a pure snapshot check, not a visual one.** The collector already
+ * walks invisible children, so the hidden icon layer is in the tree; the only
+ * thing that had to be added was `NodeSnapshot.propertyReferences`. No clone, no
+ * resize, no render. It therefore runs across *every* variant rather than a
+ * sampled one.
+ *
+ * **Where bindings can live.** A property reference can only sit on a node in
+ * the component's own tree, never inside a nested instance - instance interiors
+ * belong to their main component, and nested properties surface through the
+ * separate `exposedInstances` mechanism instead. The collector stops at instance
+ * boundaries but walks everything above them, which is exactly the region where
+ * set-level bindings are expressible. So a missing binding here is a real
+ * missing binding, not a blind spot.
+ *
+ * **The set is its own oracle.** Two of the three findings work by comparing
+ * variants against each other rather than against a rule we invented:
+ * the layer to fix is identified by name from the variants that *are* wired,
+ * and an odd binding target is one that disagrees with the rest of the set.
+ * That keeps the check free of naming heuristics - it never guesses that
+ * `icon-left` ought to belong to `Show Left Icon`, it only observes that eleven
+ * variants agree and one does not.
+ */
+
+import type {
+  ComponentPropertySnapshot,
+  ComponentSetSnapshot,
+  NodeSnapshot,
+  VariantSnapshot,
+} from "../snapshot";
+import type { CheckResult, CheckStatus, Finding } from "../types";
+
+const TITLE = "Property bindings across variants";
+
+/**
+ * Item 3 asks for more than wiring: cycle the combinations and see nothing
+ * breaks, *always* try long text, and confirm icon colour follows text colour -
+ * a standing DS invariant, and the concrete failure design found mid-call.
+ * This check speaks only to whether each property is connected, so the rest
+ * stays a tick on the row.
+ *
+ * Unconditional, on item 7's logic rather than item 19's: that every property is
+ * correctly wired says nothing about whether the states it exposes render
+ * correctly, so the remainder is owed on every outcome - including
+ * `not_applicable`, where variant combinations and long text still want cycling.
+ */
+const RENDER_REMAINDER =
+  "Cycle the property combinations and confirm nothing breaks - long text " +
+  "especially, and that icon colour follows text colour. Only whether each " +
+  "property is wired is checked automatically.";
+
+/**
+ * Which node property each kind of component property drives, and therefore
+ * which `propertyReferences` key carries its binding. `VARIANT` is absent
+ * deliberately: variant properties are expressed by the set's children, not by
+ * a reference on a layer, so there is nothing to wire.
+ */
+const REFERENCE_KEY: Record<string, string> = {
+  BOOLEAN: "visible",
+  INSTANCE_SWAP: "mainComponent",
+  TEXT: "characters",
+};
+
+/** How many variant names a message spells out before summarising the rest. */
+const MAX_NAMED_VARIANTS = 6;
+
+function flatten(root: NodeSnapshot): NodeSnapshot[] {
+  return [root, ...root.children.flatMap(flatten)];
+}
+
+/** `Size=Small, Variant=Ghost`, falling back to the layer name for standalones. */
+function variantLabel(variant: VariantSnapshot): string {
+  const pairs = Object.entries(variant.variantProperties);
+  if (pairs.length === 0) return variant.name;
+  return pairs.map(([prop, value]) => `${prop}=${value}`).join(", ");
+}
+
+function listVariants(labels: string[]): string {
+  if (labels.length <= MAX_NAMED_VARIANTS) return labels.join("; ");
+  const shown = labels.slice(0, MAX_NAMED_VARIANTS).join("; ");
+  return `${shown}; and ${labels.length - MAX_NAMED_VARIANTS} more`;
+}
+
+interface VariantBinding {
+  variant: VariantSnapshot;
+  nodes: NodeSnapshot[];
+  label: string;
+}
+
+function bindingsFor(
+  snapshot: ComponentSetSnapshot,
+  property: ComponentPropertySnapshot,
+  referenceKey: string,
+): VariantBinding[] {
+  return snapshot.variants.map((variant) => ({
+    variant,
+    label: variantLabel(variant),
+    nodes: flatten(variant.tree).filter(
+      (node) => node.propertyReferences?.[referenceKey] === property.key,
+    ),
+  }));
+}
+
+/**
+ * The layer in an unwired variant that should almost certainly carry the
+ * binding: same name as the layers the wired variants bind, and bound to
+ * nothing itself. Variants are usually duplicated, so the layer survives while
+ * the binding is lost, which makes this the fix location rather than a guess.
+ */
+function candidateLayer(
+  variant: VariantSnapshot,
+  boundNames: Set<string>,
+  referenceKey: string,
+): NodeSnapshot | undefined {
+  return flatten(variant.tree).find(
+    (node) =>
+      boundNames.has(node.name) &&
+      node.propertyReferences?.[referenceKey] === undefined,
+  );
+}
+
+function partialWiringFinding(
+  property: ComponentPropertySnapshot,
+  wired: VariantBinding[],
+  unwired: VariantBinding[],
+  referenceKey: string,
+): Finding {
+  const boundNames = new Set(
+    wired.flatMap((entry) => entry.nodes.map((node) => node.name)),
+  );
+
+  // Prefer the fix location as the finding's node, so a caller jumping to it
+  // lands on the layer to bind rather than on the variant root.
+  const candidates = unwired.map((entry) => ({
+    entry,
+    layer: candidateLayer(entry.variant, boundNames, referenceKey),
+  }));
+  const firstWithLayer = candidates.find((c) => c.layer !== undefined);
+  const anchor = firstWithLayer?.layer ?? unwired[0].variant.tree;
+
+  // An unbound layer left visible is the nastier shape of the same defect: the
+  // icon is always on and cannot be switched off, and it looks correct at rest.
+  const stuckVisible = candidates.filter((c) => c.layer?.visible === true);
+
+  const fixLocation = firstWithLayer
+    ? ` Layer "${firstWithLayer.layer?.name}" is present and unbound in ` +
+      `${candidates.filter((c) => c.layer).length} of them - that is the layer to bind.`
+    : "";
+
+  const stuckNote =
+    stuckVisible.length > 0
+      ? ` In ${stuckVisible.length} of them that layer is left visible, so it ` +
+        `shows regardless of the toggle and cannot be switched off.`
+      : "";
+
+  return {
+    severity: "high",
+    nodeId: anchor.id,
+    nodeName: anchor.name,
+    message:
+      `"${property.name}" is not wired in ${unwired.length} of ` +
+      `${wired.length + unwired.length} variants: ` +
+      `${listVariants(unwired.map((entry) => entry.label))}. ` +
+      `The property appears in the panel for these variants but changes ` +
+      `nothing.${fixLocation}${stuckNote}`,
+    expected: `"${property.name}" bound in every variant`,
+    actual: `bound in ${wired.length}, missing in ${unwired.length}`,
+    suggestedFix:
+      `Select the layer in each listed variant and bind it to ` +
+      `"${property.name}".`,
+    count: unwired.length,
+  };
+}
+
+function deadPropertyFinding(
+  property: ComponentPropertySnapshot,
+  snapshot: ComponentSetSnapshot,
+): Finding {
+  return {
+    severity: "high",
+    nodeId: snapshot.id,
+    nodeName: snapshot.name,
+    message:
+      `"${property.name}" (${property.type}) is bound to no layer in any ` +
+      `variant. The property appears in the panel and does nothing anywhere.`,
+    expected: `"${property.name}" bound in every variant`,
+    actual: "bound nowhere",
+    suggestedFix:
+      `Bind "${property.name}" to the layer it is meant to drive, or delete ` +
+      `the property.`,
+    count: snapshot.variants.length,
+  };
+}
+
+/**
+ * A variant binding the property to a differently-named layer than the rest of
+ * the set - the shape a crossed binding takes, where someone wired the property
+ * to the wrong layer.
+ *
+ * Deliberately decided by majority within the set rather than by reading layer
+ * names: this never asks whether `icon-left` "belongs to" `Show Left Icon`, it
+ * only observes that most variants agree and one does not. That keeps the check
+ * free of name semantics, which is why it can be reported at all.
+ *
+ * A `warn`, not a `fail`: a variant legitimately built from different layers
+ * (an icon-only variant with no label) will disagree without being wrong.
+ */
+function oddTargetFinding(
+  property: ComponentPropertySnapshot,
+  wired: VariantBinding[],
+): Finding | undefined {
+  if (wired.length < 3) return undefined;
+
+  const tally = new Map<string, VariantBinding[]>();
+  for (const entry of wired) {
+    // Only single-target bindings are comparable; a property driving several
+    // layers in one variant has no one name to weigh against the others.
+    if (entry.nodes.length !== 1) return undefined;
+    const name = entry.nodes[0].name;
+    tally.set(name, [...(tally.get(name) ?? []), entry]);
+  }
+  if (tally.size < 2) return undefined;
+
+  const ranked = [...tally.entries()].sort((a, b) => b[1].length - a[1].length);
+  const [majorityName, majority] = ranked[0];
+  const odd = ranked.slice(1);
+
+  // Require a clear majority: a two-way split says the set has no convention
+  // to violate, and picking a winner would invent one.
+  if (majority.length <= wired.length / 2) return undefined;
+
+  const oddEntries = odd.flatMap(([, entries]) => entries);
+  const anchor = oddEntries[0].nodes[0];
+
+  return {
+    severity: "medium",
+    nodeId: anchor.id,
+    nodeName: anchor.name,
+    message:
+      `"${property.name}" is bound to layer "${majorityName}" in ` +
+      `${majority.length} of ${wired.length} variants, but to ` +
+      `${odd.map(([name, entries]) => `"${name}" in ${entries.length}`).join(", ")}. ` +
+      `Check for a crossed binding in: ` +
+      `${listVariants(oddEntries.map((entry) => entry.label))}.`,
+    expected: `"${property.name}" bound to "${majorityName}" throughout`,
+    actual: odd.map(([name]) => `"${name}"`).join(", "),
+    suggestedFix:
+      `Confirm the listed variants bind the layer they mean to. A variant ` +
+      `built from different layers may differ legitimately.`,
+    count: oddEntries.length,
+  };
+}
+
+export function checkVariantPropertyBindings(
+  snapshot: ComponentSetSnapshot,
+): CheckResult {
+  const bindable = snapshot.properties.filter(
+    (property) => REFERENCE_KEY[property.type] !== undefined,
+  );
+
+  if (bindable.length === 0) {
+    return {
+      checkId: "variant-property-bindings",
+      title: TITLE,
+      status: "not_applicable",
+      findings: [],
+      note:
+        "The set declares no boolean, text or instance-swap properties, so " +
+        "there is nothing to wire. Variant properties carry no layer binding.",
+      manualRemainder: RENDER_REMAINDER,
+    };
+  }
+
+  const findings: Finding[] = [];
+  let hasFail = false;
+
+  for (const property of bindable) {
+    const referenceKey = REFERENCE_KEY[property.type];
+    const perVariant = bindingsFor(snapshot, property, referenceKey);
+    const wired = perVariant.filter((entry) => entry.nodes.length > 0);
+    const unwired = perVariant.filter((entry) => entry.nodes.length === 0);
+
+    if (wired.length === 0) {
+      findings.push(deadPropertyFinding(property, snapshot));
+      hasFail = true;
+      continue;
+    }
+
+    if (unwired.length > 0) {
+      findings.push(
+        partialWiringFinding(property, wired, unwired, referenceKey),
+      );
+      hasFail = true;
+    }
+
+    const odd = oddTargetFinding(property, wired);
+    if (odd) findings.push(odd);
+  }
+
+  const status: CheckStatus = hasFail
+    ? "fail"
+    : findings.length > 0
+      ? "warn"
+      : "pass";
+
+  return {
+    checkId: "variant-property-bindings",
+    title: TITLE,
+    status,
+    findings,
+    ...(status === "pass"
+      ? {
+          note:
+            `All ${bindable.length} bindable propert` +
+            `${bindable.length === 1 ? "y is" : "ies are"} wired in every ` +
+            `variant. Whether each drives the *right* layer is only checked ` +
+            `where the set disagrees with itself.`,
+        }
+      : {}),
+    manualRemainder: RENDER_REMAINDER,
+  };
+}

--- a/src/plugins/qa/collector.ts
+++ b/src/plugins/qa/collector.ts
@@ -178,6 +178,22 @@ function snapshotNode(node: SceneNode): NodeSnapshot {
     snap.children = node.children.map(snapshotNode);
   }
 
+  // Which component property drives this node (#3). Recorded with Figma's raw
+  // suffixed keys so the check can join a binding to its definition exactly.
+  // Kept on instances too: an INSTANCE_SWAP property binds via `mainComponent`
+  // on the instance node itself, which is walked even though its interior is not.
+  if ("componentPropertyReferences" in node) {
+    const refs = node.componentPropertyReferences;
+    if (refs) {
+      const bound = Object.entries(refs).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string",
+      );
+      if (bound.length > 0) {
+        snap.propertyReferences = Object.fromEntries(bound);
+      }
+    }
+  }
+
   // Only when it is not 1, so fixtures and payloads stay terse. #16 composites
   // this with paint opacity to measure contrast on translucent surfaces.
   if ("opacity" in node && node.opacity !== 1) {
@@ -304,6 +320,9 @@ function snapshotProperties(
       .map((alias) => alias.id);
     return {
       name: propertyDisplayName(rawName),
+      // The suffixed key is what layers reference (#3), so it has to survive
+      // the display-name stripping rather than be reconstructed from it.
+      key: rawName,
       type: def.type,
       ...(def.type === "INSTANCE_SWAP"
         ? { preferredValuesCount: def.preferredValues?.length ?? 0 }

--- a/src/plugins/qa/snapshot.ts
+++ b/src/plugins/qa/snapshot.ts
@@ -97,6 +97,22 @@ export interface NodeSnapshot {
     remote: boolean;
   };
   /**
+   * Which component property drives which of this node's own properties (#3),
+   * straight from Figma's `componentPropertyReferences`. Keyed by the node
+   * property being driven - `visible` for BOOLEAN, `mainComponent` for
+   * INSTANCE_SWAP, `characters` for TEXT - with the **raw suffixed property
+   * key** as the value, e.g. `"Show Left Icon#123:4"`.
+   *
+   * Absent when the node is driven by nothing, which is the normal case.
+   *
+   * This is the only record of a property's *binding*. Figma stores a boolean
+   * property's definition on the component set, so its toggle appears in the
+   * panel for every variant, but the binding lives on one layer inside one
+   * variant and does not propagate when variants are added. Without this field
+   * an unwired toggle is indistinguishable from a wired one.
+   */
+  propertyReferences?: Record<string, string>;
+  /**
    * INSTANCE nodes only: whether this instance itself is exposed to its
    * containing component's panel (#14). When false, none of its exposed
    * descendants surface there either, however deep `exposedInstances` goes.
@@ -192,6 +208,13 @@ export interface NodeSnapshot {
 export interface ComponentPropertySnapshot {
   /** Property name without the Figma "#id" suffix. */
   name: string;
+  /**
+   * The raw Figma key including the "#id" suffix, e.g. `"Show Left Icon#123:4"`
+   * (#3). Kept alongside the display name because `NodeSnapshot.propertyReferences`
+   * holds this exact string: joining a binding to its definition is an exact
+   * match on the key, not a comparison of stripped display names.
+   */
+  key: string;
   /** "VARIANT" | "BOOLEAN" | "TEXT" | "INSTANCE_SWAP" */
   type: string;
   /** INSTANCE_SWAP properties only (#15). */

--- a/src/plugins/qa/types.ts
+++ b/src/plugins/qa/types.ts
@@ -27,7 +27,8 @@ export type CheckId =
   | "themes"
   | "high-contrast"
   | "responsive-bounds"
-  | "documentation";
+  | "documentation"
+  | "variant-property-bindings";
 
 export interface Finding {
   severity: SeverityLevel;
@@ -135,6 +136,11 @@ export const CHECKS: readonly CheckDefinition[] = [
     id: "documentation",
     prdSection: 19,
     title: "Documentation",
+  },
+  {
+    id: "variant-property-bindings",
+    prdSection: 3,
+    title: "Property bindings across variants",
   },
 ];
 

--- a/src/plugins/qa/variable-usage.test.ts
+++ b/src/plugins/qa/variable-usage.test.ts
@@ -85,7 +85,12 @@ describe("collectVariableUsage", () => {
     const usage = collectVariableUsage(
       fixture([[node()]], {
         properties: [
-          { name: "Label", type: "TEXT", boundVariableIds: ["v-label"] },
+          {
+            name: "Label",
+            key: "Label#1:2",
+            type: "TEXT",
+            boundVariableIds: ["v-label"],
+          },
         ],
       }),
     );


### PR DESCRIPTION
Closes #110.

## The defect

Figma splits a component property in two, and the halves live in different places.
The **definition** sits on the component set, so the toggle appears in the properties panel for every variant the moment it is created.
The **binding** sits on one layer inside one variant, and it does not propagate when variants are added or duplicated.

So a set ships where `Show Left Icon` is wired on Primary and silently missed on Ghost.
The designer selects Ghost, sees a toggle identical to the working one, flips it, and nothing happens.
Figma raises no error and draws no distinction between a wired toggle and a decorative one, because the panel renders the definition and knows nothing about this variant's binding.

Three things make it survive review: booleans default to off, so the evidence sits in the state everybody looks at; two booleans across twelve variants is twenty-four bindings, which nobody verifies by hand; and it surfaces in a consumer's file weeks later rather than in the library.

## Why this is a snapshot check

Item 3 was filed as a dynamic check needing a scratch clone and a text stress test (#78).
That reading comes from the source interview, which describes the QA **workflow** faithfully and cannot be expected to describe the **tool's** failure modes - this one is an artifact of how Figma models properties, not something a designer would think to mention.

`collector.ts` already walks invisible children unconditionally, so the hidden icon layer was in every snapshot; only the bindings were missing.
The check is therefore pure `(snapshot) -> CheckResult`, runs across **every** variant rather than a sampled one, and needs no clone, no resize, no render and no image tokens.

It also catches a case rendering cannot: a property bound to the *wrong* layer changes something when toggled, so any "did toggling do anything" test passes it.

## Changes

**Collector, two fields.**

- `NodeSnapshot.propertyReferences` - Figma's `componentPropertyReferences`, kept with raw suffixed keys.
- `ComponentPropertySnapshot.key` - the suffixed key beside the stripped display name. Joining a binding to its definition is an exact key match; `snapshotProperties` strips the `#id` suffix for display, so the key had to survive separately rather than be reconstructed. Making it required flushed out six fixture sites, all updated.

**New check `variant-property-bindings`** (`prdSection: 3`, Tier 1, wired to catalogue item 3):

| Finding | Status | How it decides |
|---|---|---|
| Partial wiring | `fail`, high | Bound in some variants, not others. Names every unwired variant, names the unbound layer to fix, anchors `nodeId` to that layer, and flags when it is left visible |
| Bound nowhere | `fail`, high | Property exists and binds no layer in any variant |
| Odd binding target | `warn`, medium | One variant binds a differently-named layer than the majority - the crossed-binding shape |

Covers `BOOLEAN` (via `visible`), `INSTANCE_SWAP` (`mainComponent`) and `TEXT` (`characters`). `VARIANT` is skipped: variant properties carry no layer binding.

### The set is its own oracle

The fuzzy name-matching heuristic sketched during grilling is **not** in here.
The check never guesses that `icon-left` ought to belong to `Show Left Icon`.
It observes that eleven variants agree and one does not:

- the layer to bind is identified by name from the variants that *are* wired, which is reliable because variants get duplicated - the layer survives while the binding is lost;
- an odd target is one the majority contradicts, and that finding self-silences without a clear majority, under three wired variants, or when a property legitimately drives several layers.

Consistent with the line `themes` already draws about a real concern being "a false-positive factory until it is narrowed much harder".

### Partial wiring also catches the stuck-visible case

An unbound layer left `visible: true` is the nastier shape of the same defect: the icon shows regardless of the toggle and cannot be switched off, and it looks correct at rest. Reported in the same finding.

### The row keeps a tickbox

Item 3 asks for more than wiring - all combinations cycled, long text *always*, and icon colour following text colour, the last being a standing DS invariant and the live failure design found mid-call.
So the check emits an **unconditional** `manualRemainder`, on item 7's logic rather than item 19's: correct wiring says nothing about whether the states it exposes render correctly, so the tick is owed on every outcome including `not_applicable`.

Row 3 now carries a status chip **and** a tickbox, and counts toward `counts.partial`. Without that the row would overclaim on every run - the defect #115 is filed for.

## Verification

- `npx tsc --noEmit` clean.
- `npm run lint` 0 errors. The 173 warnings are pre-existing `any`s in `src/shared/types.ts`; none in the new files.
- `npm run test` 521/521, including 22 new fixture tests.
- `npm run build` clean, both bundles.

**Not verified:** the collector field has only been type-checked against `@figma/plugin-typings`. Whether `componentPropertyReferences` comes back as expected on a real variant tree needs a plugin reload in Figma with the window focused, which is worth doing before merge.

## Docs

`prd-automated-qa.md` (shipped-as note explaining the Figma modelling artifact), `prd-qa-canvas-checklist.md` (row 3), `qa-source-interview.md` (Tier 3 table row 3 to shipped, plus a new section on why the source could not have described this failure), and the check-id lists in `mcp-server/src/catalogue.ts` and `claude-plugin/commands/tidy-qa.md`.
