### PR TITLE
fix(mcp): let the mode showcase hug its content, not its prose

### DIFF
--- a/src/plugins/qa/render/mode-showcase.ts
+++ b/src/plugins/qa/render/mode-showcase.ts
@@ -44,14 +44,6 @@ export type ModeShowcasePlan =
     }
   | { show: false; reason: string };
 
-/**
- * Decide whether a per-mode showcase is worth drawing.
- *
- * Suppressed in every case where it would imply a comparison that did not
- * happen. #115 made row 17's manual remainder conditional for exactly this
- * reason: a set with no theme axis renders identically in every mode, so two
- * pictures of it are two identical pictures.
- */
 /** Everything the decision needs, as one value rather than three positionals. */
 export interface ModeShowcaseInput {
   /** The resolved per-mode table, absent when the run did not probe. */

--- a/src/plugins/qa/render/renderModeShowcase.ts
+++ b/src/plugins/qa/render/renderModeShowcase.ts
@@ -25,6 +25,14 @@ const SHOWCASE_DATA_KEY = "tidy:qa-mode-showcase";
 
 const GAP_FROM_ANCHOR = 32;
 
+/**
+ * Narrowest the prose may wrap to. The block's width should come from the
+ * component it shows, not from the longest sentence explaining it - left to hug,
+ * a single unwrapped caption made the card roughly twice as wide as two buttons
+ * needed and stranded them in white space.
+ */
+const MIN_BODY_WIDTH = 240;
+
 export type ShowcaseSubject = ComponentSetNode | ComponentNode;
 
 /** The component this showcase illustrates: the set's default variant. */
@@ -101,16 +109,16 @@ function buildInto(
   card(root);
 
   root.appendChild(track(text(root.name, 16, FONT_BOLD, INK)));
-  root.appendChild(
-    track(
-      text(
-        `${plan.modes.length} modes of "${collection.name}" - ${plan.coverageNote}`,
-        11,
-        FONT_REGULAR,
-        MUTED,
-      ),
+
+  const caption = track(
+    text(
+      `${plan.modes.length} modes of "${collection.name}" - ${plan.coverageNote}`,
+      11,
+      FONT_REGULAR,
+      MUTED,
     ),
   );
+  root.appendChild(caption);
 
   const columns = track(autoLayout("modes", "HORIZONTAL", 0, 0, 16));
   columns.counterAxisAlignItems = "MIN";
@@ -135,29 +143,29 @@ function buildInto(
     stage.appendChild(track(main.createInstance()));
   }
 
-  root.appendChild(
-    track(
-      text(
-        // The transparent-stage limit, stated where the person judging will see
-        // it. Inventing a surface colour would mean guessing which variable is
-        // "the background", which nothing here can know.
-        "Stages are transparent, so a component that relies on the page behind it will read thinner here than in place.",
-        10,
-        FONT_REGULAR,
-        MUTED,
-      ),
+  // One note rather than two: at 10px, a pair of grey disclaimers under two
+  // buttons is more chrome than substance. Both facts still get said - what the
+  // block is for, and what it cannot show.
+  const note = track(
+    text(
+      "Aid only: this row's status comes from the themes check, and the tick is still yours. " +
+        "Stages are transparent, so a component that relies on the page behind it reads thinner here than in place.",
+      10,
+      FONT_REGULAR,
+      MUTED,
     ),
   );
-  root.appendChild(
-    track(
-      text(
-        "Aid only: this row's status comes from the themes check, and the tick is still yours.",
-        10,
-        FONT_REGULAR,
-        MUTED,
-      ),
-    ),
-  );
+  root.appendChild(note);
+
+  // Sized after everything is in place, because the width to wrap to is the width
+  // the modes ended up needing. The root keeps hugging, so the card ends up as
+  // wide as its content rather than as wide as its prose.
+  const bodyWidth = Math.max(MIN_BODY_WIDTH, columns.width);
+  for (const node of [caption, note]) {
+    node.textAutoResize = "HEIGHT";
+    node.resize(bodyWidth, node.height);
+  }
+
   return root;
 }
 

--- a/src/plugins/qa/theme-probe.test.ts
+++ b/src/plugins/qa/theme-probe.test.ts
@@ -100,12 +100,9 @@ describe("withProbeFrame", () => {
 
     expect(result).toBe("resolved");
     expect(probe.removed).toBe(1);
-    // Sweeping precedes creation, so a run never resolves against a page that
-    // still holds a stale probe with pinned modes. Asserted on the order rather
-    // than from inside the callback, which cannot tell the two apart.
-    // Sweeping is not in here: it is a per-run concern, not a per-probe one, and
-    // burying it in the lifecycle meant every early return in
-    // probeThemeResolution skipped the cleanup entirely.
+    // Sweeping is deliberately absent: it is a per-run concern, not a per-probe
+    // one, and burying it in the lifecycle meant every early return in
+    // probeThemeResolution skipped the cleanup entirely. See sweepStrayProbes.
     expect(log).toEqual(["create", "prepare", "use"]);
   });
 


### PR DESCRIPTION
Follow-up to #121, found by looking at the canvas rather than the code.

## The defect

The block came out roughly twice as wide as two buttons needed. With the root set to hug, the widest element decided the card width — and the widest element was an unwrapped 10px disclaimer, not the component. The content ended up stranded in white space.

## The fix

The prose now wraps to the width the modes actually needed, computed *after* they are laid out and floored at a minimum so a one-mode block does not squeeze text into a column. The root still hugs, so the card is as wide as what it shows.

The two grey disclaimers become one. At 10px, a pair of them under two buttons is more chrome than substance; both facts still get said.

## Verified on the real canvas, not in the source

| | Before | After |
|---|---|---|
| exported width (2×) | ~1118px | ~620px |
| prose | one unwrapped line, set the width | wraps to content width |
| disclaimers | two lines | one paragraph |

I also corrected a judgement I got wrong from the canvas screenshot: I reported that the light and dark instances "read as nearly identical". In the 2× render they are clearly different purples — that was an artefact of viewing a 1× screenshot, not of the block. The colour signal is fine.

## Also in here

Two leftovers from scripted edits in the previous few commits, both cosmetic and both on `main`:

- a docblock duplicated above `planModeShowcase`
- a contradictory comment pair in the `withProbeFrame` ordering test, where my old claim about sweeping was left sitting above the replacement

## Not fixed here — filed as #141

Both stages are transparent, so a dark-mode component is shown on white. That means the block still cannot answer row 17's actual question: whether a non-text element vanishes into the surface in one mode. It needs a design pass rather than a layout tweak.

The maintainer's requirement shaped that issue and is worth repeating: when no surface variable can be identified, the fallback must **not** be transparent, because the tool gets pointed at elements that are not from a well-formed DS — and those are exactly the cases where "does this disappear" matters most. A neutral dark surface (or a two-tone stage) still answers it.

## Validation

630 tests, typecheck (src and mcp-server), lint 0 errors, formatting, `build`, `build:plugin`, both MCP smoketests. Plus a live render against the reference `Button`, which is what produced the before/after above.
