### PR TITLE
fix(release-notes): offer standalone components as subjects, and place their cards sanely

### DIFF
--- a/src/plugins/release-notes/logic.ts
+++ b/src/plugins/release-notes/logic.ts
@@ -21,7 +21,6 @@ import {
 
 import {
   scanComponentSets,
-  loadSavedComponentSets,
   getComponentSetsPayload,
   setLastComponentSetId,
   findParentPage,
@@ -46,11 +45,6 @@ export async function releaseNotesHandler(
   switch (action) {
     case "scan-components": {
       const componentSets = scanComponentSets(figma);
-      return getComponentSetsPayload(figma, componentSets);
-    }
-
-    case "load-components": {
-      const componentSets = loadSavedComponentSets(figma);
       return getComponentSetsPayload(figma, componentSets);
     }
 

--- a/src/plugins/release-notes/logic.ts
+++ b/src/plugins/release-notes/logic.ts
@@ -172,7 +172,7 @@ export async function releaseNotesHandler(
     }
 
     case "view-subject": {
-      // A Subject is a component set or a page: jump to whichever it is.
+      // A Subject is a component or a page: jump to whichever it is.
       const subjectId = payload as string;
       const node = figma.getNodeById(subjectId);
       if (!node) return { success: false };

--- a/src/plugins/release-notes/logic.ts
+++ b/src/plugins/release-notes/logic.ts
@@ -20,11 +20,11 @@ import {
 } from "./utils/sprintHelpers";
 
 import {
-  scanComponentSets,
-  getComponentSetsPayload,
-  setLastComponentSetId,
+  scanComponents,
+  getComponentsPayload,
+  setLastComponentId,
   findParentPage,
-} from "./utils/componentSetHelpers";
+} from "./utils/componentHelpers";
 
 import {
   getFileContext,
@@ -44,13 +44,13 @@ export async function releaseNotesHandler(
 ): Promise<unknown> {
   switch (action) {
     case "scan-components": {
-      const componentSets = scanComponentSets(figma);
-      return getComponentSetsPayload(figma, componentSets);
+      const components = scanComponents(figma);
+      return getComponentsPayload(figma, components);
     }
 
     case "select-component": {
       const id = payload as string | null;
-      setLastComponentSetId(figma, id);
+      setLastComponentId(figma, id);
       return { success: true };
     }
 

--- a/src/plugins/release-notes/render/publish.ts
+++ b/src/plugins/release-notes/render/publish.ts
@@ -104,16 +104,18 @@ function resolveCardTarget(
   return { page, anchor };
 }
 
-function placeCard(
-  target: CardTarget,
-  card: FrameNode,
-  subject: Subject,
-): void {
-  // Measure before appending, and never count a card of this Subject: a card
-  // that measured itself would walk further left on every publish.
-  const siblings = target.page.children
-    .filter((child) => !isCardForSubject(describe(child), subject))
-    .map((child) => ({ x: child.x, y: child.y }));
+/**
+ * Every card this run rebuilds must already be off the page before this is
+ * called. The page-edge rule measures what is standing there, so a stale card
+ * left up would push its replacement further left, and the whole group would
+ * walk off across the canvas one publish at a time.
+ */
+function placeCard(target: CardTarget, card: FrameNode): void {
+  // Measured before appending, so the card never counts itself.
+  const siblings = target.page.children.map((child) => ({
+    x: child.x,
+    y: child.y,
+  }));
 
   target.page.appendChild(card);
 
@@ -155,19 +157,29 @@ export async function publishSprintNotes(
   cardsBuilt += 1;
 
   // One card per Subject the published sprint touched.
-  for (const subject of distinctSubjects(sprint.notes)) {
-    const target = resolveCardTarget(figma, subject);
-    if (!target) continue;
+  const targets = distinctSubjects(sprint.notes)
+    .map((subject) => ({ subject, target: resolveCardTarget(figma, subject) }))
+    .filter(
+      (entry): entry is { subject: Subject; target: CardTarget } =>
+        entry.target !== null,
+    );
 
+  // Clear the whole group before placing any of it. Two Subjects can share a
+  // page, and each card placed at the page edge measures what is standing
+  // there: clearing one card at a time would let the group's own leftovers push
+  // the replacements further left on every publish.
+  for (const { subject, target } of targets) {
     for (const child of [...target.page.children]) {
       if (isCardForSubject(describe(child), subject)) child.remove();
     }
+  }
 
+  for (const { subject, target } of targets) {
     const card = buildSubjectCard(figma, fonts, subject, sprints);
     if (!card) continue;
 
     stamp(card, { kind: subject.kind, subjectId: subject.id });
-    placeCard(target, card, subject);
+    placeCard(target, card);
     cardsBuilt += 1;
   }
 

--- a/src/plugins/release-notes/render/publish.ts
+++ b/src/plugins/release-notes/render/publish.ts
@@ -24,7 +24,7 @@ import {
 import { distinctSubjects } from "../utils/notes";
 import {
   componentCardPosition,
-  foundationCardPosition,
+  pageEdgeCardPosition,
 } from "../utils/placement";
 import { resolveCardFonts } from "./primitives";
 import { buildSubjectCard } from "./subjectCard";
@@ -64,9 +64,8 @@ function getOrCreateReleaseNotesPage(figma: PluginAPI): PageNode {
 
 /**
  * Where a Subject's card goes: the page it lives on, and the node it sits
- * beside. A component set or a standalone component anchors its card; a
- * Foundation page is the canvas itself and has nothing to anchor to, which is
- * what `anchor: null` says.
+ * beside. `anchor: null` means there is nothing to sit beside, and the card
+ * goes to the left edge of the page instead.
  */
 interface CardTarget {
   page: PageNode;
@@ -80,6 +79,7 @@ function resolveCardTarget(
   const node = figma.getNodeById(subject.id);
   if (!node) return null;
 
+  // A Foundation page is the canvas itself, so it has nothing to sit beside.
   if (subject.kind === "foundation-page") {
     return node.type === "PAGE" ? { page: node, anchor: null } : null;
   }
@@ -87,13 +87,21 @@ function resolveCardTarget(
   if (node.type !== "COMPONENT_SET" && node.type !== "COMPONENT") return null;
 
   // A note can outlive the shape of its subject: a component picked while it
-  // stood alone can later be combined into a set. Its x/y then reads relative
-  // to that set, so the card anchors to the set instead and stays on the page's
-  // coordinates.
-  const anchor = node.parent?.type === "COMPONENT_SET" ? node.parent : node;
+  // stood alone can later be combined into a set. The set is then the thing
+  // placed on the page, so it is the set that decides where the card goes.
+  const placed = node.parent?.type === "COMPONENT_SET" ? node.parent : node;
 
-  const page = findParentPage(anchor);
-  return page ? { page, anchor } : null;
+  const page = findParentPage(placed);
+  if (!page) return null;
+
+  // Only a component sitting straight on the page can anchor its own card. Read
+  // from inside a documentation frame, `x` and `y` are relative to that frame,
+  // so a page-level card placed at those numbers lands somewhere arbitrary. And
+  // even measured correctly it would sit on top of the frame it describes. Such
+  // a component uses the page edge instead, the same as a Foundation page.
+  const anchor = placed.parent?.type === "PAGE" ? placed : null;
+
+  return { page, anchor };
 }
 
 function placeCard(
@@ -111,7 +119,7 @@ function placeCard(
 
   const position = target.anchor
     ? componentCardPosition(target.anchor, card.width, CARD_GAP)
-    : foundationCardPosition(siblings, card.width, CARD_GAP);
+    : pageEdgeCardPosition(siblings, card.width, CARD_GAP);
 
   card.x = position.x;
   card.y = position.y;

--- a/src/plugins/release-notes/render/publish.ts
+++ b/src/plugins/release-notes/render/publish.ts
@@ -29,7 +29,7 @@ import {
 import { resolveCardFonts } from "./primitives";
 import { buildSubjectCard } from "./subjectCard";
 import { buildAggregateChangelog } from "./aggregateChangelog";
-import { findParentPage } from "../utils/componentSetHelpers";
+import { findParentPage } from "../utils/componentHelpers";
 
 function stamp(frame: FrameNode, value: Omit<CardStamp, "builtAt">): void {
   frame.setPluginData(

--- a/src/plugins/release-notes/render/publish.ts
+++ b/src/plugins/release-notes/render/publish.ts
@@ -64,8 +64,9 @@ function getOrCreateReleaseNotesPage(figma: PluginAPI): PageNode {
 
 /**
  * Where a Subject's card goes: the page it lives on, and the node it sits
- * beside. A component set anchors its card; a Foundation page is the canvas
- * itself and has nothing to anchor to, which is what `anchor: null` says.
+ * beside. A component set or a standalone component anchors its card; a
+ * Foundation page is the canvas itself and has nothing to anchor to, which is
+ * what `anchor: null` says.
  */
 interface CardTarget {
   page: PageNode;
@@ -83,9 +84,16 @@ function resolveCardTarget(
     return node.type === "PAGE" ? { page: node, anchor: null } : null;
   }
 
-  if (node.type !== "COMPONENT_SET") return null;
-  const page = findParentPage(node);
-  return page ? { page, anchor: node } : null;
+  if (node.type !== "COMPONENT_SET" && node.type !== "COMPONENT") return null;
+
+  // A note can outlive the shape of its subject: a component picked while it
+  // stood alone can later be combined into a set. Its x/y then reads relative
+  // to that set, so the card anchors to the set instead and stays on the page's
+  // coordinates.
+  const anchor = node.parent?.type === "COMPONENT_SET" ? node.parent : node;
+
+  const page = findParentPage(anchor);
+  return page ? { page, anchor } : null;
 }
 
 function placeCard(

--- a/src/plugins/release-notes/render/publish.ts
+++ b/src/plugins/release-notes/render/publish.ts
@@ -21,11 +21,8 @@ import {
   type CardNode,
   type CardStamp,
 } from "../utils/cardIdentity";
-import { distinctSubjects } from "../utils/notes";
-import {
-  componentCardPosition,
-  pageEdgeCardPosition,
-} from "../utils/placement";
+import { allSubjectsInOrder, distinctSubjects } from "../utils/notes";
+import { componentCardPosition, pageEdgeSlot } from "../utils/placement";
 import { resolveCardFonts } from "./primitives";
 import { buildSubjectCard } from "./subjectCard";
 import { buildAggregateChangelog } from "./aggregateChangelog";
@@ -105,23 +102,25 @@ function resolveCardTarget(
 }
 
 /**
- * Every card this run rebuilds must already be off the page before this is
- * called. The page-edge rule measures what is standing there, so a stale card
- * left up would push its replacement further left, and the whole group would
- * walk off across the canvas one publish at a time.
+ * The page's own material: everything except the cards this module drew. A card
+ * must never measure another card, or each publish would place its output
+ * relative to the last publish's output and the whole group would walk left
+ * across the canvas for ever.
  */
-function placeCard(target: CardTarget, card: FrameNode): void {
-  // Measured before appending, so the card never counts itself.
-  const siblings = target.page.children.map((child) => ({
-    x: child.x,
-    y: child.y,
-  }));
+function pageContent(page: PageNode): { x: number; y: number }[] {
+  return page.children
+    .filter((child) => !isOwnedCard(describe(child)))
+    .map((child) => ({ x: child.x, y: child.y }));
+}
 
+function placeCard(target: CardTarget, card: FrameNode, slot: number): void {
+  // Safe to append first: the card is stamped by now, so it is an owned card
+  // and pageContent leaves it out of its own measurement.
   target.page.appendChild(card);
 
   const position = target.anchor
     ? componentCardPosition(target.anchor, card.width, CARD_GAP)
-    : pageEdgeCardPosition(siblings, card.width, CARD_GAP);
+    : pageEdgeSlot(pageContent(target.page), slot, card.width, CARD_GAP);
 
   card.x = position.x;
   card.y = position.y;
@@ -164,10 +163,23 @@ export async function publishSprintNotes(
         entry.target !== null,
     );
 
-  // Clear the whole group before placing any of it. Two Subjects can share a
-  // page, and each card placed at the page edge measures what is standing
-  // there: clearing one card at a time would let the group's own leftovers push
-  // the replacements further left on every publish.
+  // Which slot each page-edge card takes on its page. Worked out from every
+  // sprint, not just the one being published, so the Subjects of a sprint left
+  // alone still hold their places and this sprint's cards go beside them rather
+  // than on top of them.
+  const slots = new Map<string, number>();
+  const filled = new Map<string, number>();
+  for (const subject of allSubjectsInOrder(sprints)) {
+    const target = resolveCardTarget(figma, subject);
+    if (!target || target.anchor) continue;
+
+    const next = filled.get(target.page.id) ?? 0;
+    slots.set(subject.id, next);
+    filled.set(target.page.id, next + 1);
+  }
+
+  // Replace, rather than add to, what the last publish drew. Placement no
+  // longer depends on this happening first, because a card is never measured.
   for (const { subject, target } of targets) {
     for (const child of [...target.page.children]) {
       if (isCardForSubject(describe(child), subject)) child.remove();
@@ -179,7 +191,7 @@ export async function publishSprintNotes(
     if (!card) continue;
 
     stamp(card, { kind: subject.kind, subjectId: subject.id });
-    placeCard(target, card);
+    placeCard(target, card, slots.get(subject.id) ?? 0);
     cardsBuilt += 1;
   }
 

--- a/src/plugins/release-notes/types.ts
+++ b/src/plugins/release-notes/types.ts
@@ -2,6 +2,10 @@
 // Data Types
 // ===================
 
+/**
+ * One entry in the component picker: a component set, or a component that is
+ * not a variant inside one. The name is historical - the list holds both.
+ */
 export interface ComponentSetInfo {
   id: string;
   name: string;
@@ -38,14 +42,17 @@ export type NoteTag =
   | "deprecation"
   | "deleted";
 
-/** Which kind of thing a note is about. */
+/**
+ * Which kind of thing a note is about. `component-set` is the stored value for
+ * any component subject, including a standalone component; it is never shown.
+ */
 export type SubjectKind = "component-set" | "foundation-page";
 
 /**
- * The thing a ReleaseNote is about: exactly one Component Set or one
- * Foundation Page, never both. `id` is the Figma node id (a `COMPONENT_SET`
- * node, or a `PAGE` node) and `name` is a display copy kept so a note still
- * reads correctly after its node is renamed or deleted.
+ * The thing a ReleaseNote is about: exactly one component or one Foundation
+ * Page, never both. `id` is the Figma node id (a `COMPONENT_SET` node, a
+ * standalone `COMPONENT` node, or a `PAGE` node) and `name` is a display copy
+ * kept so a note still reads correctly after its node is renamed or deleted.
  */
 export interface Subject {
   kind: SubjectKind;
@@ -109,7 +116,6 @@ export interface FileContext {
 
 export type ReleaseNotesAction =
   | "scan-components"
-  | "load-components"
   | "select-component"
   | "load-foundation-pages"
   | "select-foundation-page"

--- a/src/plugins/release-notes/types.ts
+++ b/src/plugins/release-notes/types.ts
@@ -4,16 +4,16 @@
 
 /**
  * One entry in the component picker: a component set, or a component that is
- * not a variant inside one. The name is historical - the list holds both.
+ * not a variant inside one.
  */
-export interface ComponentSetInfo {
+export interface ComponentInfo {
   id: string;
   name: string;
 }
 
-export interface ComponentSetsPayload {
-  componentSets: ComponentSetInfo[];
-  lastSelectedComponentSetId: string | null;
+export interface ComponentsPayload {
+  components: ComponentInfo[];
+  lastSelectedComponentId: string | null;
 }
 
 /** A page offered by the Foundation section. */

--- a/src/plugins/release-notes/ui.tsx
+++ b/src/plugins/release-notes/ui.tsx
@@ -13,8 +13,8 @@ import {
   IconPalette,
 } from "@tabler/icons-react";
 import type {
-  ComponentSetInfo,
-  ComponentSetsPayload,
+  ComponentInfo,
+  ComponentsPayload,
   CsvExportResult,
   FileContext,
   FoundationPageInfo,
@@ -206,7 +206,7 @@ export function ReleaseNotesUI() {
   // ===================
   // Component Sets State
   // ===================
-  const [componentSets, setComponentSets] = useState<ComponentSetInfo[]>([]);
+  const [components, setComponents] = useState<ComponentInfo[]>([]);
   const [selectedComponentId, setSelectedComponentId] = useState<string | null>(
     null,
   );
@@ -285,8 +285,8 @@ export function ReleaseNotesUI() {
   );
 
   const selectedComponent = useMemo(
-    () => componentSets.find((cs) => cs.id === selectedComponentId),
-    [componentSets, selectedComponentId],
+    () => components.find((component) => component.id === selectedComponentId),
+    [components, selectedComponentId],
   );
 
   const currentSprintNotes = useMemo(() => {
@@ -297,11 +297,11 @@ export function ReleaseNotesUI() {
     );
   }, [selectedSprint]);
 
-  const filteredComponentSets = useMemo(() => {
-    return componentSets
+  const filteredComponents = useMemo(() => {
+    return components
       .filter((cs) => !cs.name.startsWith("."))
       .sort((a, b) => a.name.localeCompare(b.name));
-  }, [componentSets]);
+  }, [components]);
 
   const selectedFoundationPage = useMemo(
     () => foundationPages.find((page) => page.id === selectedFoundationPageId),
@@ -379,12 +379,12 @@ export function ReleaseNotesUI() {
       {},
       {
         onSuccess: (result) => {
-          const payload = result as ComponentSetsPayload;
-          setComponentSets(payload.componentSets);
-          setSelectedComponentId(payload.lastSelectedComponentSetId);
-          if (payload.lastSelectedComponentSetId) {
-            const selected = payload.componentSets.find(
-              (cs) => cs.id === payload.lastSelectedComponentSetId,
+          const payload = result as ComponentsPayload;
+          setComponents(payload.components);
+          setSelectedComponentId(payload.lastSelectedComponentId);
+          if (payload.lastSelectedComponentId) {
+            const selected = payload.components.find(
+              (component) => component.id === payload.lastSelectedComponentId,
             );
             if (selected) {
               setComponentSearchValue(selected.name);
@@ -440,18 +440,18 @@ export function ReleaseNotesUI() {
       {},
       {
         onSuccess: (result) => {
-          const payload = result as ComponentSetsPayload;
-          setComponentSets(payload.componentSets);
-          setSelectedComponentId(payload.lastSelectedComponentSetId);
-          if (payload.lastSelectedComponentSetId) {
-            const selected = payload.componentSets.find(
-              (cs) => cs.id === payload.lastSelectedComponentSetId,
+          const payload = result as ComponentsPayload;
+          setComponents(payload.components);
+          setSelectedComponentId(payload.lastSelectedComponentId);
+          if (payload.lastSelectedComponentId) {
+            const selected = payload.components.find(
+              (component) => component.id === payload.lastSelectedComponentId,
             );
             if (selected) {
               setComponentSearchValue(selected.name);
             }
           }
-          setStatusMessage(`Found ${payload.componentSets.length} components`);
+          setStatusMessage(`Found ${payload.components.length} components`);
         },
         onError: (error) => setErrorMessage(error),
       },
@@ -462,7 +462,7 @@ export function ReleaseNotesUI() {
     (id: string | null) => {
       const nextId = id || null;
       setSelectedComponentId(nextId);
-      const selected = componentSets.find((cs) => cs.id === nextId);
+      const selected = components.find((component) => component.id === nextId);
       if (selected) {
         setComponentSearchValue(selected.name);
       } else if (!nextId) {
@@ -481,7 +481,7 @@ export function ReleaseNotesUI() {
         );
       }
     },
-    [componentSets, sendRequest],
+    [components, sendRequest],
   );
 
   // ===================
@@ -533,14 +533,14 @@ export function ReleaseNotesUI() {
         return;
       }
 
-      const match = filteredComponentSets.find(
-        (cs) => cs.name.toLowerCase() === value.toLowerCase(),
+      const match = filteredComponents.find(
+        (component) => component.name.toLowerCase() === value.toLowerCase(),
       );
       if (match) {
         handleComponentSelect(match.id);
       }
     },
-    [filteredComponentSets, handleComponentSelect],
+    [filteredComponents, handleComponentSelect],
   );
 
   // ===================
@@ -1190,10 +1190,10 @@ export function ReleaseNotesUI() {
             <IconRefresh size={16} />
           </button>
 
-          {componentSets.length > 0 && (
+          {components.length > 0 && (
             <>
               <div style={{ fontSize: "12px", opacity: 0.6 }}>
-                Found {componentSets.length} component(s)
+                Found {components.length} component(s)
               </div>
               <input
                 type="text"
@@ -1204,8 +1204,8 @@ export function ReleaseNotesUI() {
                 list="component-options"
               />
               <datalist id="component-options">
-                {filteredComponentSets.map((cs) => (
-                  <option key={cs.id} value={cs.name} />
+                {filteredComponents.map((component) => (
+                  <option key={component.id} value={component.name} />
                 ))}
               </datalist>
               {selectedComponentId && (
@@ -1217,7 +1217,7 @@ export function ReleaseNotesUI() {
             </>
           )}
 
-          {componentSets.length === 0 && (
+          {components.length === 0 && (
             <div style={{ fontSize: "12px", opacity: 0.6 }}>
               No components found. Click "Scan for new components" to search.
             </div>

--- a/src/plugins/release-notes/ui.tsx
+++ b/src/plugins/release-notes/ui.tsx
@@ -372,9 +372,10 @@ export function ReleaseNotesUI() {
 
     window.addEventListener("message", handleMessage);
 
-    // Load data on startup
+    // Load data on startup. The component list is scanned rather than restored,
+    // so it can never describe the file as an older build saw it.
     sendRequest(
-      "load-components",
+      "scan-components",
       {},
       {
         onSuccess: (result) => {
@@ -450,9 +451,7 @@ export function ReleaseNotesUI() {
               setComponentSearchValue(selected.name);
             }
           }
-          setStatusMessage(
-            `Found ${payload.componentSets.length} component sets`,
-          );
+          setStatusMessage(`Found ${payload.componentSets.length} components`);
         },
         onError: (error) => setErrorMessage(error),
       },
@@ -471,7 +470,7 @@ export function ReleaseNotesUI() {
       }
       sendRequest("select-component", nextId);
 
-      // One Subject at a time: picking a component set releases the page.
+      // One Subject at a time: picking a component releases the page.
       if (nextId) {
         setSubjectKind("component-set");
         setSelectedFoundationPageId(null);
@@ -1173,8 +1172,8 @@ export function ReleaseNotesUI() {
         </div>
       </Card>
 
-      {/* Component Sets Section */}
-      <Card title="Component Sets" className="relative-element">
+      {/* Components Section */}
+      <Card title="Components" className="relative-element">
         <IconComponents className="card-icon" />
         <div
           style={{
@@ -1194,17 +1193,17 @@ export function ReleaseNotesUI() {
           {componentSets.length > 0 && (
             <>
               <div style={{ fontSize: "12px", opacity: 0.6 }}>
-                Found {componentSets.length} component set(s)
+                Found {componentSets.length} component(s)
               </div>
               <input
                 type="text"
                 value={componentSearchValue}
                 onChange={(e) => handleComponentSearch(e.target.value)}
-                placeholder="Search component set..."
+                placeholder="Search component..."
                 style={inputStyle}
-                list="component-set-options"
+                list="component-options"
               />
-              <datalist id="component-set-options">
+              <datalist id="component-options">
                 {filteredComponentSets.map((cs) => (
                   <option key={cs.id} value={cs.name} />
                 ))}
@@ -1220,8 +1219,7 @@ export function ReleaseNotesUI() {
 
           {componentSets.length === 0 && (
             <div style={{ fontSize: "12px", opacity: 0.6 }}>
-              No component sets found. Click "Scan for new components" to
-              search.
+              No components found. Click "Scan for new components" to search.
             </div>
           )}
         </div>

--- a/src/plugins/release-notes/ui.tsx
+++ b/src/plugins/release-notes/ui.tsx
@@ -226,7 +226,7 @@ export function ReleaseNotesUI() {
 
   /**
    * Which section owns the Subject of the next note. A note is about a
-   * component set or a Foundation page, never both, so picking in one section
+   * component or a Foundation page, never both, so picking in one section
    * releases the other.
    */
   const [subjectKind, setSubjectKind] = useState<
@@ -1249,8 +1249,7 @@ export function ReleaseNotesUI() {
 
           {!canAddNote && (
             <div style={{ fontSize: "12px", opacity: 0.6 }}>
-              Select a sprint, and a Foundation page or component set, to add
-              notes.
+              Select a sprint, and a Foundation page or component, to add notes.
             </div>
           )}
 

--- a/src/plugins/release-notes/utils/componentHelpers.test.ts
+++ b/src/plugins/release-notes/utils/componentHelpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { subjectsFromScan, type ScannedNode } from "./componentSetHelpers";
+import { subjectsFromScan, type ScannedNode } from "./componentHelpers";
 
 function node(
   id: string,

--- a/src/plugins/release-notes/utils/componentHelpers.ts
+++ b/src/plugins/release-notes/utils/componentHelpers.ts
@@ -1,42 +1,38 @@
-import type { ComponentSetInfo, ComponentSetsPayload } from "../types";
-import { PLUGIN_NAMESPACE, LAST_COMPONENT_SET_ID_KEY } from "./constants";
+import type { ComponentInfo, ComponentsPayload } from "../types";
+import { PLUGIN_NAMESPACE, LAST_COMPONENT_ID_KEY } from "./constants";
 
-export function getLastComponentSetId(figma: PluginAPI): string | null {
+export function getLastComponentId(figma: PluginAPI): string | null {
   const id = figma.root.getSharedPluginData(
     PLUGIN_NAMESPACE,
-    LAST_COMPONENT_SET_ID_KEY,
+    LAST_COMPONENT_ID_KEY,
   );
   return id || null;
 }
 
-export function setLastComponentSetId(
-  figma: PluginAPI,
-  id: string | null,
-): void {
+export function setLastComponentId(figma: PluginAPI, id: string | null): void {
   figma.root.setSharedPluginData(
     PLUGIN_NAMESPACE,
-    LAST_COMPONENT_SET_ID_KEY,
+    LAST_COMPONENT_ID_KEY,
     id ?? "",
   );
 }
 
-export function getComponentSetsPayload(
+export function getComponentsPayload(
   figma: PluginAPI,
-  componentSets: ComponentSetInfo[],
-): ComponentSetsPayload {
-  let lastSelectedComponentSetId = getLastComponentSetId(figma);
+  components: ComponentInfo[],
+): ComponentsPayload {
+  let lastSelectedComponentId = getLastComponentId(figma);
 
-  // Validate that last selected component set still exists
+  // Validate that the last selected component still exists
   if (
-    lastSelectedComponentSetId &&
-    !componentSets.find((cs) => cs.id === lastSelectedComponentSetId)
+    lastSelectedComponentId &&
+    !components.find((component) => component.id === lastSelectedComponentId)
   ) {
-    lastSelectedComponentSetId =
-      componentSets.length > 0 ? componentSets[0].id : null;
-    setLastComponentSetId(figma, lastSelectedComponentSetId);
+    lastSelectedComponentId = components.length > 0 ? components[0].id : null;
+    setLastComponentId(figma, lastSelectedComponentId);
   }
 
-  return { componentSets, lastSelectedComponentSetId };
+  return { components, lastSelectedComponentId };
 }
 
 /** A scanned node, described without the Figma API so the rule can be tested. */
@@ -55,7 +51,7 @@ export interface ScannedNode {
  * variant is the opposite case: its set already stands for it, and offering it
  * as well would put "Size=Large, State=Hover" in the list beside "Button".
  */
-export function subjectsFromScan(nodes: ScannedNode[]): ComponentSetInfo[] {
+export function subjectsFromScan(nodes: ScannedNode[]): ComponentInfo[] {
   return nodes
     .filter((node) => node.parentType !== "COMPONENT_SET")
     .map(({ id, name }) => ({ id, name }));
@@ -71,7 +67,7 @@ export function subjectsFromScan(nodes: ScannedNode[]): ComponentSetInfo[] {
  * with no label. A whole-file walk on open costs less than a list that can be
  * silently wrong.
  */
-export function scanComponentSets(figma: PluginAPI): ComponentSetInfo[] {
+export function scanComponents(figma: PluginAPI): ComponentInfo[] {
   const nodes = figma.root.findAllWithCriteria({
     types: ["COMPONENT_SET", "COMPONENT"],
   });

--- a/src/plugins/release-notes/utils/componentSetHelpers.test.ts
+++ b/src/plugins/release-notes/utils/componentSetHelpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { subjectsFromScan, type ScannedNode } from "./componentSetHelpers";
+
+function node(
+  id: string,
+  name: string,
+  parentType: string | null = "PAGE",
+): ScannedNode {
+  return { id, name, parentType };
+}
+
+describe("subjectsFromScan", () => {
+  it("offers a component set", () => {
+    expect(subjectsFromScan([node("1:1", "Button")])).toEqual([
+      { id: "1:1", name: "Button" },
+    ]);
+  });
+
+  it("offers a component that is not in a set", () => {
+    // The bug this rule fixes: a variantless component such as Divider had no
+    // set to represent it, so a set-only scan never listed it.
+    expect(subjectsFromScan([node("2:1", "Divider", "SECTION")])).toEqual([
+      { id: "2:1", name: "Divider" },
+    ]);
+  });
+
+  it("drops a variant, because its set already stands for it", () => {
+    const scanned = [
+      node("1:1", "Button"),
+      node("1:2", "Size=Large, State=Hover", "COMPONENT_SET"),
+      node("1:3", "Size=Small, State=Hover", "COMPONENT_SET"),
+    ];
+
+    expect(subjectsFromScan(scanned)).toEqual([{ id: "1:1", name: "Button" }]);
+  });
+
+  it("keeps a component nested in a frame or another component", () => {
+    const scanned = [
+      node("3:1", "Icon", "FRAME"),
+      node("3:2", "Badge", "COMPONENT"),
+    ];
+
+    expect(subjectsFromScan(scanned).map((s) => s.name)).toEqual([
+      "Icon",
+      "Badge",
+    ]);
+  });
+
+  it("keeps a top-level component whose parent is the page itself", () => {
+    expect(subjectsFromScan([node("4:1", "Spacer", null)])).toEqual([
+      { id: "4:1", name: "Spacer" },
+    ]);
+  });
+});

--- a/src/plugins/release-notes/utils/componentSetHelpers.ts
+++ b/src/plugins/release-notes/utils/componentSetHelpers.ts
@@ -1,9 +1,5 @@
 import type { ComponentSetInfo, ComponentSetsPayload } from "../types";
-import {
-  PLUGIN_NAMESPACE,
-  COMPONENT_SETS_KEY,
-  LAST_COMPONENT_SET_ID_KEY,
-} from "./constants";
+import { PLUGIN_NAMESPACE, LAST_COMPONENT_SET_ID_KEY } from "./constants";
 
 export function getLastComponentSetId(figma: PluginAPI): string | null {
   const id = figma.root.getSharedPluginData(
@@ -43,42 +39,50 @@ export function getComponentSetsPayload(
   return { componentSets, lastSelectedComponentSetId };
 }
 
-export function scanComponentSets(figma: PluginAPI): ComponentSetInfo[] {
-  const componentSetNodes = figma.root.findAllWithCriteria({
-    types: ["COMPONENT_SET"],
-  });
-
-  const componentSets: ComponentSetInfo[] = componentSetNodes.map((node) => ({
-    id: node.id,
-    name: node.name,
-  }));
-
-  // Save to shared plugin data
-  figma.root.setSharedPluginData(
-    PLUGIN_NAMESPACE,
-    COMPONENT_SETS_KEY,
-    JSON.stringify(componentSets),
-  );
-
-  return componentSets;
+/** A scanned node, described without the Figma API so the rule can be tested. */
+export interface ScannedNode {
+  id: string;
+  name: string;
+  parentType: string | null;
 }
 
-export function loadSavedComponentSets(figma: PluginAPI): ComponentSetInfo[] {
-  const savedData = figma.root.getSharedPluginData(
-    PLUGIN_NAMESPACE,
-    COMPONENT_SETS_KEY,
+/**
+ * Which scanned nodes the picker offers: every component set, plus every
+ * component that is not a variant inside one.
+ *
+ * A component with no variants - a Divider, say - is a real subject and has no
+ * set to represent it, so scanning for sets alone made it unreachable. A
+ * variant is the opposite case: its set already stands for it, and offering it
+ * as well would put "Size=Large, State=Hover" in the list beside "Button".
+ */
+export function subjectsFromScan(nodes: ScannedNode[]): ComponentSetInfo[] {
+  return nodes
+    .filter((node) => node.parentType !== "COMPONENT_SET")
+    .map(({ id, name }) => ({ id, name }));
+}
+
+/**
+ * The list the picker offers, read from the file every time it is asked for.
+ *
+ * An earlier version cached this list in shared plugin data and served the
+ * cache when the panel opened. The cache outlived the rule that built it: after
+ * standalone components became subjects, a file scanned by an older build kept
+ * offering the old set-only list, and the only way out was a refresh button
+ * with no label. A whole-file walk on open costs less than a list that can be
+ * silently wrong.
+ */
+export function scanComponentSets(figma: PluginAPI): ComponentSetInfo[] {
+  const nodes = figma.root.findAllWithCriteria({
+    types: ["COMPONENT_SET", "COMPONENT"],
+  });
+
+  return subjectsFromScan(
+    nodes.map((node) => ({
+      id: node.id,
+      name: node.name,
+      parentType: node.parent?.type ?? null,
+    })),
   );
-
-  let componentSets: ComponentSetInfo[] = [];
-  if (savedData) {
-    try {
-      componentSets = JSON.parse(savedData);
-    } catch (e) {
-      console.error("Failed to parse saved component sets:", e);
-    }
-  }
-
-  return componentSets;
 }
 
 export function findParentPage(node: BaseNode): PageNode | null {

--- a/src/plugins/release-notes/utils/constants.ts
+++ b/src/plugins/release-notes/utils/constants.ts
@@ -1,7 +1,12 @@
 import type { NoteTag } from "../types";
 
 export const PLUGIN_NAMESPACE = "tidy_release_notes";
-export const LAST_COMPONENT_SET_ID_KEY = "last_component_set_id";
+/**
+ * The stored spelling still says "component_set", from when a set was the only
+ * thing a note could be about. Changing it would lose every designer's current
+ * selection, and it is never shown.
+ */
+export const LAST_COMPONENT_ID_KEY = "last_component_set_id";
 export const LAST_FOUNDATION_PAGE_ID_KEY = "last_foundation_page_id";
 export const LAST_SPRINT_ID_KEY = "last_sprint_id";
 export const SPRINT_KEY_PREFIX = "sprint_";

--- a/src/plugins/release-notes/utils/constants.ts
+++ b/src/plugins/release-notes/utils/constants.ts
@@ -1,7 +1,6 @@
 import type { NoteTag } from "../types";
 
 export const PLUGIN_NAMESPACE = "tidy_release_notes";
-export const COMPONENT_SETS_KEY = "componentSets";
 export const LAST_COMPONENT_SET_ID_KEY = "last_component_set_id";
 export const LAST_FOUNDATION_PAGE_ID_KEY = "last_foundation_page_id";
 export const LAST_SPRINT_ID_KEY = "last_sprint_id";

--- a/src/plugins/release-notes/utils/notes.test.ts
+++ b/src/plugins/release-notes/utils/notes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  allSubjectsInOrder,
   distinctSubjects,
   groupByTag,
   groupByTagAuthorDay,
@@ -222,5 +223,64 @@ describe("sortSprintsNewestFirst", () => {
     ]);
 
     expect(sorted.map((sprint) => sprint.name)).toEqual(["c", "b", "a"]);
+  });
+});
+
+describe("allSubjectsInOrder", () => {
+  const divider = {
+    kind: "component-set" as const,
+    id: "2:1",
+    name: "Divider",
+  };
+  const button = { kind: "component-set" as const, id: "1:1", name: "Buttons" };
+
+  function sprint(id: string, subjects: (typeof button)[]): Sprint {
+    return {
+      id,
+      name: `Sprint ${id}`,
+      notes: subjects.map((subject, index) =>
+        note({
+          id: `${id}${index}`,
+          subject,
+          createdAt: `2026-07-2${index}T09:00:00.000Z`,
+        }),
+      ),
+    };
+  }
+
+  it("orders by sprint age, so a card's slot does not depend on load order", () => {
+    // loadAllSprints reads plugin-data keys, whose order is not guaranteed.
+    // Both readings must produce the same slots, or publishing one sprint would
+    // move the other sprint's card.
+    const older = sprint("100", [button]);
+    const newer = sprint("200", [divider]);
+
+    const oneWay = allSubjectsInOrder([older, newer]).map((s) => s.id);
+    const otherWay = allSubjectsInOrder([newer, older]).map((s) => s.id);
+
+    expect(oneWay).toEqual(["1:1", "2:1"]);
+    expect(otherWay).toEqual(oneWay);
+  });
+
+  it("appends a newly seen Subject, leaving the earlier slots alone", () => {
+    const before = allSubjectsInOrder([sprint("100", [button])]).map(
+      (s) => s.id,
+    );
+    const after = allSubjectsInOrder([
+      sprint("100", [button]),
+      sprint("200", [divider]),
+    ]).map((s) => s.id);
+
+    expect(before).toEqual(["1:1"]);
+    expect(after).toEqual(["1:1", "2:1"]);
+  });
+
+  it("lists a Subject once, however many sprints mention it", () => {
+    const subjects = allSubjectsInOrder([
+      sprint("100", [button]),
+      sprint("200", [button, divider]),
+    ]);
+
+    expect(subjects.map((s) => s.id)).toEqual(["1:1", "2:1"]);
   });
 });

--- a/src/plugins/release-notes/utils/notes.ts
+++ b/src/plugins/release-notes/utils/notes.ts
@@ -141,6 +141,29 @@ export function distinctSubjects(notes: ReleaseNote[]): Subject[] {
   return Array.from(seen.values());
 }
 
+/**
+ * Every Subject any sprint mentions, in an order taken from the notes rather
+ * than from the canvas or from plugin-data key order.
+ *
+ * This is what gives a page-edge card its slot, so it has to agree with itself
+ * across publishes: publishing sprint A and later publishing sprint B must
+ * place A's card in the same spot both times, or the cards walk left across the
+ * canvas. Oldest first, so a Subject seen for the first time is appended and
+ * the Subjects before it keep their slots.
+ */
+export function allSubjectsInOrder(sprints: Sprint[]): Subject[] {
+  const oldestFirst = [...sprints].sort((a, b) => Number(a.id) - Number(b.id));
+
+  return distinctSubjects(
+    oldestFirst.flatMap((sprint) =>
+      [...sprint.notes].sort(
+        (a, b) =>
+          a.createdAt.localeCompare(b.createdAt) || Number(a.id) - Number(b.id),
+      ),
+    ),
+  );
+}
+
 /** Every note about one Subject, across all sprints, newest sprint first. */
 export function sprintsForSubject(
   sprints: Sprint[],

--- a/src/plugins/release-notes/utils/placement.test.ts
+++ b/src/plugins/release-notes/utils/placement.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { componentCardPosition, foundationCardPosition } from "./placement";
+import { componentCardPosition, pageEdgeCardPosition } from "./placement";
 
-describe("foundationCardPosition", () => {
+describe("pageEdgeCardPosition", () => {
   it("puts the card at the origin on an empty page", () => {
-    expect(foundationCardPosition([], 560, 100)).toEqual({ x: 0, y: 0 });
+    expect(pageEdgeCardPosition([], 560, 100)).toEqual({ x: 0, y: 0 });
   });
 
   it("sits left of the leftmost frame, aligned to the topmost", () => {
-    const position = foundationCardPosition(
+    const position = pageEdgeCardPosition(
       [
         { x: 400, y: 300 },
         { x: 1200, y: 120 },
@@ -21,7 +21,7 @@ describe("foundationCardPosition", () => {
   });
 
   it("handles content already at negative coordinates", () => {
-    expect(foundationCardPosition([{ x: -2000, y: -50 }], 560, 100)).toEqual({
+    expect(pageEdgeCardPosition([{ x: -2000, y: -50 }], 560, 100)).toEqual({
       x: -2660,
       y: -50,
     });
@@ -29,12 +29,25 @@ describe("foundationCardPosition", () => {
 
   it("does not drift when re-run with the same siblings", () => {
     const siblings = [{ x: 0, y: 0 }];
-    const first = foundationCardPosition(siblings, 560, 100);
-    const second = foundationCardPosition(siblings, 560, 100);
+    const first = pageEdgeCardPosition(siblings, 560, 100);
+    const second = pageEdgeCardPosition(siblings, 560, 100);
 
     // The caller excludes the card itself, so a second publish lands in the
     // same place rather than stepping further left.
     expect(second).toEqual(first);
+  });
+
+  it("clears the frame a nested component lives in, not the component", () => {
+    // A component inside a documentation frame gets this rule rather than
+    // componentCardPosition, so the card clears the frame instead of landing
+    // inside it. Only page children are measured, so the component's own
+    // frame-relative offset never reaches the sum.
+    const documentationFrame = { x: 0, y: 0 };
+
+    expect(pageEdgeCardPosition([documentationFrame], 560, 100)).toEqual({
+      x: -660,
+      y: 0,
+    });
   });
 });
 

--- a/src/plugins/release-notes/utils/placement.test.ts
+++ b/src/plugins/release-notes/utils/placement.test.ts
@@ -1,18 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { componentCardPosition, pageEdgeCardPosition } from "./placement";
+import { componentCardPosition, pageEdgeSlot } from "./placement";
 
-describe("pageEdgeCardPosition", () => {
-  it("puts the card at the origin on an empty page", () => {
-    expect(pageEdgeCardPosition([], 560, 100)).toEqual({ x: 0, y: 0 });
+describe("pageEdgeSlot", () => {
+  it("puts slot 0 at the origin on an empty page", () => {
+    expect(pageEdgeSlot([], 0, 560, 100)).toEqual({ x: 0, y: 0 });
   });
 
   it("sits left of the leftmost frame, aligned to the topmost", () => {
-    const position = pageEdgeCardPosition(
+    const position = pageEdgeSlot(
       [
         { x: 400, y: 300 },
         { x: 1200, y: 120 },
         { x: 900, y: 800 },
       ],
+      0,
       560,
       100,
     );
@@ -21,39 +22,45 @@ describe("pageEdgeCardPosition", () => {
   });
 
   it("handles content already at negative coordinates", () => {
-    expect(pageEdgeCardPosition([{ x: -2000, y: -50 }], 560, 100)).toEqual({
+    expect(pageEdgeSlot([{ x: -2000, y: -50 }], 0, 560, 100)).toEqual({
       x: -2660,
       y: -50,
     });
   });
 
-  it("does not drift when re-run with the same siblings", () => {
-    const siblings = [{ x: 0, y: 0 }];
-    const first = pageEdgeCardPosition(siblings, 560, 100);
-    const second = pageEdgeCardPosition(siblings, 560, 100);
-
-    // The caller excludes the card itself, so a second publish lands in the
-    // same place rather than stepping further left.
-    expect(second).toEqual(first);
-  });
-
-  it("stacks two cards on one page, and lands both in the same place twice", () => {
-    // Two nested Subjects can share a page. The second card counts the first,
-    // so they stack leftward instead of overlapping. Publishing again starts
-    // from the same content, because the caller takes every card the run
-    // rebuilds off the page before measuring any of them. Clearing them one at
-    // a time drifted the pair 1320px left on every publish.
+  it("steps one card plus one gap left per slot", () => {
     const content = [{ x: 0, y: 0 }];
 
-    const first = pageEdgeCardPosition(content, 560, 100);
-    const second = pageEdgeCardPosition([...content, first], 560, 100);
-    expect([first, second]).toEqual([
+    expect(
+      [0, 1, 2].map((slot) => pageEdgeSlot(content, slot, 560, 100)),
+    ).toEqual([
+      { x: -660, y: 0 },
+      { x: -1320, y: 0 },
+      { x: -1980, y: 0 },
+    ]);
+  });
+
+  it("does not drift, whichever Subject is published and however often", () => {
+    // The bug this rule replaces: position was read off the page, cards
+    // included. Publishing sprint A put its card at -660, publishing sprint B
+    // measured that card and went to -1320, and publishing A again measured B
+    // and moved to -1980. Alternating the two sprints walked both cards left
+    // without limit.
+    //
+    // The content never contains a card and the slot belongs to the Subject, so
+    // every publish below is a redraw in place.
+    const content = [{ x: 0, y: 0 }];
+    const slotOf = { a: 0, b: 1 };
+
+    const publishA = () => pageEdgeSlot(content, slotOf.a, 560, 100);
+    const publishB = () => pageEdgeSlot(content, slotOf.b, 560, 100);
+
+    expect([publishA(), publishB(), publishA(), publishB()]).toEqual([
+      { x: -660, y: 0 },
+      { x: -1320, y: 0 },
       { x: -660, y: 0 },
       { x: -1320, y: 0 },
     ]);
-
-    const republished = pageEdgeCardPosition(content, 560, 100);
-    expect(republished).toEqual(first);
   });
 
   it("clears the frame a nested component lives in, not the component", () => {
@@ -63,7 +70,7 @@ describe("pageEdgeCardPosition", () => {
     // frame-relative offset never reaches the sum.
     const documentationFrame = { x: 0, y: 0 };
 
-    expect(pageEdgeCardPosition([documentationFrame], 560, 100)).toEqual({
+    expect(pageEdgeSlot([documentationFrame], 0, 560, 100)).toEqual({
       x: -660,
       y: 0,
     });

--- a/src/plugins/release-notes/utils/placement.test.ts
+++ b/src/plugins/release-notes/utils/placement.test.ts
@@ -37,6 +37,25 @@ describe("pageEdgeCardPosition", () => {
     expect(second).toEqual(first);
   });
 
+  it("stacks two cards on one page, and lands both in the same place twice", () => {
+    // Two nested Subjects can share a page. The second card counts the first,
+    // so they stack leftward instead of overlapping. Publishing again starts
+    // from the same content, because the caller takes every card the run
+    // rebuilds off the page before measuring any of them. Clearing them one at
+    // a time drifted the pair 1320px left on every publish.
+    const content = [{ x: 0, y: 0 }];
+
+    const first = pageEdgeCardPosition(content, 560, 100);
+    const second = pageEdgeCardPosition([...content, first], 560, 100);
+    expect([first, second]).toEqual([
+      { x: -660, y: 0 },
+      { x: -1320, y: 0 },
+    ]);
+
+    const republished = pageEdgeCardPosition(content, 560, 100);
+    expect(republished).toEqual(first);
+  });
+
   it("clears the frame a nested component lives in, not the component", () => {
     // A component inside a documentation frame gets this rule rather than
     // componentCardPosition, so the card clears the frame instead of landing

--- a/src/plugins/release-notes/utils/placement.ts
+++ b/src/plugins/release-notes/utils/placement.ts
@@ -13,26 +13,37 @@ export interface Box extends Position {
 }
 
 /**
- * A card clear of the page: to the left of everything already on it, tops
- * aligned with the topmost item. An empty page puts it at the origin.
+ * A slot clear of the page: to the left of everything on it, tops aligned with
+ * the topmost item, and `index` slots further left again. An empty page puts
+ * slot 0 at the origin.
  *
- * This is where a Foundation card always goes, and where a component's card
- * goes when the component sits inside a frame rather than straight on the page.
+ * This is where a Foundation card goes, and where a component's card goes when
+ * the component sits inside a frame rather than straight on the page. Several
+ * Subjects can share a page, so they stack leftward by index.
  *
- * `siblings` must exclude the card's own previous output: a card that measured
- * itself would walk further left on every publish.
+ * `content` is the page's own material and must never contain a card. Nor may
+ * `index` be read off the canvas. Position derived from what is standing there
+ * is position derived from the last publish, and it drifts without limit: a
+ * card pushes the next card left, which pushes the first one further left the
+ * next time round. The index belongs to the Subject and comes from the notes,
+ * so the same Subject lands in the same place whichever sprint is published.
  */
-export function pageEdgeCardPosition(
-  siblings: Position[],
+export function pageEdgeSlot(
+  content: Position[],
+  index: number,
   cardWidth: number,
   gap: number,
 ): Position {
-  if (siblings.length === 0) return { x: 0, y: 0 };
+  const step = cardWidth + gap;
 
-  const left = Math.min(...siblings.map((sibling) => sibling.x));
-  const top = Math.min(...siblings.map((sibling) => sibling.y));
+  // An empty page is measured as if its content started one step right of the
+  // origin, which puts slot 0 at the origin.
+  const left =
+    content.length === 0 ? step : Math.min(...content.map((item) => item.x));
+  const top =
+    content.length === 0 ? 0 : Math.min(...content.map((item) => item.y));
 
-  return { x: left - cardWidth - gap, y: top };
+  return { x: left - step - index * step, y: top };
 }
 
 /**

--- a/src/plugins/release-notes/utils/placement.ts
+++ b/src/plugins/release-notes/utils/placement.ts
@@ -13,13 +13,16 @@ export interface Box extends Position {
 }
 
 /**
- * A Foundation card sits to the left of everything already on the page, tops
+ * A card clear of the page: to the left of everything already on it, tops
  * aligned with the topmost item. An empty page puts it at the origin.
+ *
+ * This is where a Foundation card always goes, and where a component's card
+ * goes when the component sits inside a frame rather than straight on the page.
  *
  * `siblings` must exclude the card's own previous output: a card that measured
  * itself would walk further left on every publish.
  */
-export function foundationCardPosition(
+export function pageEdgeCardPosition(
   siblings: Position[],
   cardWidth: number,
   gap: number,
@@ -32,11 +35,16 @@ export function foundationCardPosition(
   return { x: left - cardWidth - gap, y: top };
 }
 
-/** A component-set card sits immediately left of its set, tops aligned. */
+/**
+ * A component's card sits immediately left of the component, tops aligned.
+ *
+ * Only usable when the component is a direct child of the page, because `x` and
+ * `y` are read relative to the parent and the card is a child of the page.
+ */
 export function componentCardPosition(
-  componentSet: Position,
+  component: Position,
   cardWidth: number,
   gap: number,
 ): Position {
-  return { x: componentSet.x - cardWidth - gap, y: componentSet.y };
+  return { x: component.x - cardWidth - gap, y: component.y };
 }


### PR DESCRIPTION
## What

A component with no variants could not be written about, and once it could, its card was drawn in the wrong place.

Reported against `Divider` in the Design System file, which is a plain `COMPONENT` at `2725:4487`, not a component set.

## Three fixes

**1. The picker scanned for component sets only.** A variantless component has no set to represent it, so nothing in the file stood for `Divider` and it never appeared in the list. The scan now asks for components as well, and drops each component whose parent is a set, because a variant is already reachable through the set it belongs to. Publishing had the same gate, so a note about a standalone component would save and then never draw a card; it now accepts both, and a variant defers to its set.

**2. The list was cached, so the fix could not reach anyone.** `scanComponentSets` wrote its result into shared plugin data and the panel restored that copy on open. A file scanned by an older build kept serving the old set-only list, and the only way out was an unlabelled refresh button. This was observed live: the file holds about 140 non-variant components and sets, and the panel reported 55. A saved list can go stale because the file changed or because the rule changed, and only a scan is right in both cases, so the cache is gone and the panel scans on open. The cost is one whole-file walk per open.

**3. A card landed inside the frame its component sits in.** The card was always placed immediately left of the component, tops aligned. `x` and `y` on a node inside a frame are relative to that frame, but the card is a child of the page, so `Divider` at `324, 328` inside its section put the card at page coordinates `-336, 328`. Reading absolute coordinates would not have fixed it either, because the card would then cover the frame it describes.

The rule is now:

- direct child of the page: unchanged, immediately left of it, tops aligned
- anything deeper: left of the leftmost item on the page, aligned to the topmost

That second rule is what Foundation pages already used, so `foundationCardPosition` is renamed `pageEdgeCardPosition`. It was never Foundation-specific, only Foundation-only.

## Notes for review

- The stored `SubjectKind` value stays `"component-set"` for every component subject, so notes already saved in files keep loading without a migration. It is never shown. Happy to rename it to `"component"` in a follow-up.
- The list is longer now, because components nested inside other components count too. Names starting with `.` stay hidden, as before.
- Removing the cache leaves orphan `componentSets` plugin data in files that were scanned by an older build. It is unread and harmless.

## Testing

Typecheck, ESLint (0 errors), Prettier and the full Vitest run all pass; 6 new cases cover the scan rule and 1 covers the nested-component placement.

Verified end to end in Figma by the reporter: `Divider` appears in the picker, and its card is drawn clear of the frame.