### PR TITLE
feat(mcp): let the checklist return the frame it draws

### DIFF
--- a/claude-plugin/commands/tidy-qa.md
+++ b/claude-plugin/commands/tidy-qa.md
@@ -76,6 +76,8 @@ rather than duplicating it.
 
 The response is a small stub only:
 `{ frameId, target: { id, name }, counts: { pass, warn, fail, manual, notImplemented, notApplicable, notRun, partial } }`.
+`modeShowcaseId` is also present when the set has more than one theme mode: a labelled block drawn beside the checklist showing the default variant per mode.
+Pass `includeImage: true` to get `image` as well - the drawn checklist as a viewable picture - when you need to describe how the frame itself looks, or when the user cannot see their canvas.
 `partial` counts automated rows that still need a human tick because the check covers only part of the item.
 Several rows are like this, and which ones can depend on what the check found, so read it off the response rather than assuming a fixed set.
 Those rows are also counted by their own status, so report them as outstanding work even when `manual` is 0.

--- a/mcp-server/src/catalogue.ts
+++ b/mcp-server/src/catalogue.ts
@@ -380,7 +380,7 @@ export const CATALOGUE: CatalogueEntry[] = [
     kind: "execute",
     module: "qa",
     summary:
-      `Run the DS Component QA checklist and render it as a frame on the canvas next to the target - intended for a placed instance (resolves up to its owning set), or omit the target to use the current selection. Draws all ${ROW_COUNT} checklist items: automated ones with grouped findings, manual ones on a tinted row with no status chip. Alongside it, when the set has more than one theme mode, draws a labelled block showing the default variant rendered once per mode side by side (returned as \`modeShowcaseId\`) - evidence for row 17's visual half, which no check can judge; it never changes any row's status. Idempotent per target - re-running replaces the prior checklist frame instead of duplicating it. Returns only a stub (frame id, target, and pass/warn/fail/manual/pending/notApplicable/notRun counts plus a \`partial\` overlay), never the full findings payload. The status counts sum to all ${ROW_COUNT} rows, so a short total means one was misread rather than rows missing. Takes an explicit nodeId (or the current selection) - no name/glob lookup here; resolve a name to a nodeId with tidy_qa_run first if needed.`,
+      `Run the DS Component QA checklist and render it as a frame on the canvas next to the target - intended for a placed instance (resolves up to its owning set), or omit the target to use the current selection. Draws all ${ROW_COUNT} checklist items: automated ones with grouped findings, manual ones on a tinted row with no status chip. Alongside it, when the set has more than one theme mode, draws a labelled block showing the default variant rendered once per mode side by side (returned as \`modeShowcaseId\`) - evidence for row 17's visual half, which no check can judge; it never changes any row's status. Idempotent per target - re-running replaces the prior checklist frame instead of duplicating it. Returns only a stub (frame id, target, and pass/warn/fail/manual/pending/notApplicable/notRun counts plus a \`partial\` overlay), never the full findings payload - pass \`includeImage\` to also get a picture of the drawn frame. The status counts sum to all ${ROW_COUNT} rows, so a short total means one was misread rather than rows missing. Takes an explicit nodeId (or the current selection) - no name/glob lookup here; resolve a name to a nodeId with tidy_qa_run first if needed.`,
     inputSchema: {
       nodeId: z
         .string()
@@ -399,6 +399,12 @@ export const CATALOGUE: CatalogueEntry[] = [
         .optional()
         .describe(
           "Optional: place the checklist frame next to this node instead of the resolved target — lets the frame stay by the instance even though checks ran against its owning component set.",
+        ),
+      includeImage: z
+        .boolean()
+        .optional()
+        .describe(
+          "If true, also return `image`: the drawn checklist as a viewable image block. The frame stays on the canvas either way - this only lets you look at what was drawn, which is otherwise the one artifact here you cannot see. Useful when reporting on the checklist's own appearance, or when the designer cannot look at the canvas themselves. Costs a render, so ask for it when seeing it matters rather than on every run.",
         ),
     },
     timeoutMs: 60_000,

--- a/src/plugins/qa/agent-surface.test.ts
+++ b/src/plugins/qa/agent-surface.test.ts
@@ -79,6 +79,24 @@ describe("the MCP input schema", () => {
   });
 });
 
+describe("the checklist image flag", () => {
+  // The checklist frame is the primary artifact this module draws, and until
+  // #146 it was the one thing an agent could not look at. A flag that exists in
+  // the plugin but is undeclared here is a capability nobody can reach, and one
+  // documented in the command but absent from the schema is a promise that
+  // errors - both have happened to this catalogue before (#133).
+  it("is declared on the operation an agent actually calls", () => {
+    const schema = entry("tidy_qa_build_checklist").inputSchema.includeImage;
+
+    expect(schema).toBeDefined();
+    expect(schema?.description).toMatch(/image/i);
+  });
+
+  it("is described to the agent in the command it reads", () => {
+    expect(QA_COMMAND).toMatch(/includeImage/);
+  });
+});
+
 describe("the /tidy-ds:tidy-qa command", () => {
   it("classifies exactly the engine's check ids as check filters", () => {
     // The ids live in the "Check-id" bullet, backticked one per id, between the

--- a/src/plugins/qa/operations.ts
+++ b/src/plugins/qa/operations.ts
@@ -337,6 +337,12 @@ interface BuildChecklistResult {
    * that anything failed.
    */
   modeShowcaseId?: string;
+  /**
+   * The checklist frame as a PNG data URL, when `includeImage` asked for it.
+   * Lifted into a viewable image block by the bridge (#116), which recognises an
+   * image by the payload being a data URL rather than by any field name.
+   */
+  image?: string;
 }
 
 // No `name`/glob field: per CONTEXT.md, Execute Operations take explicit ids
@@ -353,6 +359,20 @@ interface BuildChecklistParams {
    * though checks ran against the owning set.
    */
   anchorNodeId?: string;
+  /**
+   * Return the drawn checklist as an image as well as an id (#146).
+   *
+   * The frame is the primary artifact this operation produces, and until this
+   * existed it was the one thing an agent could not look at - the per-mode
+   * showcase beside it was exportable while the checklist was not. Three visual
+   * defects in this module passed a full test suite and were only caught by
+   * rendering, so a change to the checklist's appearance had no way to be
+   * checked except by asking a human.
+   *
+   * Off by default: it costs a render, and a run that only wants the counts
+   * should not pay for one.
+   */
+  includeImage?: boolean;
 }
 
 function isSceneNode(node: BaseNode): node is SceneNode {
@@ -424,11 +444,25 @@ registerOperation<BuildChecklistParams, BuildChecklistResult>(
       modeShowcaseId = showcase.frame.id;
     }
 
+    // Exported after everything is placed, so the picture is of the finished
+    // artifact rather than of a frame still being assembled. 2x because the
+    // finding lines are 10-11px: at 1x they are the size where a vision model
+    // stops being able to read them, which would make the image decorative.
+    const image = params.includeImage
+      ? `data:image/png;base64,${figma.base64Encode(
+          await frame.exportAsync({
+            format: "PNG",
+            constraint: { type: "SCALE", value: 2 },
+          }),
+        )}`
+      : undefined;
+
     return {
       frameId: frame.id,
       target: result.target,
       counts: result.checklist.counts,
       ...(modeShowcaseId ? { modeShowcaseId } : {}),
+      ...(image ? { image } : {}),
     };
   },
 );


### PR DESCRIPTION
Closes #146.

The checklist is the primary artifact this module produces, and it was the one thing an agent could not look at. The per-mode showcase beside it became exportable in #121; the checklist itself never did.

## Why this is not a convenience

Three visual defects in this module passed a full test suite with mutation-verified guards and were caught **only** by rendering:

- a backdrop painted in the component's own colour, making it invisible
- a neutral backdrop that read as a bug rather than a deliberate neutral
- a polarity bug that drew four distinct theme modes identically

When the tick boxes came out and manual rows were tinted (#145), the tint was the one change nobody could verify — the maintainer had to confirm it by eye, because there was no way to get the frame back.

**The first run of this feature closed that loop**: the tint is visibly deliberate, and the empty right column on manual rows reads as intentional rather than unfinished. That is now checkable by anyone, not just whoever has the file open.

## What it does

`includeImage: true` returns `image` as a data URL. The bridge lifts it into a viewable block on its own — a result declares an image by *being* a data URL (#116), so there is no new plumbing. Off by default: a run that wants only the counts should not pay for a render.

## Decisions from the issue's open questions

**`SCALE: 2`, exported after everything is placed.** The finding lines are 10–11px; at 1× that is where a vision model stops being able to read them, which would make the picture decorative. Verified on a real 19-row checklist with findings — every caveat line is legible, at about **540 KB**. That size is the honest cost, and it is why the flag is opt-in.

**Checklist only.** `tidy_qa_run` already exports the showcase; two ways to obtain the same picture is worse than one.

**Not on `tidy_qa_run`.** It would mean drawing a checklist transiently in a Query under the ADR-0001 carve-out, and `build_checklist` already has the frame.

## On the seam

There is no pure decision here to unit-test — it is `exportAsync` and a data URL. I did not invent a seam for the sake of having one; that mistake was made earlier in this codebase with an ignored parameter and was rightly called out.

What *is* guarded is drift: the flag must exist in the MCP schema **and** be described in the command an agent reads. One without the other is either a capability nobody can reach or a promise that errors, and both have happened to this catalogue (#133). Undeclaring it reddens five tests.

## Validation

670 tests, typecheck (both projects), lint 0 errors, formatting, `build`, `build:plugin`, both MCP smoketests — plus the live export above, which is the point of the change.
