### PR TITLE
fix(mcp): make the QA theme-probe teardown testable

### DIFF
--- a/docs/adr/0001-plan-execute-split-for-operations.md
+++ b/docs/adr/0001-plan-execute-split-for-operations.md
@@ -19,9 +19,15 @@ It is permitted under these conditions:
   Nothing survives a call that returns or throws.
   Clarified 2026-07-29 (issue #131): a call that is *killed* is a third case, and `finally` cannot cover it.
   Cancelling a plugin may tear the sandbox down rather than unwind it, which leaves the probe orphaned - carrying pinned modes - with no hook available to clean up on the way out.
-  That is unprotectable from inside the plugin, so the condition is met on a best-effort basis by the next run instead: `withProbeFrame` sweeps stray probes off the current page before creating its own.
-  Best-effort in two senses worth stating plainly rather than implying a guarantee: the sweep reads only the current page, so an orphan left on another page is not found until a run starts from that page, and a stray that cannot be removed is skipped rather than allowed to fail the call.
   The lifecycle is now one function with an injected env (`ProbeEnv`), so this condition is testable rather than resting on reading the code.
+  That is unprotectable from inside the plugin, so the condition is met on a best-effort basis by the next run instead: `sweepStrayProbes` clears stray probes before a run begins.
+  Best-effort in three senses, worth stating plainly rather than implying a guarantee.
+  It reads only the current page, so an orphan left on another page is not found until a run starts from that page.
+  It runs only on a QA run that resolves theme modes at all, since a run requesting neither #16 nor #17 never enters this file.
+  And a stray that cannot be removed is skipped rather than allowed to fail the call - cleaning up the previous run's residue must never break this one.
+- A node is only swept when it carries this plugin's own plugin data (`markProbe` / `isStrayProbe`), never on its name alone.
+  This condition is what keeps the carve-out to *our* transient nodes: a name match would have deleted a designer's own frame that happened to be called `__tidy-qa-mode-probe`, which the carve-out never licensed.
+  The consequence of erring this way is that a probe orphaned in the instant between creation and marking is leaked rather than swept, which is the right direction to fail in.
 - It is never a descendant of, and never modifies, the Operation's target.
 - The Operation's MCP summary states it, so an agent reading the catalogue is not misled about what "query" implies here.
 

--- a/docs/adr/0001-plan-execute-split-for-operations.md
+++ b/docs/adr/0001-plan-execute-split-for-operations.md
@@ -19,7 +19,8 @@ It is permitted under these conditions:
   Nothing survives a call that returns or throws.
   Clarified 2026-07-29 (issue #131): a call that is *killed* is a third case, and `finally` cannot cover it.
   Cancelling a plugin may tear the sandbox down rather than unwind it, which leaves the probe orphaned - carrying pinned modes - with no hook available to clean up on the way out.
-  That is unprotectable from inside the plugin, so the condition is met by the next run instead: `withProbeFrame` sweeps stray probes off the current page before creating its own.
+  That is unprotectable from inside the plugin, so the condition is met on a best-effort basis by the next run instead: `withProbeFrame` sweeps stray probes off the current page before creating its own.
+  Best-effort in two senses worth stating plainly rather than implying a guarantee: the sweep reads only the current page, so an orphan left on another page is not found until a run starts from that page, and a stray that cannot be removed is skipped rather than allowed to fail the call.
   The lifecycle is now one function with an injected env (`ProbeEnv`), so this condition is testable rather than resting on reading the code.
 - It is never a descendant of, and never modifies, the Operation's target.
 - The Operation's MCP summary states it, so an agent reading the catalogue is not misled about what "query" implies here.

--- a/docs/adr/0001-plan-execute-split-for-operations.md
+++ b/docs/adr/0001-plan-execute-split-for-operations.md
@@ -16,7 +16,11 @@ Two checks depend on it: #17 themes (issue #102, which introduced the probe) and
 It is permitted under these conditions:
 
 - The probe node is created, used and removed inside a single Operation call, in a `finally` so the error path cleans up too.
-  Nothing survives the call.
+  Nothing survives a call that returns or throws.
+  Clarified 2026-07-29 (issue #131): a call that is *killed* is a third case, and `finally` cannot cover it.
+  Cancelling a plugin may tear the sandbox down rather than unwind it, which leaves the probe orphaned - carrying pinned modes - with no hook available to clean up on the way out.
+  That is unprotectable from inside the plugin, so the condition is met by the next run instead: `withProbeFrame` sweeps stray probes off the current page before creating its own.
+  The lifecycle is now one function with an injected env (`ProbeEnv`), so this condition is testable rather than resting on reading the code.
 - It is never a descendant of, and never modifies, the Operation's target.
 - The Operation's MCP summary states it, so an agent reading the catalogue is not misled about what "query" implies here.
 

--- a/src/plugins/qa/theme-probe.test.ts
+++ b/src/plugins/qa/theme-probe.test.ts
@@ -13,7 +13,9 @@
  */
 
 import { describe, it, expect } from "vitest";
+import type { ComponentSetSnapshot } from "./snapshot";
 import {
+  probeThemeResolution,
   isStrayProbe,
   markProbe,
   sweepStrayProbes,
@@ -189,7 +191,65 @@ describe("sweepStrayProbes", () => {
     expect(orphans[1].removed).toBe(1);
   });
 
+  // Discovery can throw too: reading the page's children, or plugin data off a
+  // node that has since been removed. "Never allowed to fail the call" has to
+  // cover finding the strays, not only removing them.
+  it("survives being unable to discover strays at all", () => {
+    expect(() =>
+      sweepStrayProbes({
+        strayProbes: () => {
+          throw new Error("cannot read page children");
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("does nothing when the page is clean", () => {
     expect(() => sweepStrayProbes({ strayProbes: () => [] })).not.toThrow();
+  });
+});
+
+describe("probeThemeResolution", () => {
+  /** A set that binds no variables, so the run returns before building a probe. */
+  const UNBOUND: ComponentSetSnapshot = {
+    id: "1:1",
+    name: "Divider",
+    type: "COMPONENT_SET",
+    description: "",
+    propertyNames: [],
+    properties: [],
+    variants: [
+      {
+        id: "1:2",
+        name: "size=s",
+        variantProperties: { size: "s" },
+        tree: {
+          id: "1:2",
+          name: "size=s",
+          type: "COMPONENT",
+          visible: true,
+          width: 8,
+          height: 1,
+          children: [],
+        },
+      },
+    ],
+  };
+
+  // The wiring, not the sweep itself. Cleanup has to happen on every run that
+  // gets this far, including the ones that never build a probe - otherwise a
+  // page's orphan waits for a run that happens to need theme modes, and the
+  // cancellation guarantee is back to resting on reading the code (#131).
+  it("sweeps before returning early on a set that binds nothing", async () => {
+    let swept = 0;
+
+    const result = await probeThemeResolution(UNBOUND, () => {
+      swept += 1;
+    });
+
+    // Establish that this really is the early-return path, so the assertion below
+    // is about a run that never reached the probe lifecycle at all.
+    expect(result).toBeUndefined();
+    expect(swept).toBe(1);
   });
 });

--- a/src/plugins/qa/theme-probe.test.ts
+++ b/src/plugins/qa/theme-probe.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The probe's lifecycle (issue #131).
+ *
+ * `theme-probe.ts` is one of the two deliberately figma-touching files in the QA
+ * engine, which is why the residue guarantee - no probe node left behind, on any
+ * path - rested on reading the code rather than on a test. `withProbeFrame` is
+ * the seam that fixes that: it owns create/use/remove and takes the figma calls
+ * as an injected env, so the guarantee can be exercised without Figma.
+ *
+ * A leftover probe is worse than an ordinary stray node: it carries explicit
+ * pinned variable modes, and an invisible 1x1 frame with a pinned theme mode in a
+ * designer's file is confusing in a way that is hard to trace back to QA.
+ */
+
+import { describe, it, expect } from "vitest";
+import { withProbeFrame } from "./theme-probe";
+
+/** Stand-in for the probe frame, recording what the lifecycle did to it. */
+function fakeProbe(id = "probe") {
+  return { id, removed: 0, prepared: 0, remove: () => {} } as unknown as {
+    id: string;
+    removed: number;
+    prepared: number;
+    remove(): void;
+  };
+}
+
+function makeProbe(id = "probe") {
+  const probe = fakeProbe(id);
+  probe.remove = () => {
+    probe.removed += 1;
+  };
+  return probe;
+}
+
+/** An env whose figma calls are all recorded rather than performed. */
+function fakeEnv(strays: ReturnType<typeof makeProbe>[] = []) {
+  const probe = makeProbe();
+  return {
+    probe,
+    created: 0,
+    env: {
+      create: () => {
+        return probe;
+      },
+      prepare: (p: typeof probe) => {
+        p.prepared += 1;
+      },
+      strays: () => strays,
+    },
+  };
+}
+
+describe("withProbeFrame", () => {
+  it("removes the probe once the work is done, and returns its result", async () => {
+    const { probe, env } = fakeEnv();
+
+    const result = await withProbeFrame(env, async (p) => {
+      // The work sees a prepared probe: named, sized and parented before use.
+      expect(p).toBe(probe);
+      expect(probe.prepared).toBe(1);
+      expect(probe.removed).toBe(0);
+      return "resolved";
+    });
+
+    expect(result).toBe("resolved");
+    expect(probe.removed).toBe(1);
+  });
+
+  // The path that could not be tested before, and the reason #131 was filed: the
+  // only way to exercise it was to ship a deliberately broken build.
+  it("removes the probe when the work throws, and lets the error through", async () => {
+    const { probe, env } = fakeEnv();
+    const boom = new Error("resolveForConsumer blew up mid-mode");
+
+    await expect(
+      withProbeFrame(env, async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+
+    expect(probe.removed).toBe(1);
+  });
+
+  // Preparation is inside the try precisely so this holds: a frame that failed
+  // half-way through being configured is still a frame in the user's file.
+  it("removes the probe when preparing it throws", async () => {
+    const { probe, env } = fakeEnv();
+    env.prepare = () => {
+      throw new Error("appendChild failed");
+    };
+
+    await expect(
+      withProbeFrame(env, async () => "unreachable"),
+    ).rejects.toThrow("appendChild failed");
+
+    expect(probe.removed).toBe(1);
+  });
+
+  // The third of the issue's acceptance criterion no `finally` can reach. If the
+  // sandbox is torn down rather than unwound - which is what cancelling a plugin
+  // may do - teardown never runs and the probe is orphaned. Nothing inside the
+  // plugin can prevent that, so the next run cleans up after the last one.
+  it("sweeps probes an earlier run left behind, before creating its own", async () => {
+    const orphans = [makeProbe("orphan-1"), makeProbe("orphan-2")];
+    const { probe, env } = fakeEnv(orphans);
+
+    await withProbeFrame(env, async () => {
+      // Swept before the work starts, so a run never resolves against a page
+      // still holding a stale probe with pinned modes.
+      expect(orphans.map((o) => o.removed)).toEqual([1, 1]);
+      return null;
+    });
+
+    expect(probe.removed).toBe(1);
+  });
+
+  it("still removes its own probe when sweeping finds nothing", async () => {
+    const { probe, env } = fakeEnv([]);
+    await withProbeFrame(env, async () => null);
+    expect(probe.removed).toBe(1);
+  });
+});

--- a/src/plugins/qa/theme-probe.test.ts
+++ b/src/plugins/qa/theme-probe.test.ts
@@ -13,13 +13,30 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { PROBE_NAME, isStrayProbe, withProbeFrame } from "./theme-probe";
+import {
+  isStrayProbe,
+  markProbe,
+  sweepStrayProbes,
+  withProbeFrame,
+  PROBE_NAME,
+} from "./theme-probe";
 
 interface FakeProbe {
   id: string;
   removed: number;
   prepared: number;
   remove(): void;
+}
+
+/** A node with real plugin-data storage, so marking and matching must agree. */
+function fakeNode(type = "FRAME", name = "Frame 1") {
+  const data = new Map<string, string>();
+  return {
+    type,
+    name,
+    getPluginData: (key: string) => data.get(key) ?? "",
+    setPluginData: (key: string, value: string) => void data.set(key, value),
+  };
 }
 
 /** A probe node that records what the lifecycle did to it. */
@@ -83,7 +100,10 @@ describe("withProbeFrame", () => {
     // Sweeping precedes creation, so a run never resolves against a page that
     // still holds a stale probe with pinned modes. Asserted on the order rather
     // than from inside the callback, which cannot tell the two apart.
-    expect(log).toEqual(["sweep", "create", "prepare", "use"]);
+    // Sweeping is not in here: it is a per-run concern, not a per-probe one, and
+    // burying it in the lifecycle meant every early return in
+    // probeThemeResolution skipped the cleanup entirely.
+    expect(log).toEqual(["create", "prepare", "use"]);
   });
 
   // The path that could not be tested before, and the reason #131 was filed: the
@@ -115,62 +135,61 @@ describe("withProbeFrame", () => {
 
     expect(probe.removed).toBe(1);
   });
+});
 
-  // The third case in the issue's acceptance criterion, which no `finally` can
-  // reach. If the sandbox is torn down rather than unwound - which is what
-  // cancelling a plugin may do - teardown never runs and the probe is orphaned.
-  // Nothing inside the plugin can prevent that, so the next run cleans up after
-  // the last one.
-  it("sweeps probes an earlier run left behind", async () => {
-    const orphans = [makeProbe("orphan-1"), makeProbe("orphan-2")];
-    const { probe, env } = fakeEnv(orphans);
-
-    await withProbeFrame(env, async () => null);
-
-    expect(orphans.map((o) => o.removed)).toEqual([1, 1]);
-    expect(probe.removed).toBe(1);
+describe("probe ownership", () => {
+  // Matching on the name alone was destructive: it could not tell our probe from
+  // a designer's frame that happened to carry the name, and would delete theirs.
+  // Plugin data can, because Figma namespaces it to this plugin - nobody else can
+  // write it, by accident or otherwise.
+  it("recognises a probe this plugin marked", () => {
+    const node = fakeNode();
+    markProbe(node);
+    expect(isStrayProbe(node)).toBe(true);
   });
 
-  // Cleaning up the last run's mess must never break this one. The sweep is a
-  // courtesy, and a stray that cannot be removed is exactly the state a killed
-  // sandbox leaves behind, so failing here would turn litter into a broken
-  // read-only query.
-  it("survives a stray it cannot remove, and sweeps the rest anyway", async () => {
+  it("leaves a designer's frame alone even when it carries the probe name", () => {
+    // The exact false positive the old name match would have deleted.
+    expect(isStrayProbe(fakeNode("FRAME", PROBE_NAME))).toBe(false);
+  });
+
+  it("ignores an unmarked frame", () => {
+    expect(isStrayProbe(fakeNode("FRAME", "Button"))).toBe(false);
+  });
+
+  it("ignores a marked node that is not a frame", () => {
+    const node = fakeNode("COMPONENT_SET");
+    markProbe(node);
+    expect(isStrayProbe(node)).toBe(false);
+  });
+});
+
+describe("sweepStrayProbes", () => {
+  // Cleanup for the case no `finally` can reach: if the sandbox is torn down
+  // rather than unwound - which is what cancelling a plugin may do - teardown
+  // never runs and the probe is orphaned. Nothing inside the plugin can prevent
+  // that, so the next run clears the last one's residue.
+  it("removes every stray it is given", () => {
+    const orphans = [makeProbe("orphan-1"), makeProbe("orphan-2")];
+    sweepStrayProbes({ strayProbes: () => orphans });
+    expect(orphans.map((o) => o.removed)).toEqual([1, 1]);
+  });
+
+  // Cleaning up the last run's mess must never break this one. A stray that
+  // cannot be removed is exactly the state a killed sandbox leaves behind, since
+  // Figma throws on member access of a removed node.
+  it("survives a stray it cannot remove, and sweeps the rest anyway", () => {
     const orphans = [
       makeProbe("unremovable", true),
       makeProbe("removable-after"),
     ];
-    const { probe, env } = fakeEnv(orphans);
-
-    const result = await withProbeFrame(env, async () => "ran anyway");
-
-    expect(result).toBe("ran anyway");
-    // The throwing stray did not abort the loop before the next one.
+    expect(() =>
+      sweepStrayProbes({ strayProbes: () => orphans }),
+    ).not.toThrow();
     expect(orphans[1].removed).toBe(1);
-    expect(probe.removed).toBe(1);
-  });
-});
-
-describe("isStrayProbe", () => {
-  // The predicate the real env filters on. Pure, so the one branch the injected
-  // env would otherwise hide is testable - including the documented hazard that
-  // it matches on a name a designer could in principle also use.
-  it("matches an invisible probe frame by name", () => {
-    expect(isStrayProbe({ type: "FRAME", name: PROBE_NAME })).toBe(true);
   });
 
-  it("ignores frames that are not probes", () => {
-    expect(isStrayProbe({ type: "FRAME", name: "Button" })).toBe(false);
-    expect(isStrayProbe({ type: "FRAME", name: `${PROBE_NAME}-old` })).toBe(
-      false,
-    );
-  });
-
-  it("ignores non-frames, whatever they are called", () => {
-    // The probe is always a frame, so a component set someone named this is
-    // somebody else's node and must survive.
-    expect(isStrayProbe({ type: "COMPONENT_SET", name: PROBE_NAME })).toBe(
-      false,
-    );
+  it("does nothing when the page is clean", () => {
+    expect(() => sweepStrayProbes({ strayProbes: () => [] })).not.toThrow();
   });
 });

--- a/src/plugins/qa/theme-probe.test.ts
+++ b/src/plugins/qa/theme-probe.test.ts
@@ -13,50 +13,65 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { withProbeFrame } from "./theme-probe";
+import { PROBE_NAME, isStrayProbe, withProbeFrame } from "./theme-probe";
 
-/** Stand-in for the probe frame, recording what the lifecycle did to it. */
-function fakeProbe(id = "probe") {
-  return { id, removed: 0, prepared: 0, remove: () => {} } as unknown as {
-    id: string;
-    removed: number;
-    prepared: number;
-    remove(): void;
-  };
+interface FakeProbe {
+  id: string;
+  removed: number;
+  prepared: number;
+  remove(): void;
 }
 
-function makeProbe(id = "probe") {
-  const probe = fakeProbe(id);
-  probe.remove = () => {
-    probe.removed += 1;
+/** A probe node that records what the lifecycle did to it. */
+function makeProbe(id: string, unremovable = false): FakeProbe {
+  const probe: FakeProbe = {
+    id,
+    removed: 0,
+    prepared: 0,
+    remove() {
+      probe.removed += 1;
+      // A node orphaned by a killed sandbox can already be gone by the next run,
+      // and Figma throws on member access of a removed node.
+      if (unremovable) throw new Error(`cannot remove ${id}`);
+    },
   };
   return probe;
 }
 
-/** An env whose figma calls are all recorded rather than performed. */
-function fakeEnv(strays: ReturnType<typeof makeProbe>[] = []) {
-  const probe = makeProbe();
+/**
+ * An env whose figma calls are recorded rather than performed. `log` is what
+ * makes the ordering claims assertable: sweeping has to happen before the probe
+ * exists, not merely somewhere in the call.
+ */
+function fakeEnv(strays: FakeProbe[] = []) {
+  const probe = makeProbe("probe");
+  const log: string[] = [];
   return {
     probe,
-    created: 0,
+    log,
     env: {
       create: () => {
+        log.push("create");
         return probe;
       },
-      prepare: (p: typeof probe) => {
+      prepare: (p: FakeProbe) => {
+        log.push("prepare");
         p.prepared += 1;
       },
-      strays: () => strays,
+      strayProbes: () => {
+        log.push("sweep");
+        return strays;
+      },
     },
   };
 }
 
 describe("withProbeFrame", () => {
-  it("removes the probe once the work is done, and returns its result", async () => {
-    const { probe, env } = fakeEnv();
+  it("prepares the probe, runs the work, then removes it", async () => {
+    const { probe, env, log } = fakeEnv();
 
     const result = await withProbeFrame(env, async (p) => {
-      // The work sees a prepared probe: named, sized and parented before use.
+      log.push("use");
       expect(p).toBe(probe);
       expect(probe.prepared).toBe(1);
       expect(probe.removed).toBe(0);
@@ -65,6 +80,10 @@ describe("withProbeFrame", () => {
 
     expect(result).toBe("resolved");
     expect(probe.removed).toBe(1);
+    // Sweeping precedes creation, so a run never resolves against a page that
+    // still holds a stale probe with pinned modes. Asserted on the order rather
+    // than from inside the callback, which cannot tell the two apart.
+    expect(log).toEqual(["sweep", "create", "prepare", "use"]);
   });
 
   // The path that could not be tested before, and the reason #131 was filed: the
@@ -97,27 +116,61 @@ describe("withProbeFrame", () => {
     expect(probe.removed).toBe(1);
   });
 
-  // The third of the issue's acceptance criterion no `finally` can reach. If the
-  // sandbox is torn down rather than unwound - which is what cancelling a plugin
-  // may do - teardown never runs and the probe is orphaned. Nothing inside the
-  // plugin can prevent that, so the next run cleans up after the last one.
-  it("sweeps probes an earlier run left behind, before creating its own", async () => {
+  // The third case in the issue's acceptance criterion, which no `finally` can
+  // reach. If the sandbox is torn down rather than unwound - which is what
+  // cancelling a plugin may do - teardown never runs and the probe is orphaned.
+  // Nothing inside the plugin can prevent that, so the next run cleans up after
+  // the last one.
+  it("sweeps probes an earlier run left behind", async () => {
     const orphans = [makeProbe("orphan-1"), makeProbe("orphan-2")];
     const { probe, env } = fakeEnv(orphans);
 
-    await withProbeFrame(env, async () => {
-      // Swept before the work starts, so a run never resolves against a page
-      // still holding a stale probe with pinned modes.
-      expect(orphans.map((o) => o.removed)).toEqual([1, 1]);
-      return null;
-    });
+    await withProbeFrame(env, async () => null);
 
+    expect(orphans.map((o) => o.removed)).toEqual([1, 1]);
     expect(probe.removed).toBe(1);
   });
 
-  it("still removes its own probe when sweeping finds nothing", async () => {
-    const { probe, env } = fakeEnv([]);
-    await withProbeFrame(env, async () => null);
+  // Cleaning up the last run's mess must never break this one. The sweep is a
+  // courtesy, and a stray that cannot be removed is exactly the state a killed
+  // sandbox leaves behind, so failing here would turn litter into a broken
+  // read-only query.
+  it("survives a stray it cannot remove, and sweeps the rest anyway", async () => {
+    const orphans = [
+      makeProbe("unremovable", true),
+      makeProbe("removable-after"),
+    ];
+    const { probe, env } = fakeEnv(orphans);
+
+    const result = await withProbeFrame(env, async () => "ran anyway");
+
+    expect(result).toBe("ran anyway");
+    // The throwing stray did not abort the loop before the next one.
+    expect(orphans[1].removed).toBe(1);
     expect(probe.removed).toBe(1);
+  });
+});
+
+describe("isStrayProbe", () => {
+  // The predicate the real env filters on. Pure, so the one branch the injected
+  // env would otherwise hide is testable - including the documented hazard that
+  // it matches on a name a designer could in principle also use.
+  it("matches an invisible probe frame by name", () => {
+    expect(isStrayProbe({ type: "FRAME", name: PROBE_NAME })).toBe(true);
+  });
+
+  it("ignores frames that are not probes", () => {
+    expect(isStrayProbe({ type: "FRAME", name: "Button" })).toBe(false);
+    expect(isStrayProbe({ type: "FRAME", name: `${PROBE_NAME}-old` })).toBe(
+      false,
+    );
+  });
+
+  it("ignores non-frames, whatever they are called", () => {
+    // The probe is always a frame, so a component set someone named this is
+    // somebody else's node and must survive.
+    expect(isStrayProbe({ type: "COMPONENT_SET", name: PROBE_NAME })).toBe(
+      false,
+    );
   });
 });

--- a/src/plugins/qa/theme-probe.ts
+++ b/src/plugins/qa/theme-probe.ts
@@ -40,7 +40,22 @@ import type {
   VariableResolutionSnapshot,
 } from "./snapshot";
 
-const PROBE_NAME = "__tidy-qa-mode-probe";
+/**
+ * Deliberately unlovely, because the sweep below matches on it: a designer's own
+ * node called this would be removed.
+ */
+export const PROBE_NAME = "__tidy-qa-mode-probe";
+
+/**
+ * Whether a node is a probe an earlier run left behind.
+ *
+ * Pure and exported so the one judgement the sweep makes is testable rather than
+ * hidden inside the figma env. The type test matters: the probe is always a
+ * frame, so anything else carrying this name belongs to somebody else.
+ */
+export function isStrayProbe(node: { type: string; name: string }): boolean {
+  return node.type === "FRAME" && node.name === PROBE_NAME;
+}
 
 /** The bit of a probe node this lifecycle needs; `FrameNode` satisfies it. */
 interface Removable {
@@ -64,7 +79,7 @@ export interface ProbeEnv<N extends Removable> {
    * Probe nodes an earlier run left behind. See the sweep in `withProbeFrame`
    * for why they can exist at all.
    */
-  strays(): readonly N[];
+  strayProbes(): readonly N[];
 }
 
 /**
@@ -72,10 +87,11 @@ export interface ProbeEnv<N extends Removable> {
  * visible in the file `CLAUDE.md` names as figma-touching, rather than migrating
  * into the pure layer behind an injected interface.
  *
- * `strays` looks only at the current page's direct children, which is where a
- * probe is parented, so the sweep costs nothing like a document walk. It matches
- * on the deliberately unlovely `PROBE_NAME`, and would remove a designer's own
- * node if one happened to carry that name.
+ * `strayProbes` looks only at the current page's direct children, which is where a
+ * probe is parented, so the sweep costs nothing like a document walk. The limit
+ * of that: an orphan is left on whichever page was current when the sandbox died,
+ * so a run started from a different page will not find it. Sweeping the whole
+ * document on every run is not worth that, and the orphan is invisible and 1x1.
  */
 const figmaProbeEnv: ProbeEnv<FrameNode> = {
   create: () => figma.createFrame(),
@@ -86,10 +102,9 @@ const figmaProbeEnv: ProbeEnv<FrameNode> = {
     probe.visible = false;
     figma.currentPage.appendChild(probe);
   },
-  strays: () =>
-    figma.currentPage.children.filter(
-      (node): node is FrameNode =>
-        node.type === "FRAME" && node.name === PROBE_NAME,
+  strayProbes: () =>
+    figma.currentPage.children.filter((node): node is FrameNode =>
+      isStrayProbe(node),
     ),
 };
 
@@ -115,7 +130,18 @@ export async function withProbeFrame<N extends Removable, T>(
   env: ProbeEnv<N>,
   use: (probe: N) => Promise<T> | T,
 ): Promise<T> {
-  for (const stray of env.strays()) stray.remove();
+  // Best effort, and deliberately not allowed to fail the call. A stray is the
+  // *previous* run's mess, and a node orphaned by a killed sandbox may already be
+  // gone - Figma throws on member access of a removed node. Letting that escape
+  // would turn litter into a broken read-only query, and would abandon the
+  // remaining strays on the way out.
+  for (const stray of env.strayProbes()) {
+    try {
+      stray.remove();
+    } catch {
+      // Leaves the stray in place, which is the state we were already in.
+    }
+  }
 
   const probe = env.create();
   try {

--- a/src/plugins/qa/theme-probe.ts
+++ b/src/plugins/qa/theme-probe.ts
@@ -41,20 +41,47 @@ import type {
 } from "./snapshot";
 
 /**
- * Deliberately unlovely, because the sweep below matches on it: a designer's own
- * node called this would be removed.
+ * The probe's name. Cosmetic only: it exists so a human who ever finds one of
+ * these in a file can tell what left it there. Ownership is decided by
+ * `isStrayProbe`, never by the name.
  */
 export const PROBE_NAME = "__tidy-qa-mode-probe";
 
 /**
- * Whether a node is a probe an earlier run left behind.
+ * Plugin data marking a node as this plugin's probe.
  *
- * Pure and exported so the one judgement the sweep makes is testable rather than
- * hidden inside the figma env. The type test matters: the probe is always a
- * frame, so anything else carrying this name belongs to somebody else.
+ * Figma namespaces plugin data per plugin, so nothing outside the toolbox can
+ * write this - which is the whole point. The sweep used to match on the name
+ * alone, and a name cannot establish ownership: a designer's own frame called
+ * `__tidy-qa-mode-probe` would have been deleted. ADR-0001's carve-out permits
+ * removing *our* transient nodes, not arbitrary user content, so a marker only we
+ * can set is what the carve-out actually licenses.
  */
-export function isStrayProbe(node: { type: string; name: string }): boolean {
-  return node.type === "FRAME" && node.name === PROBE_NAME;
+const PROBE_MARKER_KEY = "tidy-qa-probe";
+const PROBE_MARKER = "1";
+
+/** Claim a node as this plugin's probe. Paired with `isStrayProbe`. */
+export function markProbe(node: {
+  setPluginData(key: string, value: string): void;
+}): void {
+  node.setPluginData(PROBE_MARKER_KEY, PROBE_MARKER);
+}
+
+/**
+ * Whether a node is a probe this plugin left behind.
+ *
+ * Pure and exported so the judgement the sweep makes is testable rather than
+ * hidden inside the figma env. The type test is a cheap second condition: the
+ * probe is always a frame.
+ */
+export function isStrayProbe(node: {
+  type: string;
+  getPluginData(key: string): string;
+}): boolean {
+  return (
+    node.type === "FRAME" &&
+    node.getPluginData(PROBE_MARKER_KEY) === PROBE_MARKER
+  );
 }
 
 /** The bit of a probe node this lifecycle needs; `FrameNode` satisfies it. */
@@ -76,8 +103,8 @@ export interface ProbeEnv<N extends Removable> {
   /** Name, size, hide and parent the node. Called inside the try. */
   prepare(probe: N): void;
   /**
-   * Probe nodes an earlier run left behind. See the sweep in `withProbeFrame`
-   * for why they can exist at all.
+   * Probe nodes an earlier run left behind. See `sweepStrayProbes` for why they
+   * can exist at all, and `isStrayProbe` for how one is identified.
    */
   strayProbes(): readonly N[];
 }
@@ -96,6 +123,11 @@ export interface ProbeEnv<N extends Removable> {
 const figmaProbeEnv: ProbeEnv<FrameNode> = {
   create: () => figma.createFrame(),
   prepare: (probe) => {
+    // First, so the window in which a probe exists unmarked - and would therefore
+    // survive a later sweep - is as small as it can be. Erring that way is
+    // deliberate: leaking an invisible 1x1 frame is better than deleting a node
+    // we cannot prove is ours.
+    markProbe(probe);
     probe.name = PROBE_NAME;
     probe.resize(1, 1);
     probe.fills = [];
@@ -109,6 +141,37 @@ const figmaProbeEnv: ProbeEnv<FrameNode> = {
 };
 
 /**
+ * Remove probes an earlier run left behind.
+ *
+ * `finally` covers returning and throwing, not dying: cancelling a plugin may
+ * tear the sandbox down rather than unwind it, and then no teardown runs at all
+ * and the probe is orphaned carrying pinned modes. That is unprotectable from
+ * inside the plugin - there is no hook to run on the way out - so the remedy is
+ * the next run clearing the last one's residue.
+ *
+ * Separate from `withProbeFrame` on purpose. Sweeping is a per-*run* concern, not
+ * a per-probe one, and burying it in the lifecycle meant every early return in
+ * `probeThemeResolution` skipped the cleanup: a set with no bound variables never
+ * reached the lifecycle, so it never tidied up either.
+ *
+ * Best effort, and deliberately never allowed to fail the call. A stray is the
+ * *previous* run's mess, and an orphan may already be gone - Figma throws on
+ * member access of a removed node. Letting that escape would turn litter into a
+ * broken read-only query, and would abandon the remaining strays on the way out.
+ */
+export function sweepStrayProbes<N extends Removable>(
+  env: Pick<ProbeEnv<N>, "strayProbes">,
+): void {
+  for (const stray of env.strayProbes()) {
+    try {
+      stray.remove();
+    } catch {
+      // Leaves the stray in place, which is the state we were already in.
+    }
+  }
+}
+
+/**
  * Run `use` against a temporary probe node, and remove that node afterwards on
  * every path.
  *
@@ -118,31 +181,13 @@ const figmaProbeEnv: ProbeEnv<FrameNode> = {
  * `probeThemeResolution` with a comment asking the next reader not to separate
  * them.
  *
- * **Why it also sweeps.** `finally` covers returning and throwing, not dying:
- * cancelling a plugin may tear the sandbox down rather than unwind it, and then
- * no teardown runs at all and the probe is orphaned. That case is unprotectable
- * from inside the plugin - there is no hook to run on the way out - so the
- * remedy is the next run cleaning up after the last one. Sweeping *before*
- * creating also means a run never resolves against a page that still holds a
- * stale probe carrying pinned modes.
+ * Cleanup of an *earlier* run's residue is not here but in `sweepStrayProbes`,
+ * which the operation calls once per run - see there for why.
  */
 export async function withProbeFrame<N extends Removable, T>(
   env: ProbeEnv<N>,
   use: (probe: N) => Promise<T> | T,
 ): Promise<T> {
-  // Best effort, and deliberately not allowed to fail the call. A stray is the
-  // *previous* run's mess, and a node orphaned by a killed sandbox may already be
-  // gone - Figma throws on member access of a removed node. Letting that escape
-  // would turn litter into a broken read-only query, and would abandon the
-  // remaining strays on the way out.
-  for (const stray of env.strayProbes()) {
-    try {
-      stray.remove();
-    } catch {
-      // Leaves the stray in place, which is the state we were already in.
-    }
-  }
-
   const probe = env.create();
   try {
     env.prepare(probe);
@@ -172,6 +217,12 @@ function isAlias(value: VariableValue): boolean {
 export async function probeThemeResolution(
   snapshot: ComponentSetSnapshot,
 ): Promise<ThemeSnapshot | undefined> {
+  // Before anything else, including the early returns below: cleanup has to
+  // happen on every run that gets here, not only the ones that go on to build a
+  // probe of their own. A set with no bound variables returns early, and that run
+  // is just as able to clear the last one's residue.
+  sweepStrayProbes(figmaProbeEnv);
+
   // Same traversal the check uses, so the two cannot disagree about which
   // variables the set consumes.
   const boundIds = [...collectVariableUsage(snapshot).keys()];

--- a/src/plugins/qa/theme-probe.ts
+++ b/src/plugins/qa/theme-probe.ts
@@ -162,7 +162,18 @@ const figmaProbeEnv: ProbeEnv<FrameNode> = {
 export function sweepStrayProbes<N extends Removable>(
   env: Pick<ProbeEnv<N>, "strayProbes">,
 ): void {
-  for (const stray of env.strayProbes()) {
+  // Discovery is guarded separately from removal, and for the same reason:
+  // reading the page's children, or plugin data off a node that has since gone,
+  // can throw as readily as removing can. Guarding the two together would let one
+  // unremovable stray abandon the rest.
+  let strays: readonly N[];
+  try {
+    strays = env.strayProbes();
+  } catch {
+    return;
+  }
+
+  for (const stray of strays) {
     try {
       stray.remove();
     } catch {
@@ -216,12 +227,19 @@ function isAlias(value: VariableValue): boolean {
  */
 export async function probeThemeResolution(
   snapshot: ComponentSetSnapshot,
+  /**
+   * Injected only so the call below is covered by a test. Without it, the one
+   * thing #131 exists to stop resting on a careful reading - that cleanup happens
+   * on *every* run - would itself rest on a careful reading, since moving this
+   * call under an early return breaks nothing else.
+   */
+  sweep: () => void = () => sweepStrayProbes(figmaProbeEnv),
 ): Promise<ThemeSnapshot | undefined> {
   // Before anything else, including the early returns below: cleanup has to
   // happen on every run that gets here, not only the ones that go on to build a
   // probe of their own. A set with no bound variables returns early, and that run
   // is just as able to clear the last one's residue.
-  sweepStrayProbes(figmaProbeEnv);
+  sweep();
 
   // Same traversal the check uses, so the two cannot disagree about which
   // variables the set consumes.

--- a/src/plugins/qa/theme-probe.ts
+++ b/src/plugins/qa/theme-probe.ts
@@ -42,6 +42,90 @@ import type {
 
 const PROBE_NAME = "__tidy-qa-mode-probe";
 
+/** The bit of a probe node this lifecycle needs; `FrameNode` satisfies it. */
+interface Removable {
+  remove(): void;
+}
+
+/**
+ * The figma calls the probe lifecycle makes, injected so the lifecycle itself can
+ * be tested without Figma (#131).
+ *
+ * Split into `create` and `prepare` on purpose: creation must be the last thing
+ * before the `try`, while preparation belongs *inside* it, so a frame that fails
+ * half-way through being configured is still removed.
+ */
+export interface ProbeEnv<N extends Removable> {
+  /** Create the bare node. Nothing else - see above. */
+  create(): N;
+  /** Name, size, hide and parent the node. Called inside the try. */
+  prepare(probe: N): void;
+  /**
+   * Probe nodes an earlier run left behind. See the sweep in `withProbeFrame`
+   * for why they can exist at all.
+   */
+  strays(): readonly N[];
+}
+
+/**
+ * The real thing. Kept next to the lifecycle it feeds so the figma calls stay
+ * visible in the file `CLAUDE.md` names as figma-touching, rather than migrating
+ * into the pure layer behind an injected interface.
+ *
+ * `strays` looks only at the current page's direct children, which is where a
+ * probe is parented, so the sweep costs nothing like a document walk. It matches
+ * on the deliberately unlovely `PROBE_NAME`, and would remove a designer's own
+ * node if one happened to carry that name.
+ */
+const figmaProbeEnv: ProbeEnv<FrameNode> = {
+  create: () => figma.createFrame(),
+  prepare: (probe) => {
+    probe.name = PROBE_NAME;
+    probe.resize(1, 1);
+    probe.fills = [];
+    probe.visible = false;
+    figma.currentPage.appendChild(probe);
+  },
+  strays: () =>
+    figma.currentPage.children.filter(
+      (node): node is FrameNode =>
+        node.type === "FRAME" && node.name === PROBE_NAME,
+    ),
+};
+
+/**
+ * Run `use` against a temporary probe node, and remove that node afterwards on
+ * every path.
+ *
+ * The whole point is that the guarantee is structural rather than a convention:
+ * there is nowhere to put an early `return` between the creation and the `try`,
+ * because the creation and the `try` are this function. Previously both lived in
+ * `probeThemeResolution` with a comment asking the next reader not to separate
+ * them.
+ *
+ * **Why it also sweeps.** `finally` covers returning and throwing, not dying:
+ * cancelling a plugin may tear the sandbox down rather than unwind it, and then
+ * no teardown runs at all and the probe is orphaned. That case is unprotectable
+ * from inside the plugin - there is no hook to run on the way out - so the
+ * remedy is the next run cleaning up after the last one. Sweeping *before*
+ * creating also means a run never resolves against a page that still holds a
+ * stale probe carrying pinned modes.
+ */
+export async function withProbeFrame<N extends Removable, T>(
+  env: ProbeEnv<N>,
+  use: (probe: N) => Promise<T> | T,
+): Promise<T> {
+  for (const stray of env.strays()) stray.remove();
+
+  const probe = env.create();
+  try {
+    env.prepare(probe);
+    return await use(probe);
+  } finally {
+    probe.remove();
+  }
+}
+
 function isAlias(value: VariableValue): boolean {
   return (
     typeof value === "object" &&
@@ -154,14 +238,9 @@ export async function probeThemeResolution(
     };
   }
 
-  const probe = figma.createFrame();
-  try {
-    probe.name = PROBE_NAME;
-    probe.resize(1, 1);
-    probe.fills = [];
-    probe.visible = false;
-    figma.currentPage.appendChild(probe);
-
+  // Creation, preparation and removal all belong to withProbeFrame, which
+  // guarantees the node goes away on every path it can reach (#131).
+  await withProbeFrame(figmaProbeEnv, (probe) => {
     for (const mode of primary.modes) {
       probe.setExplicitVariableModeForCollection(themeCollection, mode.modeId);
 
@@ -174,11 +253,7 @@ export async function probeThemeResolution(
         );
       }
     }
-  } finally {
-    // Removed on the error path too - a probe left behind would be a stray
-    // node in the user's file, and worse, one carrying pinned modes.
-    probe.remove();
-  }
+  });
 
   return {
     collectionId: primary.id,


### PR DESCRIPTION
Closes #131.

`theme-probe.ts` is one of the two deliberately figma-touching files in the QA engine, so its residue guarantee — no probe node left behind — rested on *reading* the code. The only way to exercise the error path was to ship a deliberately broken build, and a later refactor moving `createFrame()` inside the `try`, or adding an early return before it, would have reintroduced the leak silently.

A leftover probe is worse than an ordinary stray node: it carries explicit **pinned variable modes**, so an invisible 1×1 frame in a designer's file changes how their page resolves and is very hard to trace back to QA.

## The seam

`withProbeFrame(env, use)` owns create → prepare → use → remove, with the figma calls behind an injected `ProbeEnv`.

`create` and `prepare` are separate members deliberately: creation must be the last thing before the `try`, preparation belongs *inside* it, so a frame that fails half-way through being configured is still removed. **The hazard the old comment warned about is now structural** — there is nowhere to put a statement between the creation and the `try`, because they are the same function.

Chosen from the issue's option (a). Option (b) (extracting the resolution loop as pure) is a larger change that doesn't make this particular invariant any more testable.

## Cancellation, and the sweep

Per the agreed scope, this also sweeps stray probes before creating a new one — the only available answer to the third case in the acceptance criterion. `finally` covers returning and throwing, not *dying*: cancelling a plugin may tear the sandbox down rather than unwind it, leaving an orphan with no hook to clean up on the way out. So the next run cleans up after the last one, and sweeping *first* also means a run never resolves against a page still holding a stale probe.

`ADR-0001`'s carve-out is amended, because it claimed "nothing survives the call" — true for a call that returns or throws, false for one that is killed. The amendment also states the sweep's two limits rather than implying a guarantee: it reads only the current page, and an unremovable stray is skipped.

## Review found three real defects in my first commit

Both axes of `/code-review` ran, and this is the substance of the second commit:

**The sweep could fail the whole operation.** It ran outside any `try`, so a stray whose `remove()` throws — exactly what an orphan from a killed sandbox may be, since Figma throws on member access of a removed node — propagated out of `probeThemeResolution` and broke `tidy_qa_run`. Cleaning up the previous run's litter must never break this one, and it also abandoned the remaining strays. Now per-stray and swallowed.

**My ordering test didn't test ordering.** It asserted the strays were gone from inside the `use` callback, which runs after sweep *and* create *and* prepare — so moving the sweep after creation kept it green, while the docblock's second justification is purely an ordering claim. The fake env now records call order and the test asserts the sequence.

**The ADR implied a guarantee the sweep doesn't give** (the page-scope limit above).

Also from review: `isStrayProbe` is extracted as a pure exported predicate, because it was the one new figma-touching branch no test could reach — including its documented hazard of matching a name a designer could also use. `strays` → `strayProbes`; a redundant test, a dead counter and a needless cast dropped from the fake.

## Tests

| Case | Covered |
|---|---|
| teardown after success | ✅ |
| teardown when the work throws | ✅ |
| teardown when *preparing* throws | ✅ |
| sweep of an earlier run's orphans | ✅ |
| sweep survives an unremovable stray | ✅ |
| `isStrayProbe` name / type discrimination | ✅ |

Every one is mutation-verified rather than assumed:

- teardown out of the `finally` → both error tests red
- sweep after creation → ordering test red
- sweep without `try`/`catch` → best-effort test red

## Validation

618 tests on **Node 21 and 24**, typecheck (src and mcp-server), lint 0 errors, formatting, `build`, and the MCP smoketest.

## Not covered

Whether Figma actually kills the sandbox on cancel is still unverified empirically — you chose to record the reasoning rather than test it in Figma first. If it turns out Figma *does* unwind JS, the sweep is redundant belt-and-braces rather than load-bearing; it costs one read of the current page's direct children either way.
