### PR TITLE
fix(mcp): deliver operation images as MCP image content blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,28 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+  # The suite existed long before this job did, so 600+ tests gated nothing and a
+  # broken one could merge unnoticed. Added while fixing #116, whose own
+  # regression test lives here.
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Vitest
+        run: npm test
+
   typecheck:
     name: Type Safety Check
     runs-on: ubuntu-latest

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -248,7 +248,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "query",
     module: "ds-explorer",
     summary:
-      "Import a registered DS Explorer component by name and return its properties, description, and nested instances. Set includeImage=true to also return a base64 PNG preview (heavier — only when the agent needs to actually see the component). Errors INVALID_PARAMS with details.availableNames if the name is unknown.",
+      "Import a registered DS Explorer component by name and return its properties, description, and nested instances. Set includeImage=true to also see the component: the preview is returned as an image content block you can actually look at, not as text (heavier - only when seeing it matters). Errors INVALID_PARAMS with details.availableNames if the name is unknown.",
     inputSchema: {
       name: z
         .string()
@@ -259,7 +259,7 @@ export const CATALOGUE: CatalogueEntry[] = [
         .boolean()
         .optional()
         .describe(
-          "If true, include a base64-encoded PNG preview of the component (default variant for sets). Defaults to false.",
+          "If true, render a PNG preview of the component (default variant for sets) and return it as a viewable image block alongside the JSON. Defaults to false.",
         ),
     },
     timeoutMs: 60_000,

--- a/mcp-server/src/image-content.test.ts
+++ b/mcp-server/src/image-content.test.ts
@@ -49,6 +49,18 @@ describe("liftImages", () => {
     expect(result).toEqual({ a: svg, b: notBase64 });
   });
 
+  // An earlier depth cap returned anything nested deeper untouched, which
+  // silently recreated the very bug this module exists to fix. Nesting depth is
+  // not something a result should have to stay under to be seen.
+  it("finds an image however deeply it is nested", () => {
+    let value: unknown = { image: PNG_URL };
+    for (let i = 0; i < 60; i++) value = { inner: value };
+
+    const { result, images } = liftImages(value);
+    expect(images).toEqual([{ data: PNG, mimeType: "image/png" }]);
+    expect(JSON.stringify(result)).not.toContain(PNG);
+  });
+
   it("caps the images it lifts and says so instead of dropping them", () => {
     const many = Array.from({ length: 10 }, () => PNG_URL);
     const { result, images } = liftImages(many);

--- a/mcp-server/src/image-content.test.ts
+++ b/mcp-server/src/image-content.test.ts
@@ -49,16 +49,25 @@ describe("liftImages", () => {
     expect(result).toEqual({ a: svg, b: notBase64 });
   });
 
-  // An earlier depth cap returned anything nested deeper untouched, which
-  // silently recreated the very bug this module exists to fix. Nesting depth is
-  // not something a result should have to stay under to be seen.
-  it("finds an image however deeply it is nested", () => {
+  // Two failure modes have lived here. A depth cap returned anything deeper
+  // untouched, silently recreating the very bug this module fixes. Uncapped
+  // *recursion* then threw RangeError at a few thousand levels - while
+  // JSON.stringify handles them fine, so a result the server could serialise
+  // failed in the extractor alone. Depth is now bounded by the heap, not the
+  // call stack.
+  //
+  // 5,000 is the depth the second bug was caught at; the assertion below proves
+  // the payload is genuinely serialisable at it, so this is a depth a real
+  // result could reach rather than a synthetic one.
+  it.each([60, 5_000])("finds an image nested %i levels deep", (depth) => {
     let value: unknown = { image: PNG_URL };
-    for (let i = 0; i < 60; i++) value = { inner: value };
+    for (let i = 0; i < depth; i++) value = { inner: value };
 
     const { result, images } = liftImages(value);
     expect(images).toEqual([{ data: PNG, mimeType: "image/png" }]);
-    expect(JSON.stringify(result)).not.toContain(PNG);
+    const json = JSON.stringify(result);
+    expect(json).not.toContain(PNG);
+    expect(json).toContain("returned as image block 1");
   });
 
   it("caps the images it lifts and says so instead of dropping them", () => {

--- a/mcp-server/src/image-content.test.ts
+++ b/mcp-server/src/image-content.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { liftImages } from "./image-content";
+
+const PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==";
+const PNG_URL = `data:image/png;base64,${PNG}`;
+
+describe("liftImages", () => {
+  it("lifts an image and leaves a placeholder in its place", () => {
+    const { result, images } = liftImages({ name: "Button", image: PNG_URL });
+
+    expect(images).toEqual([{ data: PNG, mimeType: "image/png" }]);
+    // The field survives, so the result keeps its shape and the agent can see
+    // where the image went rather than finding the key silently absent.
+    const out = result as { name: string; image: string };
+    expect(out.name).toBe("Button");
+    expect(out.image).toMatch(/^<image\/png, [\d.]+ KB - returned as image block 1/);
+    expect(out.image).not.toContain(PNG);
+  });
+
+  it("leaves a result with no image completely alone", () => {
+    const input = { name: "Button", nested: [{ id: "1:2" }], n: 4, ok: null };
+    const { result, images } = liftImages(input);
+    expect(images).toEqual([]);
+    expect(result).toEqual(input);
+  });
+
+  it("does not mutate the input", () => {
+    const input = { image: PNG_URL };
+    liftImages(input);
+    expect(input.image).toBe(PNG_URL);
+  });
+
+  it("finds images nested in arrays and objects, in encounter order", () => {
+    const jpeg = `data:image/jpeg;base64,${PNG}`;
+    const { images } = liftImages({
+      variants: [{ preview: PNG_URL }, { preview: jpeg }],
+    });
+    expect(images.map((i) => i.mimeType)).toEqual(["image/png", "image/jpeg"]);
+  });
+
+  // An SVG data URL is source a model can genuinely read, unlike a PNG, so it
+  // is more useful left in the text than turned into an unreadable image block.
+  it("leaves non-raster and malformed data URLs as text", () => {
+    const svg = "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=";
+    const notBase64 = "data:image/png;base64,not valid base64!";
+    const { result, images } = liftImages({ a: svg, b: notBase64 });
+    expect(images).toEqual([]);
+    expect(result).toEqual({ a: svg, b: notBase64 });
+  });
+
+  it("caps the images it lifts and says so instead of dropping them", () => {
+    const many = Array.from({ length: 10 }, () => PNG_URL);
+    const { result, images } = liftImages(many);
+    expect(images).toHaveLength(8);
+    const out = result as string[];
+    // The 9th and 10th are still accounted for, so a reader cannot mistake the
+    // response for one that only ever had eight images.
+    expect(out[8]).toContain("not returned");
+    expect(out[9]).toContain("maximum of 8");
+    expect(out[8]).not.toContain(PNG);
+  });
+});

--- a/mcp-server/src/image-content.test.ts
+++ b/mcp-server/src/image-content.test.ts
@@ -51,21 +51,31 @@ describe("liftImages", () => {
 
   // Two failure modes have lived here. A depth cap returned anything deeper
   // untouched, silently recreating the very bug this module fixes. Uncapped
-  // *recursion* then threw RangeError at a few thousand levels - while
-  // JSON.stringify handles them fine, so a result the server could serialise
-  // failed in the extractor alone. Depth is now bounded by the heap, not the
-  // call stack.
+  // *recursion* then threw RangeError a few thousand levels down. Depth is now
+  // bounded by the heap rather than the call stack.
   //
-  // 5,000 is the depth the second bug was caught at; the assertion below proves
-  // the payload is genuinely serialisable at it, so this is a depth a real
-  // result could reach rather than a synthetic one.
+  // Asserted by descending the copy iteratively rather than via JSON.stringify:
+  // how deep V8 can serialise varies by version (Node 24 manages 5,000 levels,
+  // Node 20 does not), and a test for *this module's* depth-independence must
+  // not fail on someone else's limit. Serialisability is covered at 60 levels
+  // below, where every supported runtime is comfortable.
   it.each([60, 5_000])("finds an image nested %i levels deep", (depth) => {
     let value: unknown = { image: PNG_URL };
     for (let i = 0; i < depth; i++) value = { inner: value };
 
     const { result, images } = liftImages(value);
     expect(images).toEqual([{ data: PNG, mimeType: "image/png" }]);
-    const json = JSON.stringify(result);
+
+    let node = result as Record<string, unknown>;
+    for (let i = 0; i < depth; i++) node = node.inner as Record<string, unknown>;
+    expect(node.image).toContain("returned as image block 1");
+    expect(node.image).not.toContain(PNG);
+  });
+
+  it("keeps a shallow result serialisable, image lifted out", () => {
+    let value: unknown = { image: PNG_URL };
+    for (let i = 0; i < 60; i++) value = { inner: value };
+    const json = JSON.stringify(liftImages(value).result);
     expect(json).not.toContain(PNG);
     expect(json).toContain("returned as image block 1");
   });

--- a/mcp-server/src/image-content.ts
+++ b/mcp-server/src/image-content.ts
@@ -51,9 +51,6 @@ const IMAGE_DATA_URL =
  */
 const MAX_IMAGES = 8;
 
-/** Depth cap: results are JSON off the bridge, so this only guards pathology. */
-const MAX_DEPTH = 12;
-
 function describe(bytes: number, mimeType: string, index: number): string {
   const kb = (bytes / 1024).toFixed(1);
   return `<${mimeType}, ${kb} KB - returned as image block ${index + 1} of this response>`;
@@ -70,9 +67,17 @@ function describe(bytes: number, mimeType: string, index: number): string {
 export function liftImages(result: unknown): LiftImagesResult {
   const images: LiftedImage[] = [];
 
-  const walk = (value: unknown, depth: number): unknown => {
-    if (depth > MAX_DEPTH) return value;
-
+  // Unbounded on purpose. An earlier depth cap here returned anything deeper
+  // untouched, which silently recreated the exact bug this module exists to fix:
+  // an image nested past the cap went back to the agent as base64 text. A cap
+  // that degrades to the defect is worse than no cap.
+  //
+  // No cap is needed, either. The value is always `JSON.parse` output from the
+  // bridge, so it is acyclic, and `JSON.stringify` runs over the same value
+  // immediately afterwards with the same recursion - anything deep enough to
+  // exhaust the stack here could never have been serialised into a response
+  // anyway, so this adds no failure mode that the caller did not already have.
+  const walk = (value: unknown): unknown => {
     if (typeof value === "string") {
       const match = IMAGE_DATA_URL.exec(value);
       if (!match) return value;
@@ -87,16 +92,16 @@ export function liftImages(result: unknown): LiftImagesResult {
       return placeholder;
     }
 
-    if (Array.isArray(value)) return value.map((v) => walk(v, depth + 1));
+    if (Array.isArray(value)) return value.map((v) => walk(v));
 
     if (value !== null && typeof value === "object") {
       const out: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(value)) out[k] = walk(v, depth + 1);
+      for (const [k, v] of Object.entries(value)) out[k] = walk(v);
       return out;
     }
 
     return value;
   };
 
-  return { result: walk(result, 0), images };
+  return { result: walk(result), images };
 }

--- a/mcp-server/src/image-content.ts
+++ b/mcp-server/src/image-content.ts
@@ -67,41 +67,70 @@ function describe(bytes: number, mimeType: string, index: number): string {
 export function liftImages(result: unknown): LiftImagesResult {
   const images: LiftedImage[] = [];
 
-  // Unbounded on purpose. An earlier depth cap here returned anything deeper
-  // untouched, which silently recreated the exact bug this module exists to fix:
-  // an image nested past the cap went back to the agent as base64 text. A cap
-  // that degrades to the defect is worse than no cap.
-  //
-  // No cap is needed, either. The value is always `JSON.parse` output from the
-  // bridge, so it is acyclic, and `JSON.stringify` runs over the same value
-  // immediately afterwards with the same recursion - anything deep enough to
-  // exhaust the stack here could never have been serialised into a response
-  // anyway, so this adds no failure mode that the caller did not already have.
-  const walk = (value: unknown): unknown => {
-    if (typeof value === "string") {
-      const match = IMAGE_DATA_URL.exec(value);
-      if (!match) return value;
-      const [, mimeType, data] = match;
-      // Approximate decoded size: 4 base64 chars per 3 bytes.
-      const bytes = Math.floor((data.length * 3) / 4);
-      if (images.length >= MAX_IMAGES) {
-        return `<${mimeType}, ${(bytes / 1024).toFixed(1)} KB - not returned: this response already carries the maximum of ${MAX_IMAGES} images>`;
-      }
-      const placeholder = describe(bytes, mimeType, images.length);
-      images.push({ data, mimeType });
-      return placeholder;
+  /** Lift one string if it is an image data URL; otherwise hand it back. */
+  const liftString = (value: string): string => {
+    const match = IMAGE_DATA_URL.exec(value);
+    if (!match) return value;
+    const [, mimeType, data] = match;
+    // Approximate decoded size: 4 base64 chars per 3 bytes.
+    const bytes = Math.floor((data.length * 3) / 4);
+    if (images.length >= MAX_IMAGES) {
+      return `<${mimeType}, ${(bytes / 1024).toFixed(1)} KB - not returned: this response already carries the maximum of ${MAX_IMAGES} images>`;
     }
-
-    if (Array.isArray(value)) return value.map((v) => walk(v));
-
-    if (value !== null && typeof value === "object") {
-      const out: Record<string, unknown> = {};
-      for (const [k, v] of Object.entries(value)) out[k] = walk(v);
-      return out;
-    }
-
-    return value;
+    const placeholder = describe(bytes, mimeType, images.length);
+    images.push({ data, mimeType });
+    return placeholder;
   };
 
-  return { result: walk(result), images };
+  // Iterative, with an explicit stack, because neither bounded nor unbounded
+  // recursion works here:
+  //
+  // - A depth cap returned anything deeper untouched, silently recreating the
+  //   very bug this module fixes - an image below the cap went back as base64
+  //   text.
+  // - Recursion with no cap throws `RangeError` at a few thousand levels, and
+  //   V8's `JSON.stringify` does *not*: it handles 5,000 levels of nesting
+  //   happily, and `JSON.parse` round-trips it. So a result the bridge can
+  //   carry and the server can serialise would fail here and nowhere else,
+  //   turning a returnable response into a hard error.
+  //
+  // The stack is heap-allocated, so nesting depth stops being a limit of this
+  // module at all. Children are pushed in reverse so they pop in source order,
+  // which keeps images in encounter order and object keys in their original
+  // order.
+  //
+  // Terminates for any tree, which is what the bridge delivers (`JSON.parse`
+  // output is acyclic by construction).
+  interface Slot {
+    parent: Record<string | number, unknown>;
+    key: string | number;
+    value: unknown;
+  }
+  const root: Record<string, unknown> = {};
+  const stack: Slot[] = [{ parent: root, key: "value", value: result }];
+
+  while (stack.length > 0) {
+    const { parent, key, value } = stack.pop()!;
+
+    if (typeof value === "string") {
+      parent[key] = liftString(value);
+    } else if (Array.isArray(value)) {
+      const copy: unknown[] = new Array(value.length);
+      parent[key] = copy;
+      for (let i = value.length - 1; i >= 0; i--) {
+        stack.push({ parent: copy as unknown as Record<number, unknown>, key: i, value: value[i] });
+      }
+    } else if (value !== null && typeof value === "object") {
+      const copy: Record<string, unknown> = {};
+      parent[key] = copy;
+      const entries = Object.entries(value);
+      for (let i = entries.length - 1; i >= 0; i--) {
+        stack.push({ parent: copy, key: entries[i][0], value: entries[i][1] });
+      }
+    } else {
+      parent[key] = value;
+    }
+  }
+
+  return { result: root.value, images };
 }

--- a/mcp-server/src/image-content.ts
+++ b/mcp-server/src/image-content.ts
@@ -1,0 +1,102 @@
+// Lifting images out of an operation result and into MCP image content blocks
+// (issue #116).
+//
+// **The bug this exists to fix.** Every result used to be serialised into one
+// text block. An operation that returns a rendered PNG (ds-explorer's
+// `includeImage`) therefore handed the agent a base64 string inside JSON, which
+// a model cannot see: it spent the render, the transfer and a great many tokens
+// to convey nothing. MCP has a first-class image block, which Claude Code turns
+// into a real vision input, so the payload only ever needed lifting out.
+//
+// **How a result declares an image, without the server knowing any operation.**
+// By being a data URL. `data:image/png;base64,…` already names its own media
+// type at the point of production, so there is nothing for an operation to
+// register and nothing here to look up: any operation that returns one gets
+// vision for free, and this module never learns a field name. The alternative -
+// a per-operation list of image-bearing fields in the catalogue - would put
+// knowledge of individual operations in the transport, which is what ADR-0004
+// keeps out of it.
+//
+// The lifted string is replaced in the JSON by a short placeholder rather than
+// deleted, so the result keeps its shape and the agent can see where the image
+// went instead of finding a field silently missing.
+
+/** An image ready to become an MCP image content block. */
+export interface LiftedImage {
+  /** Bare base64, no data-URL prefix - what the MCP image block carries. */
+  data: string;
+  /** e.g. "image/png". */
+  mimeType: string;
+}
+
+export interface LiftImagesResult {
+  /** The result with every lifted data URL replaced by a placeholder. */
+  result: unknown;
+  images: LiftedImage[];
+}
+
+/**
+ * Media types worth lifting: the raster formats a vision model can actually
+ * read. An SVG data URL is deliberately left as text - it is source, and it is
+ * usefully readable where a PNG is not.
+ */
+const IMAGE_DATA_URL =
+  /^data:(image\/(?:png|jpe?g|gif|webp));base64,([A-Za-z0-9+/]+={0,2})$/;
+
+/**
+ * Cap on images per response. A contact sheet operation could otherwise return
+ * dozens and blow the response budget in a way that is hard to attribute. Over
+ * the cap the placeholder says so, because silently dropping images would read
+ * as "there were only ever this many".
+ */
+const MAX_IMAGES = 8;
+
+/** Depth cap: results are JSON off the bridge, so this only guards pathology. */
+const MAX_DEPTH = 12;
+
+function describe(bytes: number, mimeType: string, index: number): string {
+  const kb = (bytes / 1024).toFixed(1);
+  return `<${mimeType}, ${kb} KB - returned as image block ${index + 1} of this response>`;
+}
+
+/**
+ * Walk `result`, replacing every image data URL with a placeholder and
+ * collecting the images in encounter order.
+ *
+ * Returns a copy; the input is not mutated. A result with no images comes back
+ * with `images: []` and an untouched structure, so the caller can use one code
+ * path for every operation.
+ */
+export function liftImages(result: unknown): LiftImagesResult {
+  const images: LiftedImage[] = [];
+
+  const walk = (value: unknown, depth: number): unknown => {
+    if (depth > MAX_DEPTH) return value;
+
+    if (typeof value === "string") {
+      const match = IMAGE_DATA_URL.exec(value);
+      if (!match) return value;
+      const [, mimeType, data] = match;
+      // Approximate decoded size: 4 base64 chars per 3 bytes.
+      const bytes = Math.floor((data.length * 3) / 4);
+      if (images.length >= MAX_IMAGES) {
+        return `<${mimeType}, ${(bytes / 1024).toFixed(1)} KB - not returned: this response already carries the maximum of ${MAX_IMAGES} images>`;
+      }
+      const placeholder = describe(bytes, mimeType, images.length);
+      images.push({ data, mimeType });
+      return placeholder;
+    }
+
+    if (Array.isArray(value)) return value.map((v) => walk(v, depth + 1));
+
+    if (value !== null && typeof value === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) out[k] = walk(v, depth + 1);
+      return out;
+    }
+
+    return value;
+  };
+
+  return { result: walk(result, 0), images };
+}

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -8,6 +8,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CATALOGUE } from "./catalogue.ts";
 import { BridgeServer } from "./bridge-server.ts";
+import { liftImages } from "./image-content.ts";
 import type { BridgeError } from "./bridge-server.ts";
 
 // Pin to the IPv4 loopback: "localhost" resolves to ::1 on modern Node, and a
@@ -61,8 +62,20 @@ async function main(): Promise<void> {
             input ?? {},
             entry.timeoutMs,
           );
+          // Any image the result carries becomes its own MCP image block, so a
+          // model can actually see it instead of receiving base64 as text
+          // (#116). Operations that return no image are unaffected: `images` is
+          // empty and the text block is the whole response, as before.
+          const { result: lifted, images } = liftImages(result);
           return {
-            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            content: [
+              { type: "text" as const, text: JSON.stringify(lifted, null, 2) },
+              ...images.map((img) => ({
+                type: "image" as const,
+                data: img.data,
+                mimeType: img.mimeType,
+              })),
+            ],
           };
         } catch (err) {
           const e = isBridgeError(err)

--- a/mcp-server/src/smoketest.ts
+++ b/mcp-server/src/smoketest.ts
@@ -14,16 +14,43 @@
 // the catalogue to register and serialize its zod schemas to JSON Schema —
 // exercising zod end-to-end.
 //
-// It does NOT round-trip a real operation: that needs a connected Figma plugin
-// over the Bridge and can't run headless. A true end-to-end operation test
-// belongs in its own issue (build a plugin sim, exercise bridge + handlers).
+// It also round-trips one real operation through the Bridge against a **plugin
+// sim** — a bare WebSocket client that answers a canned result. That covers the
+// whole path an agent actually travels (MCP stdio -> catalogue -> bridge
+// envelope -> content blocks) with only Figma itself replaced, which is what
+// makes it able to prove #116: that an image comes back as a *viewable* image
+// block and not as base64 buried in text.
 //
 // Run via `npm run mcp:smoketest`, which bundles first.
 
 import { resolve } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { WebSocket } from "ws";
 import { CATALOGUE } from "./catalogue.ts";
+
+const BRIDGE_PORT = 49876;
+
+/** A 1x1 PNG. Small, but a real decodable image, so a viewer can prove it. */
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==";
+
+/**
+ * Stand in for the Figma plugin: dial the bridge and answer every request with
+ * a fixed result. The bridge has no handshake - whoever connects is the plugin
+ * (ADR-0005, no auth on loopback) - so this is the whole sim.
+ */
+function startPluginSim(result: unknown): Promise<{ close: () => void }> {
+  return new Promise((resolveSim, rejectSim) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${BRIDGE_PORT}`);
+    ws.on("open", () => resolveSim({ close: () => ws.close() }));
+    ws.on("error", rejectSim);
+    ws.on("message", (raw) => {
+      const req = JSON.parse(raw.toString()) as { id: string };
+      ws.send(JSON.stringify({ id: req.id, ok: true, result }));
+    });
+  });
+}
 
 // Path to the server is passed as the first arg: dist/server.cjs (bundled) or
 // mcp-server/src/server.ts (raw source). Resolving it here avoids import.meta /
@@ -50,7 +77,10 @@ async function main(): Promise<void> {
     command: process.execPath,
     args: serverArgs,
     stderr: "inherit",
-    env: { ...process.env, TIDY_BRIDGE_PORT: "49876" } as Record<string, string>,
+    env: { ...process.env, TIDY_BRIDGE_PORT: String(BRIDGE_PORT) } as Record<
+      string,
+      string
+    >,
   });
   const client = new Client({ name: "tidy-smoketest", version: "0.0.1" });
 
@@ -64,7 +94,15 @@ async function main(): Promise<void> {
   for (const t of tools.tools) print(`  • ${t.name} — ${t.description}`);
 
   const missing = expected.filter((id) => !got.has(id));
-  await client.close();
+
+  // In a finally, so a failed assertion still tears the server subprocess down.
+  // Without it a red smoketest hangs instead of failing, which in CI reads as a
+  // stuck job rather than a broken build.
+  try {
+    await roundTripImage(client);
+  } finally {
+    await client.close();
+  }
 
   if (missing.length > 0) {
     throw new Error(
@@ -80,6 +118,57 @@ async function main(): Promise<void> {
   print(
     `\n✓ smoketest complete — ${expected.length} tools served from ${serverArg}`,
   );
+}
+
+/**
+ * #116: an operation that returns an image must deliver it as an MCP image
+ * content block, not as base64 inside the JSON text. A model cannot see a
+ * base64 string, so the old behaviour spent the render, the transfer and a great
+ * many tokens to convey nothing at all.
+ */
+async function roundTripImage(client: Client): Promise<void> {
+  const sim = await startPluginSim({
+    name: "Button",
+    key: "abc123",
+    type: "COMPONENT_SET",
+    description: "",
+    properties: [],
+    nestedInstances: [],
+    image: `data:image/png;base64,${PNG_BASE64}`,
+  });
+  try {
+    const res = (await client.callTool({
+      name: "tidy_ds_explorer_get_component",
+      arguments: { name: "Button", includeImage: true },
+    })) as { content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> };
+
+    const images = res.content.filter((c) => c.type === "image");
+    if (images.length !== 1) {
+      throw new Error(
+        `expected exactly 1 image content block, got ${images.length} ` +
+          `(block types: ${res.content.map((c) => c.type).join(", ")})`,
+      );
+    }
+    if (images[0].mimeType !== "image/png") {
+      throw new Error(`image block mimeType was '${images[0].mimeType}'`);
+    }
+    if (images[0].data !== PNG_BASE64) {
+      throw new Error("image block data is not the payload the plugin returned");
+    }
+
+    // The point of lifting it out: the base64 must no longer be sitting in the
+    // text block burning tokens for something the model cannot read.
+    const text = res.content.find((c) => c.type === "text")?.text ?? "";
+    if (text.includes(PNG_BASE64)) {
+      throw new Error("base64 payload is still embedded in the text block");
+    }
+    if (!text.includes('"name": "Button"')) {
+      throw new Error("text block lost the rest of the result");
+    }
+    print("✓ image operation round-tripped as a real image content block");
+  } finally {
+    sim.close();
+  }
 }
 
 function print(s: string): void {

--- a/mcp-server/src/smoketest.ts
+++ b/mcp-server/src/smoketest.ts
@@ -15,7 +15,7 @@
 // exercising zod end-to-end.
 //
 // It also round-trips one real operation through the Bridge against a **plugin
-// sim** — a bare WebSocket client that answers a canned result. That covers the
+// sim** - a bare WebSocket client that answers a canned result. That covers the
 // whole path an agent actually travels (MCP stdio -> catalogue -> bridge
 // envelope -> content blocks) with only Figma itself replaced, which is what
 // makes it able to prove #116: that an image comes back as a *viewable* image

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    // mcp-server is a separate package but its pure modules are testable from
+    // here; without this line nothing under it could have a unit test at all.
+    include: ["src/**/*.test.ts", "mcp-server/src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
Closes #116.

`includeImage: true` returned a base64 PNG as **text inside JSON**, so a model received a long opaque string and nothing else — while the catalogue entry promised it could "actually see the component". The flag cost a render, a transfer and a large number of text tokens, and delivered no information at all.

## Reproduced end-to-end first

The smoketest gained the **plugin sim** its own comment had been asking for since it was written ("a true end-to-end operation test belongs in its own issue: build a plugin sim, exercise bridge + handlers"). It's a bare WebSocket client answering a canned result — the bridge has no handshake, so whoever connects is the plugin. That covers the entire path an agent travels, with only Figma itself replaced:

```
MCP stdio → catalogue → bridge envelope → content blocks
```

Against the unfixed server it reported exactly the bug:

```
smoketest failed: Error: expected exactly 1 image content block, got 0 (block types: text)
```

It runs in **both** existing CI jobs (bundled artifact and raw source), so this can't regress silently.

## The contract: the payload declares itself

The issue asked for a way for a handler to say "this field is an image" *without the server knowing about individual operations*. It already does — by being a data URL. `data:image/png;base64,…` names its own media type at the point of production, so:

- no operation registers anything,
- this module never learns a field name,
- any future operation returning a data URL gets vision for free.

The rejected alternative — a per-operation list of image-bearing fields in the catalogue — would put knowledge of individual operations into the transport, which is what ADR-0004 keeps out of it.

## Details worth reviewing

- **Placeholder, not deletion.** The lifted string is replaced by `<image/png, 1.2 KB - returned as image block 1 of this response>`, so the result keeps its shape and the agent sees where the image went instead of finding a key silently missing.
- **Raster only.** An SVG data URL stays as text — it's source a model can genuinely read, unlike a PNG.
- **Capped at 8 per response**, and over the cap the placeholder says so rather than dropping silently, so a response can't read as one that only ever had eight images.
- **Non-image operations are untouched** — `images` is empty and the text block is the whole response. Verified byte-identical (key order included) on a realistic QA payload, since every tool now passes through the extractor.

## Two things found along the way

**The smoketest leaked its server subprocess on a failed assertion.** A red smoketest hung for minutes instead of failing, which in CI reads as a stuck job rather than a broken build. Fixed with a `finally`.

**CI never ran `npm test`.** 600+ Vitest tests gated nothing — lint, typecheck, builds and the two smoketests ran, but not the suite. Added a Unit Tests job (`59b36cb`) and extended the Vitest include to cover `mcp-server/src/**`, which previously had no way to hold a unit test at all.

## Validation

Typecheck, lint (0 errors), formatting, 607 tests, `build`, `build:plugin`, and both smoketests pass.

One gap left deliberately: `npm run typecheck` still only covers `src`, so `mcp-server/` is not typechecked. Pre-existing, and widening it is its own change.

## Not covered here

The sim proves the transport carries an image; it can't prove Figma's `exportAsync` output renders correctly. Worth one manual look with the plugin connected before relying on it for the visual QA work this unblocks (#121, #112).
