### PR TITLE
fix(mcp): leave the visual review outstanding on the themes row

### DIFF
--- a/docs/prd-automated-qa.md
+++ b/docs/prd-automated-qa.md
@@ -340,6 +340,14 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 > The theme collection is **not configured by name**: it is the bound collection with the most modes (the shared helper the generated doc pages use), and the result states which collection and modes it evaluated so a wrong pick is visible instead of silently green.
 > Where nodes pin their own explicit modes the probe cannot speak for them, and the check `warn`s rather than reporting a confidently wrong value.
 > Flagging colours bound to a *single-mode* collection as "not theme-aware" is a candidate follow-up, not v1 work: a false-positive factory until narrowed much harder.
+>
+> **The visual half is a human tick, not an omission.**
+> The source ask was that for every mode the component has, it works and *looks good* in all of them, which resolution integrity does not establish: a set can resolve perfectly in both modes and still read wrong in one.
+> Every reported outcome therefore carries a `manualRemainder` naming the modes to review, so the row shows a status chip **and** a tickbox and counts toward `counts.partial`.
+> Without it a green chip stood for the visual review on every run.
+>
+> That remainder is **conditional**, on item 19's logic rather than item 7's.
+> `not_applicable` here means no theme collection, a single-mode collection, or nothing this set binds being theme-aware, and in all three the component renders identically in every mode, so there is nothing to compare by eye.
 
 * **Intent:** Validate that variables map cleanly across dynamic display scenarios without visual bugs.
 * **Automated Plugin Action:**

--- a/docs/prd-qa-canvas-checklist.md
+++ b/docs/prd-qa-canvas-checklist.md
@@ -112,7 +112,7 @@ Three new pieces, plus one operation:
 | 14 | Nested Instance Depth (PRD: "Easy to Use") | `nesting-depth` |
 | 15 | Preferred (Instance Swapping) | `preferred-values` |
 | 16 | High Contrast (A11y) | `high-contrast` |
-| 17 | Themes (Core/DNA/OldNews) | `themes` |
+| 17 | Themes (Core/DNA/OldNews) | `themes` (resolution only; row keeps a manual tick) |
 | 18 | Page Template | manual |
 | 19 | Documentation | `documentation` |
 

--- a/docs/qa-source-interview.md
+++ b/docs/qa-source-interview.md
@@ -368,14 +368,17 @@ The remainder belongs to the **check**, not to the catalogue entry, because whet
 Item 19 asks for a content review only when a link exists; with no documentation there is nothing to read, and a static per-item string put "read the documentation" on the row precisely when there was none.
 Item 7's is unconditional by contrast, since a set being unable to hold bounds says nothing about whether it survives a resize.
 
-Item 3 is the third, and unconditional like item 7's: the check establishes that every property is wired, while the item asks for combinations cycled, long text always, and icon colour following text colour.
+Item 3 is another, and unconditional like item 7's: the check establishes that every property is wired, while the item asks for combinations cycled, long text always, and icon colour following text colour.
 Correct wiring says nothing about whether the states it exposes render correctly, so the tick is owed on every outcome.
 
 The report also counts these rows separately, as `counts.partial`.
-Without that, a run could report "0 manual" while rows 3, 7 and 19 still had unticked boxes on the canvas.
+Without that, a run could report "0 manual" while rows 3, 7, 17 and 19 still had unticked boxes on the canvas.
 
 The same treatment is owed to at least these, all pre-existing:
 
 - **Item 2** - `set-name-casing` checks casing only; matching dev's **prop names** is untouched.
-- **Item 17** - `themes` covers resolution integrity; the ask was visual, "looks good in all modes".
 - **Item 12** - `description` checks the also-known-as line and misprint marker; the **Storybook link** she described is not verified.
+
+Both are Storybook-dependent, so both are parked by the 2026-07-27 deferral.
+**Item 17** was the third and has since shipped its remainder: `themes` covers resolution integrity while the ask was visual, "looks good in all modes", so the row now names the modes to review and keeps a tick.
+Its remainder is conditional like item 19's, because a set with no theme axis renders identically in every mode and has nothing to compare.

--- a/src/plugins/qa/checklist-catalogue.ts
+++ b/src/plugins/qa/checklist-catalogue.ts
@@ -161,7 +161,12 @@ export const CHECKLIST_CATALOGUE: readonly CatalogueItem[] = [
     title: "Themes (Core/DNA/OldNews)",
     tier: 2,
     checkId: "themes",
-    blurb: "Every bound variable resolves in all theme modes, with no gaps.",
+    // States the item, which is wider than the check: design asked that the
+    // component work and *look good* in every mode, while `themes` establishes
+    // only that every bound variable resolves. The check emits a
+    // `manualRemainder` naming the modes for the visual half, so the row carries
+    // a tickbox beside its chip (#115).
+    blurb: "The component resolves and reads correctly in every theme mode.",
   },
   {
     n: 18,

--- a/src/plugins/qa/checks/themes.test.ts
+++ b/src/plugins/qa/checks/themes.test.ts
@@ -379,6 +379,92 @@ describe("checkThemes", () => {
     expect(result.note).toMatch(/no theme collection could be determined/i);
   });
 
+  describe("visual remainder (#115)", () => {
+    function passing() {
+      return checkThemes(
+        fixture(
+          [[filled("v-bg")]],
+          theme({
+            variables: { "v-bg": resolved("bg/default", ["m-core", "m-dna"]) },
+          }),
+        ),
+      );
+    }
+
+    it("leaves the visual review outstanding, naming the modes to look at", () => {
+      // The ask was "see that it works and looks good in all modes"; this check
+      // only proves every bound variable resolves. A green chip that stood for
+      // the look would be a false pass.
+      const remainder = passing().manualRemainder;
+      expect(remainder).toBeDefined();
+      // Named, not "check the modes", so the tick is actionable.
+      expect(remainder).toContain("Core");
+      expect(remainder).toContain("DNA");
+    });
+
+    it("keeps the remainder on warn and fail, not just pass", () => {
+      const failing = checkThemes(
+        fixture(
+          [[filled("v-bg")]],
+          theme({
+            variables: {
+              "v-bg": {
+                name: "bg/default",
+                collectionId: "c-theme",
+                byMode: {
+                  "m-core": { ok: true, type: "COLOR", hex: "#123456" },
+                  "m-dna": { ok: false, reason: "no-value" },
+                },
+              },
+            },
+          }),
+        ),
+      );
+      expect(failing.status).toBe("fail");
+      expect(failing.manualRemainder).toContain("Core");
+    });
+
+    it("omits the remainder when there is no theme to look at", () => {
+      // `not_applicable` means no theme collection, a single-mode collection, or
+      // nothing this set binds is theme-aware. In all three the component renders
+      // identically in every mode, so there is nothing to compare by eye -
+      // unlike #7's remainder, which is owed even on `not_applicable`.
+      const noTheme = checkThemes(fixture([[node()]]));
+      expect(noTheme.status).toBe("not_applicable");
+      expect(noTheme.manualRemainder).toBeUndefined();
+
+      const singleMode = checkThemes(
+        fixture(
+          [[filled("v-bg")]],
+          theme({
+            modes: [{ modeId: "m-only", name: "Only" }],
+            variables: { "v-bg": resolved("bg/default", ["m-only"]) },
+          }),
+        ),
+      );
+      expect(singleMode.status).toBe("not_applicable");
+      expect(singleMode.manualRemainder).toBeUndefined();
+    });
+
+    it("still asks for a look when the modes could not be determined", () => {
+      // Every binding is dead, so there are no mode names to offer - but a set
+      // with broken bindings is exactly one a human should see rendered.
+      const result = checkThemes(
+        fixture(
+          [[filled("v-dead")]],
+          theme({
+            collectionId: undefined,
+            collectionName: undefined,
+            modes: [],
+            unavailableVariableIds: ["v-dead"],
+          }),
+        ),
+      );
+      expect(result.manualRemainder).toBeDefined();
+      expect(result.manualRemainder).toMatch(/mode/i);
+    });
+  });
+
   it("orders findings deterministically by message", () => {
     const result = checkThemes(
       fixture(

--- a/src/plugins/qa/checks/themes.ts
+++ b/src/plugins/qa/checks/themes.ts
@@ -2,6 +2,18 @@
  * #17 - Themes (issue #102). Does every variable this set uses actually
  * resolve in every mode of the theme?
  *
+ * **The visual half stays a human tick.** The source ask was that for every mode
+ * the component has, it works and *looks good* in all of them. Resolution
+ * integrity is a strictly weaker claim, so every reported outcome carries a
+ * `manualRemainder` naming the modes to look at (#115).
+ *
+ * **Conditional, on #19's logic rather than #7's.** `not_applicable` here means
+ * no theme collection, a single-mode collection, or nothing this set binds being
+ * theme-aware - and in all three the component renders identically in every mode,
+ * so there is nothing to compare by eye. #7's remainder is unconditional because
+ * a set that cannot hold bounds can still break when resized; a set with no theme
+ * axis genuinely has no modes to review.
+ *
  * **Scope: resolution integrity only.** Legibility is #16's, and invisible
  * text is just contrast 1.0 - reporting it here as well would describe one
  * defect twice in two rows. So there is no contrast maths in this check at all.
@@ -165,6 +177,23 @@ export function checkThemes(snapshot: ComponentSetSnapshot): CheckResult {
   }
 
   const modeList = theme.modes.map((m) => m.name).join(", ");
+
+  // Design's ask was visual - for every mode, see that it works and *looks good*.
+  // This check proves only that every bound variable resolves, which is a
+  // different claim: a set can resolve perfectly in both modes and still read
+  // wrong in one. Without this the row overclaimed on every run (#115).
+  //
+  // Names the modes rather than saying "check the modes", so the tick is
+  // actionable, and because the collection pick is a heuristic the reviewer
+  // should see which axis they are being asked to look at.
+  const visualRemainder =
+    theme.modes.length > 0
+      ? `Look at the component in every theme mode (${modeList}) and confirm ` +
+        `it reads correctly in each. Only that every bound variable resolves ` +
+        `is checked automatically.`
+      : `Look at the component in every theme mode and confirm it reads ` +
+        `correctly. The modes could not be determined here, so they are not ` +
+        `named; only variable resolution is checked automatically.`;
   const note = theme.collectionName
     ? `Evaluated collection "${theme.collectionName}" across ${theme.modes.length} modes: ${modeList}. The theme collection is picked as the bound collection with the most modes; if that is the wrong collection here, these results describe the wrong axis.`
     : "No theme collection could be determined: none of the variables this set binds could be loaded, so there were no modes to evaluate against.";
@@ -180,5 +209,6 @@ export function checkThemes(snapshot: ComponentSetSnapshot): CheckResult {
     status,
     findings,
     note,
+    manualRemainder: visualRemainder,
   };
 }


### PR DESCRIPTION
Closes #115.

## The problem

Design's ask for item 17 was that for every mode the component has, it works and **looks good** in all of them:

> *"כל הרעיון של לבדוק את ה-modes"* - for every mode the component has, see that it works and looks good, in all of them.

`themes` establishes only that every bound variable resolves in every mode. That is a strictly weaker claim: a set can resolve perfectly in both modes and still read wrong in one. So a green chip on row 17 asserted the visual review on every run.

Rows 3, 7 and 19 already model their partial coverage with a `manualRemainder`. Item 17 was the last such debt that could ship, since looking at a component in two modes needs nothing from Storybook. Items 2 and 12 carry the same debt and stay parked by the 2026-07-27 Storybook deferral.

## The fix

`themes` now emits a `manualRemainder` naming the modes it found:

> Look at the component in every theme mode (Core, DNA) and confirm it reads correctly in each. Only that every bound variable resolves is checked automatically.

Named rather than "check the modes", so the tick is actionable - and because the theme collection is picked heuristically, the reviewer can see which axis they are being asked to look at.

### Conditional, on item 19's logic rather than item 7's

This was the issue's main open question.

`not_applicable` here means one of three things: no theme collection, a single-mode collection, or nothing this set binds being theme-aware. In **all three** the component renders identically in every mode, so there is genuinely nothing to compare by eye.

Item 7's remainder is unconditional because a set that cannot hold bounds can still break when resized. That asymmetry does not exist here.

One edge is deliberate: the remainder **does** survive the case where every binding is dead and no modes could be named, because a set with broken bindings is exactly one a human should see rendered. It degrades to an unnamed-modes wording rather than disappearing.

### The blurb now states the item, not the check

Beyond the issue's scope, but it is what let the row read as a stronger guarantee than it was. Rows 3, 7 and 19 all state the *item* and let the remainder carry the gap; row 17 described the check instead ("Every bound variable resolves in all theme modes"). It now reads "The component resolves and reads correctly in every theme mode."

## Effect

Row 17 counts toward `counts.partial`, so a run can no longer report "0 manual" while its box sits unticked on the canvas. **All four shippable honest-row debts are now paid: rows 3, 7, 17 and 19.**

## Verification

`npx tsc --noEmit` clean. `npm run lint` 0 errors (173 pre-existing `any` warnings in `src/shared/types.ts`). 551 tests pass, 4 new. Both bundles build.

Not yet re-run against the live Figma file - the rebuild drops the plugin bridge. The expected change is the checklist stub going from `partial: 3` to `partial: 4` on `Button`.

## Docs

`prd-automated-qa.md` (why the visual half is a tick rather than an omission, plus the conditional reasoning), `prd-qa-canvas-checklist.md` row 17, and `qa-source-interview.md` - where item 17 moves out of the "same treatment is owed" list into the shipped ones, leaving only items 2 and 12.

## Follow-up

Rendering the component once per mode, side by side, so the tick is easy rather than merely honest. Filed separately - it reuses `theme-probe`'s existing mode-pinning rather than needing a new harness.
