### PR TITLE
feat(mcp): measure contrast per styled run of mixed-colour text

### DIFF
--- a/docs/prd-automated-qa.md
+++ b/docs/prd-automated-qa.md
@@ -383,7 +383,12 @@ While a **Human-in-the-Loop** model will always exist for nuanced creative choic
 > Alpha is composited rather than skipped (both paint opacity and node opacity), because the Kido DS deliberately uses opacity in place of absolute hex; only a chain that never reaches opacity is skipped.
 >
 > Colours resolve through literal hex, bound variable, paint style, and a paint style whose paint is variable-bound - the `tokens` check accepts either a variable or a style, so resolving variables alone would leave most rows unevaluated for an implementation-detail reason.
-> Granularity is the layer, not the character range: mixed fills are not evaluated, and a mixed font size is judged at its smallest.
+> **Text whose colour changes mid-sentence is measured per styled run** (issue #124) - a coloured link inside a paragraph, a highlighted word.
+> Each run is measured against the same background, at its own size and weight, so a 24px word beside a 12px one is held to the threshold that actually applies to it.
+> The layer used to be skipped whole, which made the one shape of text that most often carries a low-contrast link the one shape the check could not see.
+> A run is not an occurrence: findings still count *layers*, so a paragraph with four grey runs is one occurrence of that pair rather than four, and runs sharing a pair at different sizes are described by the stricter threshold.
+> Runs that fail on genuinely different pairs report separately, because those are different fixes.
+> A mixed font size alone is still judged at its smallest - size does not change what colour is on screen, so one verdict still describes the layer.
 > Thresholds are AA's dual pair, 4.5:1 and 3:1 for large text (>= 24px, or >= 18.66px bold), with no warn tier - AA is the standard and a warn band for AAA is noise.
 > Invisible text needs no special case: it arrives as the ratio-1.0 extreme, which is why #17 leaves it here.
 >

--- a/src/plugins/qa/checks/high-contrast.test.ts
+++ b/src/plugins/qa/checks/high-contrast.test.ts
@@ -4,6 +4,7 @@ import type {
   ComponentSetSnapshot,
   NodeSnapshot,
   PaintSnapshot,
+  TextSegmentSnapshot,
   ThemeSnapshot,
 } from "../snapshot";
 
@@ -33,6 +34,32 @@ function text(overrides: Partial<NodeSnapshot> = {}): NodeSnapshot {
     type: "TEXT",
     fontSize: 16,
     bold: false,
+    ...overrides,
+  });
+}
+
+/** One styled run of a mixed-colour text layer (#124). */
+function run(
+  hex: string,
+  overrides: Partial<TextSegmentSnapshot> = {},
+): TextSegmentSnapshot {
+  return { fills: [solid(hex)], fontSize: 16, bold: false, ...overrides };
+}
+
+/**
+ * A text layer whose fills change mid-sentence. Figma leaves `fills` mixed and
+ * `fillStyleId` "MIXED" on such a layer, so the runs are the only description
+ * of its colour - the fixture says so rather than leaving it implied.
+ */
+function mixedText(
+  segments: TextSegmentSnapshot[],
+  overrides: Partial<NodeSnapshot> = {},
+): NodeSnapshot {
+  return text({
+    fills: undefined,
+    fillStyleId: "MIXED",
+    fillsMixed: true,
+    textSegments: segments,
     ...overrides,
   });
 }
@@ -654,5 +681,251 @@ describe("checkHighContrast with theme modes", () => {
     );
     expect(result.status).toBe("fail");
     expect(result.findings[0].message).toContain('"Surface/Default"');
+  });
+
+  it("resolves a styled run's bound variable per mode, like any other fill", () => {
+    // The link run is the same token that fails in DNA and passes in Core; the
+    // surrounding body copy is fine in both. A run resolves through exactly the
+    // rules a whole layer does, so only DNA is reported - and by token name.
+    const result = checkHighContrast(
+      fixture(
+        [
+          node({
+            name: "surface",
+            fills: [solid("#FFFFFF", { boundVariableId: "v-surface" })],
+            children: [
+              mixedText([
+                run("#111111"),
+                run("#595959", {
+                  fills: [solid("#595959", { boundVariableId: "v-text" })],
+                }),
+              ]),
+            ],
+          }),
+        ],
+        { theme },
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].message).toContain('in mode "DNA"');
+    expect(result.findings[0].message).toContain('"Text/Muted"');
+    expect(result.findings[0].message).toContain('"Surface/Default"');
+  });
+});
+
+/**
+ * Text whose colour changes mid-sentence (issue #124): a coloured link inside a
+ * paragraph, or a highlighted word. Before this, the whole layer was skipped -
+ * the one shape of text that most often carries a low-contrast link was the one
+ * shape the check could not see.
+ */
+describe("checkHighContrast on mixed-colour text", () => {
+  it("measures a failing run that the layer as a whole would have hidden", () => {
+    const result = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", mixedText([run("#111111"), run("#999999")])),
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(messages(result)).toEqual([
+      "Text #999999 on #FFFFFF is 2.8:1, below the WCAG AA minimum for normal text.",
+    ]);
+  });
+
+  it("leaves a layer alone when every run clears AA", () => {
+    const result = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", mixedText([run("#111111"), run("#595959")])),
+      ]),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("counts a layer once however many of its runs share a pair", () => {
+    // Four grey runs in one paragraph are one defect and one token pair to fix.
+    // Counting runs would report "4 occurrences" of a mistake made once.
+    const result = checkHighContrast(
+      fixture([
+        surface(
+          "#FFFFFF",
+          mixedText([
+            run("#999999"),
+            run("#111111"),
+            run("#999999"),
+            run("#999999"),
+            run("#999999"),
+          ]),
+        ),
+      ]),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(1);
+  });
+
+  it("still counts one per layer when several layers share the pair", () => {
+    const paragraph = () =>
+      surface("#FFFFFF", mixedText([run("#999999"), run("#999999")]));
+    const result = checkHighContrast(
+      fixture([paragraph(), paragraph(), paragraph()]),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(3);
+  });
+
+  it("reports runs that fail on genuinely different pairs separately", () => {
+    // Two colours are two fixes, so merging them would hide one behind the
+    // other - the same reason distinct pairs are never merged across layers.
+    const result = checkHighContrast(
+      fixture([
+        surface("#FFFFFF", mixedText([run("#999999"), run("#AAAAAA")])),
+      ]),
+    );
+    expect(result.findings).toHaveLength(2);
+    expect(messages(result).join(" ")).toContain("#999999");
+    expect(messages(result).join(" ")).toContain("#AAAAAA");
+    expect(result.findings.every((f) => f.count === 1)).toBe(true);
+  });
+
+  it("judges each run at its own size, not at the layer's smallest", () => {
+    // #949494 is ~3.1:1 - over AA large, under AA normal. The 24px run is
+    // compliant; judging it at the layer's smallest size would invent a
+    // failure on text that is perfectly readable.
+    const result = checkHighContrast(
+      fixture([
+        surface(
+          "#FFFFFF",
+          mixedText([run("#949494", { fontSize: 24 }), run("#333333")], {
+            fontSize: 16,
+          }),
+        ),
+      ]),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.findings).toEqual([]);
+  });
+
+  it("describes a pair failing at two sizes by its strictest threshold", () => {
+    // #999999 is under both thresholds, so both runs fail - at 3:1 for the
+    // heading and 4.5:1 for the caption. One pair is one row, described by the
+    // stricter of the two, exactly as it is when two layers share a pair.
+    const result = checkHighContrast(
+      fixture([
+        surface(
+          "#FFFFFF",
+          mixedText([run("#999999", { fontSize: 24 }), run("#999999")]),
+        ),
+      ]),
+    );
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].expected).toContain("4.5:1");
+    expect(result.findings[0].expected).toContain("normal text");
+    expect(result.findings[0].count).toBe(1);
+  });
+
+  it("applies the large-text threshold to a bold run on its own merit", () => {
+    const result = checkHighContrast(
+      fixture([
+        surface(
+          "#FFFFFF",
+          mixedText([
+            run("#949494", { fontSize: 18.66, bold: true }),
+            run("#333333"),
+          ]),
+        ),
+      ]),
+    );
+    expect(result.status).toBe("pass");
+  });
+
+  it("resolves a run through the paint style it carries, and names it", () => {
+    // The layer's own `fillStyleId` is "MIXED" and says nothing; the run's does.
+    const result = checkHighContrast(
+      fixture(
+        [
+          node({
+            name: "surface",
+            fillStyleId: "S:bg",
+            fills: [solid("#FFFFFF")],
+            children: [
+              mixedText([
+                run("#111111"),
+                run("#999999", { fillStyleId: "S:link" }),
+              ]),
+            ],
+          }),
+        ],
+        {
+          colorStyles: {
+            "S:bg": { name: "Surface/Card", paints: [solid("#FFFFFF")] },
+            "S:link": { name: "Text/Link", paints: [solid("#999999")] },
+          },
+        },
+      ),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings[0].message).toContain('"Text/Link"');
+    expect(result.findings[0].message).toContain('"Surface/Card"');
+  });
+
+  it("measures the runs it can when one of them has no single colour", () => {
+    // A gradient run has no colour to measure, but that is no reason to stop
+    // measuring the run beside it. The layer still lands in the skipped tally,
+    // so the unmeasured part is never quietly green.
+    const result = checkHighContrast(
+      fixture([
+        surface(
+          "#FFFFFF",
+          mixedText([
+            run("#999999"),
+            run("#000000", {
+              fills: [{ type: "GRADIENT_LINEAR", visible: true, opacity: 1 }],
+            }),
+          ]),
+        ),
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(messages(result)).toEqual([
+      "Text #999999 on #FFFFFF is 2.8:1, below the WCAG AA minimum for normal text.",
+      "1 text layer was not evaluated for contrast: 1 has a gradient or image in its colour chain.",
+    ]);
+  });
+
+  it("fades every run of a translucent layer alike", () => {
+    // 50% black over white renders #808080 - 3.9:1, a fail for normal text.
+    // The layer's opacity is a property of the layer, not of any one run.
+    const result = checkHighContrast(
+      fixture([
+        surface(
+          "#FFFFFF",
+          mixedText([run("#000000"), run("#000000")], { opacity: 0.5 }),
+        ),
+      ]),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].count).toBe(1);
+    expect(result.findings[0].actual).toBe("3.9:1");
+  });
+
+  it("still declines a layer that claims mixed fills but carries no runs", () => {
+    // Nothing to measure and nothing to guess from: the honest answer is that
+    // the layer was not evaluated, which is what it was before #124 too.
+    const result = checkHighContrast(
+      fixture([surface("#FFFFFF", mixedText([]))]),
+    );
+    expect(result.status).toBe("warn");
+    expect(messages(result)).toEqual([
+      "1 text layer was not evaluated for contrast: 1 uses per-character fills.",
+    ]);
+  });
+
+  it("says in the note that runs are measured and counted per layer", () => {
+    const result = checkHighContrast(
+      fixture([surface("#FFFFFF", mixedText([run("#111111")]))]),
+    );
+    expect(result.note).toContain("per styled run");
   });
 });

--- a/src/plugins/qa/checks/high-contrast.ts
+++ b/src/plugins/qa/checks/high-contrast.ts
@@ -33,10 +33,25 @@
  * implementation-detail reason - and an unevaluated contrast check is worse
  * than none, because the row still looks checked.
  *
- * Granularity is the layer, not the character range: mixed fills are not
- * evaluated (picking "the first fill" would be confidently wrong), and a mixed
- * font size is judged at its smallest, so the strictest applicable threshold
- * wins.
+ * **Mixed-colour text is measured per run** (issue #124). A layer painted in one
+ * colour is one measurement; a layer whose fills change mid-sentence - a
+ * coloured link inside a paragraph, a highlighted word - is measured once per
+ * styled run, each against the same background and at its own size and weight.
+ * Treating that layer as one unit was never possible ("the first fill" would be
+ * confidently wrong), and skipping it entirely made the one text that most often
+ * carries a low-contrast link invisible to the check.
+ *
+ * **A run is not an occurrence.** Findings still count *layers*, so a paragraph
+ * with four grey runs on white is one occurrence of that pair, not four - the
+ * defect is one token pair, and inflating the count by how many times a designer
+ * happened to split the run would make the number mean nothing. Runs that fail on
+ * genuinely different pairs do report separately, because those are different
+ * fixes. Where runs share a pair but not a threshold, the strictest one is
+ * reported, the same rule already used across layers.
+ *
+ * A mixed *font size* alone is still judged at its smallest, so the strictest
+ * applicable threshold wins: size does not change what colour is on screen, so
+ * one verdict still describes the layer.
  *
  * **AA, dual threshold, no warn tier**: 4.5:1 normally, 3:1 for large text
  * (>= 24px, or >= 18.66px bold). AA is the standard, and a warn band for AAA
@@ -64,6 +79,7 @@ import type {
   ComponentSetSnapshot,
   NodeSnapshot,
   PaintSnapshot,
+  TextSegmentSnapshot,
   ThemeSnapshot,
 } from "../snapshot";
 import type { CheckResult, CheckStatus, Finding } from "../types";
@@ -87,6 +103,9 @@ type SkipReason =
   | "no-background";
 
 const SKIP_PHRASES: Record<SkipReason, { one: string; many: string }> = {
+  // Reached only when the per-run fills could not be read at all (#124 measures
+  // them when they can). A layer that says "my fills are mixed" and offers no
+  // runs describes nothing measurable, and saying so is better than assuming.
   "mixed-fill": {
     one: "uses per-character fills",
     many: "use per-character fills",
@@ -127,6 +146,20 @@ interface Candidate {
   node: NodeSnapshot;
   /** Ancestors nearest-first, up to the variant root. */
   ancestors: NodeSnapshot[];
+}
+
+/**
+ * One measurable unit of text: a whole layer, or one styled run inside a layer
+ * whose fills change mid-sentence (#124). Everything downstream of the colour
+ * lookup is identical for both, which is why they share a shape - the run and
+ * the layer sit at the same place in the same ancestor chain, so only the
+ * foreground colour and the AA threshold differ.
+ */
+interface Piece {
+  paints: PaintSnapshot[] | undefined;
+  style?: ColorStyleSnapshot;
+  fontSize?: number;
+  bold: boolean;
 }
 
 /**
@@ -203,82 +236,93 @@ export function checkHighContrast(snapshot: ComponentSetSnapshot): CheckResult {
 
   for (const candidate of candidates) {
     const { node } = candidate;
-    // Mixed fills are mode-independent, so this is settled before any mode is
+    // A layer that declares mixed fills and carries no runs describes nothing
+    // measurable. Mode-independent, so it is settled before any mode is
     // considered - and settled once, not once per mode.
-    if (node.fillsMixed) {
+    const pieces = textPieces(node, snapshot);
+    if (pieces === undefined) {
       skip(node, "mixed-fill");
       continue;
     }
 
-    for (const mode of modes) {
-      const own = resolveColor(node, mode, snapshot);
-      if (own === undefined) {
-        skip(node, "no-fill");
-        break;
-      }
-      if (own === "non-solid" || own === "unresolved") {
-        skip(node, own === "non-solid" ? "non-solid" : "unresolved-colour");
-        continue;
-      }
+    // Which failure keys this *layer* has already been counted against, so a
+    // paragraph whose runs share a colour pair counts once. The count means
+    // "how many layers hit this pair", and a run is not a layer.
+    const counted = new Set<string>();
 
-      // The text layer's own opacity, applied here for the same reason
-      // `resolveColor` leaves it out: it is a group property, and the text is
-      // its own (leaf) group.
-      const selfOpacity = node.opacity ?? 1;
-      const start: Rgba =
-        selfOpacity === 1
-          ? own.rgba
-          : { hex: own.rgba.hex, alpha: own.rgba.alpha * selfOpacity };
-
-      const rendered = render(candidate, start, mode, snapshot);
-      if (rendered === "non-solid" || rendered === "unresolved") {
-        skip(
-          node,
-          rendered === "non-solid" ? "non-solid" : "unresolved-colour",
-        );
-        continue;
-      }
-      if (rendered === undefined) {
-        skip(node, "no-background");
-        continue;
-      }
-
-      const ratio = contrastRatio(rendered.text.hex, rendered.background.hex);
-      const required = requiredRatio(node.fontSize, node.bold ?? false);
-      if (ratio >= required) continue;
-
-      // Keyed on the **rendered** colours, not on the token names: two layers
-      // can quote the same token pair and still render differently (a 50%
-      // opacity on one of them), and merging those would report one ratio for
-      // two different pairs. Names are kept for display only.
-      const key = JSON.stringify([
-        mode.modeId,
-        rendered.text.hex,
-        rendered.background.hex,
-      ]);
-      const existing = failures.get(key);
-      if (existing) {
-        existing.count += 1;
-        // One rendered pair is one row, so a group holding both normal and
-        // large text is described by its strictest member - the count covers
-        // the rest. Splitting on the threshold instead would put the same
-        // colour pair on two rows, which the ticket rules out.
-        if (required > existing.required) {
-          existing.required = required;
-          existing.large = false;
+    for (const piece of pieces) {
+      for (const mode of modes) {
+        const own = resolvePaints(piece.paints, piece.style, mode, snapshot);
+        if (own === undefined) {
+          skip(node, "no-fill");
+          break;
         }
-      } else {
-        failures.set(key, {
-          modeName: mode.name,
-          foreground: own.label,
-          background: rendered.label,
-          ratio,
-          required,
-          large: required < AA_NORMAL,
-          nodeId: node.id,
-          nodeName: node.name,
-          count: 1,
-        });
+        if (own === "non-solid" || own === "unresolved") {
+          skip(node, own === "non-solid" ? "non-solid" : "unresolved-colour");
+          continue;
+        }
+
+        // The text layer's own opacity, applied here for the same reason
+        // `resolveColor` leaves it out: it is a group property, and the text is
+        // its own (leaf) group. It fades every run alike.
+        const selfOpacity = node.opacity ?? 1;
+        const start: Rgba =
+          selfOpacity === 1
+            ? own.rgba
+            : { hex: own.rgba.hex, alpha: own.rgba.alpha * selfOpacity };
+
+        const rendered = render(candidate, start, mode, snapshot);
+        if (rendered === "non-solid" || rendered === "unresolved") {
+          skip(
+            node,
+            rendered === "non-solid" ? "non-solid" : "unresolved-colour",
+          );
+          continue;
+        }
+        if (rendered === undefined) {
+          skip(node, "no-background");
+          continue;
+        }
+
+        const ratio = contrastRatio(rendered.text.hex, rendered.background.hex);
+        const required = requiredRatio(piece.fontSize, piece.bold);
+        if (ratio >= required) continue;
+
+        // Keyed on the **rendered** colours, not on the token names: two layers
+        // can quote the same token pair and still render differently (a 50%
+        // opacity on one of them), and merging those would report one ratio for
+        // two different pairs. Names are kept for display only.
+        const key = JSON.stringify([
+          mode.modeId,
+          rendered.text.hex,
+          rendered.background.hex,
+        ]);
+        const existing = failures.get(key);
+        if (existing) {
+          if (!counted.has(key)) existing.count += 1;
+          // One rendered pair is one row, so a group holding both normal and
+          // large text is described by its strictest member - the count covers
+          // the rest. Splitting on the threshold instead would put the same
+          // colour pair on two rows, which the ticket rules out. The same rule
+          // settles two runs of one layer that share a pair at different sizes.
+          if (required > existing.required) {
+            existing.required = required;
+            existing.large = false;
+          }
+        } else {
+          failures.set(key, {
+            modeName: mode.name,
+            foreground: own.label,
+            background: rendered.label,
+            ratio,
+            required,
+            large: required < AA_NORMAL,
+            nodeId: node.id,
+            nodeName: node.name,
+            count: 1,
+          });
+        }
+        counted.add(key);
       }
     }
   }
@@ -340,20 +384,60 @@ function evaluatedModes(theme: ThemeSnapshot | undefined): Mode[] {
   return [{ modeId: "", name: "" }];
 }
 
-/** The paints backing a node, and the style name when they came from a style. */
+/**
+ * The paints to measure, and the style name when they came from a style.
+ *
+ * A style the collector could not resolve falls back to the fills held on the
+ * node or run itself, which Figma keeps in sync with the style: the name is
+ * lost, the colour is not.
+ */
 function paintSource(
-  node: NodeSnapshot,
+  fills: PaintSnapshot[] | undefined,
+  fillStyleId: string | undefined,
   snapshot: ComponentSetSnapshot,
 ): { paints: PaintSnapshot[] | undefined; style?: ColorStyleSnapshot } {
-  const styleId = node.fillStyleId;
-  if (styleId && styleId !== "MIXED") {
-    const style = snapshot.colorStyles?.[styleId];
-    // A style the collector could not resolve falls back to the node's own
-    // fills, which Figma keeps in sync with the style: the name is lost, the
-    // colour is not.
+  if (fillStyleId && fillStyleId !== "MIXED") {
+    const style = snapshot.colorStyles?.[fillStyleId];
     if (style) return { paints: style.paints, style };
   }
-  return { paints: node.fills };
+  return { paints: fills };
+}
+
+/**
+ * The units to measure a text layer in: one per styled run when its fills change
+ * mid-sentence (#124), otherwise the single unit that is the whole layer.
+ *
+ * `undefined` means the layer says its fills are mixed but carries no runs -
+ * nothing measurable, and the caller reports it as unevaluated rather than
+ * picking a colour out of a layer that does not have one.
+ */
+function textPieces(
+  node: NodeSnapshot,
+  snapshot: ComponentSetSnapshot,
+): Piece[] | undefined {
+  const segments = node.textSegments;
+  if (segments && segments.length > 0) {
+    return segments.map((segment) => segmentPiece(segment, snapshot));
+  }
+  if (node.fillsMixed) return undefined;
+  return [
+    {
+      ...paintSource(node.fills, node.fillStyleId, snapshot),
+      fontSize: node.fontSize,
+      bold: node.bold ?? false,
+    },
+  ];
+}
+
+function segmentPiece(
+  segment: TextSegmentSnapshot,
+  snapshot: ComponentSetSnapshot,
+): Piece {
+  return {
+    ...paintSource(segment.fills, segment.fillStyleId, snapshot),
+    fontSize: segment.fontSize,
+    bold: segment.bold ?? false,
+  };
 }
 
 /**
@@ -374,7 +458,22 @@ function resolveColor(
   mode: Mode,
   snapshot: ComponentSetSnapshot,
 ): Resolved {
-  const { paints, style } = paintSource(node, snapshot);
+  const { paints, style } = paintSource(node.fills, node.fillStyleId, snapshot);
+  return resolvePaints(paints, style, mode, snapshot);
+}
+
+/**
+ * The colour of one already-chosen paint list - the body of `resolveColor`,
+ * split out so a styled run resolves through exactly the same rules as a node
+ * (#124). Variables, styles, paint opacity and multi-paint compositing must not
+ * behave one way for a layer and another way for a run inside it.
+ */
+function resolvePaints(
+  paints: PaintSnapshot[] | undefined,
+  style: ColorStyleSnapshot | undefined,
+  mode: Mode,
+  snapshot: ComponentSetSnapshot,
+): Resolved {
   if (!paints || paints.length === 0) return undefined;
 
   let accumulated: Rgba | undefined;
@@ -634,7 +733,7 @@ function buildNote(
   disabledCount: number,
 ): string {
   const scope =
-    "Contrast is measured against the nearest ancestor with a solid fill, so sibling geometry and images behind a layer are not considered, and text is judged per layer rather than per character range.";
+    "Contrast is measured against the nearest ancestor with a solid fill, so sibling geometry and images behind a layer are not considered. Text whose colour changes mid-sentence is measured per styled run, and a layer counts once per colour pair however many of its runs share it.";
   const disabled =
     disabledCount > 0
       ? ` ${disabledCount} disabled ${disabledCount === 1 ? "variant was" : "variants were"} not evaluated, since WCAG exempts inactive controls; that is recognised from a "Disabled" variant property, so a set naming it differently would still be measured.`

--- a/src/plugins/qa/collector.test.ts
+++ b/src/plugins/qa/collector.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The pure seam of the collector (issue #124).
+ *
+ * `collector.ts` is one of the deliberately figma-touching files, so most of it
+ * is exercised only by loading the plugin. `textSegmentSnapshots` is carved out
+ * of that because it is the piece that decides what the contrast check will
+ * see: get the mapping wrong and a coloured link is either invisible again or
+ * measured against the wrong colour, and nothing downstream can tell.
+ *
+ * The fixtures are typed as `StyledFillRun`, which is a `Pick` of Figma's own
+ * `StyledTextSegment`. That is the point - a fixture that drifts from what
+ * `getStyledTextSegments` actually returns stops compiling.
+ */
+
+import { describe, it, expect } from "vitest";
+import { textSegmentSnapshots } from "./collector";
+import type { StyledFillRun } from "./collector";
+
+function solidPaint(
+  r: number,
+  g: number,
+  b: number,
+  extra: Partial<SolidPaint> = {},
+): SolidPaint {
+  return { type: "SOLID", color: { r, g, b }, ...extra };
+}
+
+function run(overrides: Partial<StyledFillRun> = {}): StyledFillRun {
+  return {
+    fills: [solidPaint(0, 0, 0)],
+    fillStyleId: "",
+    fontSize: 16,
+    fontWeight: 400,
+    ...overrides,
+  };
+}
+
+describe("textSegmentSnapshots", () => {
+  it("gives each run its own colour, size and style", () => {
+    const result = textSegmentSnapshots([
+      run(),
+      run({
+        fills: [solidPaint(0.6, 0.6, 0.6)],
+        fillStyleId: "S:link",
+        fontSize: 24,
+      }),
+    ]);
+    expect(result).toEqual([
+      {
+        fills: [{ type: "SOLID", visible: true, opacity: 1, hex: "#000000" }],
+        fillStyleId: "",
+        fontSize: 16,
+      },
+      {
+        fills: [{ type: "SOLID", visible: true, opacity: 1, hex: "#999999" }],
+        fillStyleId: "S:link",
+        fontSize: 24,
+      },
+    ]);
+  });
+
+  it("marks a run bold only from 700, so the lenient threshold is earned", () => {
+    const result = textSegmentSnapshots([
+      run({ fontWeight: 600 }),
+      run({ fontWeight: 700 }),
+    ]);
+    expect(result?.[0].bold).toBeUndefined();
+    expect(result?.[1].bold).toBe(true);
+  });
+
+  it("carries a run's bound colour variable through", () => {
+    // Without the binding the check cannot resolve the run per theme mode, and
+    // a link that fails in one mode only would never be reported.
+    const result = textSegmentSnapshots([
+      run({
+        fills: [
+          solidPaint(0.35, 0.35, 0.35, {
+            boundVariables: { color: { type: "VARIABLE_ALIAS", id: "v-link" } },
+          }),
+        ],
+      }),
+    ]);
+    expect(result?.[0].fills?.[0].boundVariableId).toBe("v-link");
+  });
+
+  it("keeps a run's paint opacity and hidden flag", () => {
+    const result = textSegmentSnapshots([
+      run({
+        fills: [
+          solidPaint(0, 0, 0, { opacity: 0.3 }),
+          solidPaint(1, 1, 1, { visible: false }),
+        ],
+      }),
+    ]);
+    expect(result?.[0].fills).toEqual([
+      { type: "SOLID", visible: true, opacity: 0.3, hex: "#000000" },
+      { type: "SOLID", visible: false, opacity: 1, hex: "#FFFFFF" },
+    ]);
+  });
+
+  it("records a non-solid run without inventing a colour for it", () => {
+    // A gradient run has no single colour. It must still arrive, so the check
+    // can say it could not measure that part rather than skipping it silently.
+    const gradient: GradientPaint = {
+      type: "GRADIENT_LINEAR",
+      gradientTransform: [
+        [1, 0, 0],
+        [0, 1, 0],
+      ],
+      gradientStops: [],
+    };
+    const result = textSegmentSnapshots([run({ fills: [gradient] })]);
+    expect(result?.[0].fills).toEqual([
+      { type: "GRADIENT_LINEAR", visible: true, opacity: 1 },
+    ]);
+  });
+
+  it("reports a run that paints nothing as an empty fill list", () => {
+    const result = textSegmentSnapshots([run({ fills: [] })]);
+    expect(result?.[0].fills).toEqual([]);
+  });
+
+  it("returns undefined when there are no runs at all", () => {
+    // Figma returns no segments for an empty text layer. There is nothing to
+    // measure, and the check reports the layer as unevaluated.
+    expect(textSegmentSnapshots([])).toBeUndefined();
+  });
+});

--- a/src/plugins/qa/collector.ts
+++ b/src/plugins/qa/collector.ts
@@ -22,6 +22,7 @@ import type {
   ExposedInstanceSnapshot,
   NodeSnapshot,
   PaintSnapshot,
+  TextSegmentSnapshot,
   VariantSnapshot,
 } from "./snapshot";
 
@@ -59,6 +60,8 @@ function styleId(value: string | typeof figma.mixed): string {
   return value === figma.mixed ? "MIXED" : value;
 }
 
+const BOLD_WEIGHT = 700;
+
 /**
  * Font size and boldness for #16's dual AA threshold.
  *
@@ -71,7 +74,6 @@ function snapshotTextMetrics(node: TextNode): {
   fontSize?: number;
   bold: boolean;
 } {
-  const BOLD_WEIGHT = 700;
   if (node.fontSize !== figma.mixed && node.fontWeight !== figma.mixed) {
     return { fontSize: node.fontSize, bold: node.fontWeight >= BOLD_WEIGHT };
   }
@@ -81,6 +83,42 @@ function snapshotTextMetrics(node: TextNode): {
     fontSize: Math.min(...segments.map((s) => s.fontSize)),
     bold: segments.every((s) => s.fontWeight >= BOLD_WEIGHT),
   };
+}
+
+/**
+ * The styled runs of a text layer whose fills are mixed (#124).
+ *
+ * Only for that case: a layer painted in one colour already has one answer, and
+ * mixed *size* alone is still resolved to the strictest threshold above. The
+ * colour is the thing a single layer-level value genuinely cannot express -
+ * without the runs, a paragraph with one coloured link is not measured at all.
+ *
+ * Figma splits a run wherever any requested field changes, so asking for size
+ * and weight alongside the fills gives each run its own real threshold rather
+ * than the layer's smallest size.
+ */
+function snapshotTextSegments(
+  node: TextNode,
+): TextSegmentSnapshot[] | undefined {
+  const segments = node.getStyledTextSegments([
+    "fills",
+    "fillStyleId",
+    "fontSize",
+    "fontWeight",
+  ]);
+  if (segments.length === 0) return undefined;
+  return segments.map((segment) => {
+    const snap: TextSegmentSnapshot = {
+      fontSize: segment.fontSize,
+      fillStyleId: segment.fillStyleId,
+    };
+    // A run's fills are never `figma.mixed` - the run is the span over which
+    // they do not change - so this always yields an array.
+    const fills = snapshotPaints(segment.fills);
+    if (fills) snap.fills = fills;
+    if (segment.fontWeight >= BOLD_WEIGHT) snap.bold = true;
+    return snap;
+  });
 }
 
 /**
@@ -207,8 +245,8 @@ function snapshotNode(node: SceneNode): NodeSnapshot {
     const fills = snapshotPaints(node.fills);
     if (fills) snap.fills = fills;
     // Recorded explicitly rather than left as an absent `fills`: #16 has to
-    // tell "mixed per character range, decline to measure" apart from "this
-    // node paints nothing".
+    // tell "mixed per character range, measure the runs instead" apart from
+    // "this node paints nothing".
     else if (node.fills === figma.mixed) snap.fillsMixed = true;
     snap.fillStyleId = styleId(node.fillStyleId);
   }
@@ -221,6 +259,10 @@ function snapshotNode(node: SceneNode): NodeSnapshot {
     const metrics = snapshotTextMetrics(node);
     if (metrics.fontSize !== undefined) snap.fontSize = metrics.fontSize;
     if (metrics.bold) snap.bold = true;
+    if (snap.fillsMixed) {
+      const segments = snapshotTextSegments(node);
+      if (segments) snap.textSegments = segments;
+    }
   }
   if ("effects" in node) {
     snap.effectCount = node.effects.length;

--- a/src/plugins/qa/collector.ts
+++ b/src/plugins/qa/collector.ts
@@ -41,10 +41,8 @@ function snapshotExposedInstance(
   };
 }
 
-function snapshotPaints(
-  paints: readonly Paint[] | typeof figma.mixed,
-): PaintSnapshot[] | undefined {
-  if (paints === figma.mixed) return undefined;
+/** Paints that are known not to be mixed. Pure - no `figma` reference. */
+function mapPaints(paints: readonly Paint[]): PaintSnapshot[] {
   return paints.map((paint) => ({
     type: paint.type,
     visible: paint.visible !== false,
@@ -54,6 +52,13 @@ function snapshotPaints(
       ? { boundVariableId: paint.boundVariables.color.id }
       : {}),
   }));
+}
+
+function snapshotPaints(
+  paints: readonly Paint[] | typeof figma.mixed,
+): PaintSnapshot[] | undefined {
+  if (paints === figma.mixed) return undefined;
+  return mapPaints(paints);
 }
 
 function styleId(value: string | typeof figma.mixed): string {
@@ -85,6 +90,38 @@ function snapshotTextMetrics(node: TextNode): {
   };
 }
 
+/** The fields #124 asks `getStyledTextSegments` for, and nothing else. */
+export type StyledFillRun = Pick<
+  StyledTextSegment,
+  "fills" | "fillStyleId" | "fontSize" | "fontWeight"
+>;
+
+/**
+ * Styled runs as the snapshot carries them (#124). The pure half of
+ * `snapshotTextSegments`, split out so the mapping is fixture-tested rather
+ * than trusted: it is the one piece of #124 that decides what the check will
+ * see, and it is the reason a coloured link is measurable at all.
+ *
+ * Figma's own types settle the two facts this relies on: a run's `fills` is
+ * `Paint[]`, never `figma.mixed` - a run is by definition the span over which
+ * they do not change - and its `fillStyleId` is a plain `string`, never the
+ * `"MIXED"` sentinel a whole layer can carry.
+ */
+export function textSegmentSnapshots(
+  runs: readonly StyledFillRun[],
+): TextSegmentSnapshot[] | undefined {
+  if (runs.length === 0) return undefined;
+  return runs.map((segment) => {
+    const snap: TextSegmentSnapshot = {
+      fontSize: segment.fontSize,
+      fillStyleId: segment.fillStyleId,
+      fills: mapPaints(segment.fills),
+    };
+    if (segment.fontWeight >= BOLD_WEIGHT) snap.bold = true;
+    return snap;
+  });
+}
+
 /**
  * The styled runs of a text layer whose fills are mixed (#124).
  *
@@ -100,25 +137,14 @@ function snapshotTextMetrics(node: TextNode): {
 function snapshotTextSegments(
   node: TextNode,
 ): TextSegmentSnapshot[] | undefined {
-  const segments = node.getStyledTextSegments([
-    "fills",
-    "fillStyleId",
-    "fontSize",
-    "fontWeight",
-  ]);
-  if (segments.length === 0) return undefined;
-  return segments.map((segment) => {
-    const snap: TextSegmentSnapshot = {
-      fontSize: segment.fontSize,
-      fillStyleId: segment.fillStyleId,
-    };
-    // A run's fills are never `figma.mixed` - the run is the span over which
-    // they do not change - so this always yields an array.
-    const fills = snapshotPaints(segment.fills);
-    if (fills) snap.fills = fills;
-    if (segment.fontWeight >= BOLD_WEIGHT) snap.bold = true;
-    return snap;
-  });
+  return textSegmentSnapshots(
+    node.getStyledTextSegments([
+      "fills",
+      "fillStyleId",
+      "fontSize",
+      "fontWeight",
+    ]),
+  );
 }
 
 /**

--- a/src/plugins/qa/snapshot.ts
+++ b/src/plugins/qa/snapshot.ts
@@ -21,6 +21,40 @@ export interface PaintSnapshot {
 }
 
 /**
+ * One styled run inside a TEXT layer whose fills vary across character ranges
+ * (#16, issue #124) - a coloured link inside a paragraph, or one highlighted
+ * word.
+ *
+ * Collected **only** when the layer's fills are mixed, which is the one case a
+ * single layer-level answer cannot describe. A layer painted in one colour is
+ * already fully described by `fills` / `fillStyleId` / `fontSize` / `bold`, and
+ * splitting it into runs would add a second way to say the same thing.
+ *
+ * Each run carries its own size and weight rather than inheriting the layer's,
+ * so the AA threshold is the one that actually applies to those glyphs: the
+ * layer-level `fontSize` is the smallest size anywhere in the run, which is the
+ * right conservative answer for one verdict but the wrong one for a 24px word
+ * sitting beside a 12px one.
+ *
+ * The characters themselves are deliberately not carried. They would make each
+ * run's finding unique, and #118 dedupes findings by their message, so a defect
+ * shared by four variants would stop collapsing into one row.
+ */
+export interface TextSegmentSnapshot {
+  /**
+   * The run's own paints. Never mixed - a styled run is by definition the
+   * span over which they do not change. Absent means the run paints nothing.
+   */
+  fills?: PaintSnapshot[];
+  /** Paint style backing the run, "" when unstyled. Never "MIXED". */
+  fillStyleId?: string;
+  /** The run's own size in px, not the layer's smallest. */
+  fontSize?: number;
+  /** Whether this run is bold, i.e. font weight >= 700. */
+  bold?: boolean;
+}
+
+/**
  * One instance exposed anywhere beneath an INSTANCE node (#14 nesting depth).
  * `InstanceNode.exposedInstances` is already flattened by Figma — it lists
  * every exposed descendant at any depth, not just direct children — and
@@ -133,15 +167,26 @@ export interface NodeSnapshot {
   /**
    * TEXT nodes: the fills differ per character range (#16). `fills` is absent
    * in that case, and absent-because-mixed has to be told apart from
-   * absent-because-this-node-has-no-fills: picking "the first fill" of a
-   * mixed run would be a confidently wrong contrast answer, so #16 declines to
-   * evaluate the layer and counts it in the skipped tally instead.
+   * absent-because-this-node-has-no-fills: picking "the first fill" of a mixed
+   * run would be a confidently wrong contrast answer.
+   *
+   * `textSegments` carries the runs themselves, so #16 measures each one
+   * against its own background rather than declining to measure the layer.
+   * The flag stays because the two facts are not the same: a snapshot taken by
+   * an older plugin build has `fillsMixed` with no segments, and that layer is
+   * still honestly unevaluated rather than silently green.
    */
   fillsMixed?: boolean;
   /**
+   * TEXT nodes with mixed fills: the styled runs, in document order (#124).
+   * Absent on every other layer - see `TextSegmentSnapshot`.
+   */
+  textSegments?: TextSegmentSnapshot[];
+  /**
    * TEXT nodes: font size in px (#16 threshold). When ranges differ this is
    * the **smallest** size used - the strictest applicable threshold, so a
-   * mixed run is judged on its worst case rather than on its heading.
+   * mixed run is judged on its worst case rather than on its heading. Layers
+   * carrying `textSegments` are judged per run instead, and never through this.
    */
   fontSize?: number;
   /**

--- a/src/plugins/qa/snapshot.ts
+++ b/src/plugins/qa/snapshot.ts
@@ -42,11 +42,16 @@ export interface PaintSnapshot {
  */
 export interface TextSegmentSnapshot {
   /**
-   * The run's own paints. Never mixed - a styled run is by definition the
-   * span over which they do not change. Absent means the run paints nothing.
+   * The run's own paints. Never mixed - a styled run is by definition the span
+   * over which they do not change, which is why Figma types a run's `fills` as
+   * `Paint[]` while a layer's can be `figma.mixed`. Empty means the run paints
+   * nothing, and #16 reports it as unevaluated rather than assuming a colour.
    */
   fills?: PaintSnapshot[];
-  /** Paint style backing the run, "" when unstyled. Never "MIXED". */
+  /**
+   * Paint style backing the run, "" when unstyled. Never the "MIXED" sentinel
+   * a whole layer can carry: Figma types a run's `fillStyleId` as `string`.
+   */
   fillStyleId?: string;
   /** The run's own size in px, not the layer's smallest. */
   fontSize?: number;


### PR DESCRIPTION
Closes #124.

## The gap

`high-contrast` skipped any text layer whose fills change mid-sentence.
No single layer-level colour describes such a layer, and picking "the first fill" would be confidently wrong, so the layer went straight into the "not evaluated" tally.

That made the one shape of text which most often carries a low-contrast link - a coloured link inside a paragraph, a highlighted word - the one shape the check could not see.

## What changed

`collector.ts` records the styled runs of a mixed-fill text layer, each with its own fills, paint style, size and weight.
`high-contrast.ts` measures each run against the same background, through exactly the same rules a whole layer goes through: variables per mode, paint styles, a paint style whose paint is variable-bound, paint opacity, multi-paint compositing.
`resolveColor` was split so a run and a node cannot drift apart on any of that.

A run is judged at its **own** size, so a 24px word beside a 12px one is held to the threshold that applies to it rather than to the layer's smallest size.
The layer's node opacity still fades every run alike, since it is a group property.

## Aggregation - the design question the issue left open

**A run is not an occurrence.** Findings still count *layers*:

- A paragraph with four grey runs on white is **one** occurrence of that pair, not four. The defect is one token pair, and counting runs would report a mistake made once as four.
- Runs failing on genuinely different pairs report **separately** - those are different fixes, the same reason distinct pairs are never merged across layers.
- Runs sharing a pair at different sizes are described by the **stricter** threshold, the rule already used when two layers share a pair.

This keeps #118's dedupe-by-defect model intact: the run's characters are deliberately not carried into the snapshot, since they would make every finding unique and stop a defect shared across variants collapsing into one row.

## Unchanged on purpose

- A layer that declares mixed fills but carries no runs is still reported as unevaluated. Nothing about it is measurable.
- A mixed *font size* alone is still judged at its smallest. Size does not change what colour is on screen, so one verdict still describes the layer.
- Sibling-geometry backgrounds stay out of scope (#125).

## Verification

- `npm test` - 783 pass, 13 new cases covering per-run measurement, the counting rule, per-run thresholds, styles, variables per mode, a gradient run beside a solid one, and the no-runs fallback.
- `npm run typecheck`, `npm run lint` (no new warnings), `npm run format`, `npm run build`.

Not yet exercised end-to-end in Figma: the collector half needs the rebuilt plugin loaded in the desktop app, against a real component set containing a paragraph with a coloured link.