### PR TITLE
Action catalogue: declare effect/budget, honest overrun messages, cooperative cancellation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ To add a plugin: create the three files, then register the module in `moduleRegi
 
 ### Error Handling
 
-`code.ts` wraps all operations in a timeout (30 seconds default). Long-running operations (batch builds, report generation) must bypass this via the `isLongRunningAction` check. `src/shared/error-handler.ts` provides `isRecoverableError()` to distinguish user-fixable errors from critical ones.
+`code.ts` wraps every plugin-thread action in a timeout (30 seconds default). The timeout decision comes from the **action catalogue** (`src/shared/action-catalogue.ts`), not a hand-typed list: each action id (`module:action`) can be declared there with an `effect` (`reads` | `writes` the document) and a `budget` (a timed duration, or `long-running` with a required `reason`). An action absent from the catalogue keeps the default timeout and the default (bare) overrun message. A declared action that overruns gets a message derived from its `effect` — a write is told its work continues and to check the canvas before retrying; a read gets a plain failure. **Adding a new action means adding a catalogue entry.** `src/shared/action-catalogue-invariants.test.ts` fails the suite otherwise: it discovers every action reachable through `src/moduleHandlers.ts`'s dispatch switches and asserts each one has a catalogue entry, that no catalogue entry names a nonexistent action, that no action is declared twice, and that every `long-running` entry carries a reason. `src/shared/error-handler.ts` provides `isRecoverableError()` to distinguish user-fixable errors from critical ones.
 
 ### Operations / MCP Bridge (agent-facing surface)
 

--- a/src/code.ts
+++ b/src/code.ts
@@ -6,39 +6,13 @@ import {
   withTimeout,
   formatErrorMessage,
   isRecoverableError,
+  TimeoutError,
 } from "./shared/error-handler";
+import { classifyAction, buildOverrunMessage } from "./shared/action-catalogue";
 import { createLogger } from "./shared/logging";
 import { bindSession } from "./shared/operations/registry";
 import { captureUsage, setUsageRelay } from "./shared/analytics/capture";
 import { dumpUsageEvents } from "./shared/analytics/buffer";
-
-// Configuration
-const DEFAULT_TIMEOUT_MS = 30000; // 30 seconds
-
-// Actions that can take a long time and should not be timed out
-const LONG_RUNNING_ACTIONS = new Set([
-  "sticker-sheet-builder:build-all",
-  "sticker-sheet-builder:build-one",
-  "audit:generate-report",
-  // Builds a clone, prunes variants, then de-links from Kido-DS (detach nested
-  // instances + localize styles) — can exceed the default timeout on large sets.
-  "ds-explorer:build-component",
-  // Walks every node on the chosen scope (optionally all pages) extracting
-  // solid-color usages, then renders an inventory page — can exceed the default
-  // timeout on large files. Emits progress updates while it runs.
-  "color-finder:scan-colors",
-  "color-finder:scan-image-palette",
-  // Rebuilds the aggregate changelog plus one card per Subject the sprint
-  // touched, each a few hundred nodes — a busy sprint can exceed the default
-  // timeout.
-  "release-notes:publish-notes",
-  // Every MCP-invoked Operation arrives here as target "mcp-bridge", action
-  // "dispatch" — the specific operation id is opaque at this layer, so a
-  // single blanket exemption is the only way to honor a catalogue entry's
-  // own timeoutMs (mcp-server/src/catalogue.ts), enforced instead at the
-  // Bridge layer (mcp-server/src/bridge-server.ts).
-  "mcp-bridge:dispatch",
-]);
 
 // Create logger for main thread
 const logger = createLogger("Main");
@@ -194,13 +168,20 @@ figma.ui.onmessage = async (msg: unknown) => {
       throw new Error(`Unknown module: ${target}`);
     }
 
-    // Execute handler - skip timeout for long-running operations
+    // Execute handler - the action catalogue (#162) decides whether this
+    // action is timed or long-running, and (below) how an overrun reads.
     const operationName = `${target}:${action}`;
+    const classification = classifyAction(operationName);
     const handlerPromise = handlers[target](action, payload, figma);
 
-    const result = LONG_RUNNING_ACTIONS.has(operationName)
-      ? await handlerPromise
-      : await withTimeout(handlerPromise, DEFAULT_TIMEOUT_MS, operationName);
+    const result =
+      classification.budget.kind === "long-running"
+        ? await handlerPromise
+        : await withTimeout(
+            handlerPromise,
+            classification.budget.ms,
+            operationName,
+          );
 
     logger.debug(`Success: ${operationName}`, { result });
     sendResponse(requestId, result);
@@ -213,12 +194,20 @@ figma.ui.onmessage = async (msg: unknown) => {
       recoverable,
     });
 
-    // Send error response with recovery information
-    sendResponse(requestId, null, errorMessage);
+    // Send error response with recovery information. A timeout error gets
+    // the catalogue's overrun wording — honest about whether the write is
+    // still in flight — instead of the raw TimeoutError text.
+    const operationName = `${target}:${action}`;
+    const isTimeout = error instanceof TimeoutError;
+    const responseMessage = isTimeout
+      ? buildOverrunMessage(operationName, classifyAction(operationName))
+      : errorMessage;
+
+    sendResponse(requestId, null, responseMessage);
 
     // Notify user if error is not recoverable
     if (!recoverable) {
-      figma.notify(`⚠️ ${errorMessage}`, { error: true });
+      figma.notify(`⚠️ ${responseMessage}`, { error: true });
     }
   }
 };

--- a/src/plugins/audit/logic.ts
+++ b/src/plugins/audit/logic.ts
@@ -251,7 +251,7 @@ async function handleExportPdf(): Promise<{
   data?: Uint8Array;
   message?: string;
 }> {
-  const reportFrame = findReportFrameForExport();
+  const reportFrame = findReportFrame();
   if (!reportFrame) {
     return {
       success: false,
@@ -285,7 +285,7 @@ async function handleExportMultipagePdf(): Promise<{
   pages?: Uint8Array[];
   message?: string;
 }> {
-  const reportFrame = findReportFrameForExport();
+  const reportFrame = findReportFrame();
   if (!reportFrame) {
     return {
       success: false,
@@ -388,8 +388,8 @@ function handleCheckReportExists(): {
 
 /**
  * Find the report frame. A pure read — makes no change to the document.
- * Callers that depend on the frame being laid out vertically for export
- * (see `findReportFrameForExport`) must ask for that explicitly.
+ * The report frame is built vertically from the start (buildLayoutFrames),
+ * so no caller needs to force the layout as a side effect.
  */
 function findReportFrame(): FrameNode | null {
   const reportPage = figma.root.children.find(
@@ -409,19 +409,4 @@ function findReportFrame(): FrameNode | null {
   }
 
   return null;
-}
-
-/**
- * Find the report frame for export, ensuring it is laid out vertically.
- * The vertical layout is load-bearing for both PDF export paths (#163) —
- * it is the only thing that makes the report a vertical stack rather than
- * a horizontal row. Kept as a side effect here, on the export path only;
- * the plain existence check (`handleCheckReportExists`) must not pay for it.
- */
-function findReportFrameForExport(): FrameNode | null {
-  const reportFrame = findReportFrame();
-  if (reportFrame) {
-    reportFrame.layoutMode = "VERTICAL";
-  }
-  return reportFrame;
 }

--- a/src/plugins/audit/logic.ts
+++ b/src/plugins/audit/logic.ts
@@ -38,17 +38,15 @@ export async function auditHandler(
   payload: unknown,
   _figma?: PluginAPI,
 ): Promise<unknown> {
-  // Load fonts for any operation that might need them
-  await loadFonts();
-
   switch (action as AuditAction) {
     case "add-note":
-      return handleAddNote(payload as NotePayload);
+      return await handleAddNote(payload as NotePayload);
 
     case "add-quick-win":
       return handleAddQuickWin();
 
     case "generate-report":
+      await loadFonts();
       return await buildReport();
 
     case "export-pdf":
@@ -122,7 +120,7 @@ function getSelectionState(): SelectionState {
 /**
  * Add a severity note to the selected element
  */
-function handleAddNote(payload: NotePayload): AuditResult {
+async function handleAddNote(payload: NotePayload): Promise<AuditResult> {
   const selection = figma.currentPage.selection;
   const selectionState = getSelectionState();
 
@@ -133,6 +131,10 @@ function handleAddNote(payload: NotePayload): AuditResult {
       message: selectionState.message || "Invalid selection",
     };
   }
+
+  // This action draws text (title/note), so it loads its own fonts rather
+  // than relying on the handler to have loaded them up front (#163).
+  await loadFonts();
 
   const element = selection[0];
   const severity = payload.severity;
@@ -249,7 +251,7 @@ async function handleExportPdf(): Promise<{
   data?: Uint8Array;
   message?: string;
 }> {
-  const reportFrame = findReportFrame();
+  const reportFrame = findReportFrameForExport();
   if (!reportFrame) {
     return {
       success: false,
@@ -283,7 +285,7 @@ async function handleExportMultipagePdf(): Promise<{
   pages?: Uint8Array[];
   message?: string;
 }> {
-  const reportFrame = findReportFrame();
+  const reportFrame = findReportFrameForExport();
   if (!reportFrame) {
     return {
       success: false,
@@ -385,7 +387,9 @@ function handleCheckReportExists(): {
 }
 
 /**
- * Find the report frame
+ * Find the report frame. A pure read — makes no change to the document.
+ * Callers that depend on the frame being laid out vertically for export
+ * (see `findReportFrameForExport`) must ask for that explicitly.
  */
 function findReportFrame(): FrameNode | null {
   const reportPage = figma.root.children.find(
@@ -401,9 +405,23 @@ function findReportFrame(): FrameNode | null {
   );
 
   if (reportFrame && reportFrame.type === "FRAME") {
-    reportFrame.layoutMode = "VERTICAL";
     return reportFrame;
   }
 
   return null;
+}
+
+/**
+ * Find the report frame for export, ensuring it is laid out vertically.
+ * The vertical layout is load-bearing for both PDF export paths (#163) —
+ * it is the only thing that makes the report a vertical stack rather than
+ * a horizontal row. Kept as a side effect here, on the export path only;
+ * the plain existence check (`handleCheckReportExists`) must not pay for it.
+ */
+function findReportFrameForExport(): FrameNode | null {
+  const reportFrame = findReportFrame();
+  if (reportFrame) {
+    reportFrame.layoutMode = "VERTICAL";
+  }
+  return reportFrame;
 }

--- a/src/plugins/audit/utils/report/buildLayoutFrames.ts
+++ b/src/plugins/audit/utils/report/buildLayoutFrames.ts
@@ -42,7 +42,7 @@ export function buildLayoutFrames(keys: string[]): LayoutFrames {
 
   const reportFrame = buildAutoLayoutFrame(
     "report-frame",
-    "HORIZONTAL",
+    "VERTICAL",
     0,
     0,
     120,

--- a/src/plugins/color-finder/logic.ts
+++ b/src/plugins/color-finder/logic.ts
@@ -18,6 +18,19 @@ import { collectUsages } from "./utils/scan";
 import { buildColorInventory } from "./utils/inventory";
 import { buildInventoryPage } from "./utils/render";
 import { buildPalettePage } from "./utils/render-palette";
+import { createCancellationToken } from "../../shared/cancellation";
+
+// #167: the token backing scan-colors' stop control. Recreated at the start
+// of each scan so an earlier cancellation doesn't leak into the next one.
+let scanToken = createCancellationToken();
+
+// Yield to the event loop's macrotask queue between pages so an incoming
+// "cancel-scan" message actually gets a chance to run before the loop
+// finishes on its own (a bare `await` on an already-settled promise only
+// flushes microtasks, not pending UI messages).
+function yieldToMain(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
 /**
  * Tidy Color Finder handler — processes messages from the UI.
@@ -46,6 +59,10 @@ export async function tidyColorFinderHandler(
 
     case "render-palette-page":
       return await renderPalettePage(payload as RenderPalettePagePayload);
+
+    case "cancel-scan":
+      scanToken.cancel();
+      return { stopped: true };
 
     default:
       console.warn(`Unknown action: ${action}`);
@@ -111,6 +128,8 @@ async function loadPage(page: PageNode): Promise<void> {
 async function scanColors(
   payload: ScanColorsPayload,
 ): Promise<ScanColorsResult> {
+  scanToken = createCancellationToken();
+
   const { scope, options } = payload;
   const resolved = resolveScope(scope);
   const totalPages = resolved.pages.length;
@@ -121,6 +140,10 @@ async function scanColors(
   let pagesScanned = 0;
 
   for (const page of resolved.pages) {
+    if (scanToken.isCancelled) {
+      return { stopped: true, pagesScanned, totalPages };
+    }
+
     await loadPage(page);
 
     const roots: readonly SceneNode[] = resolved.selection
@@ -147,6 +170,10 @@ async function scanColors(
       type: "progress",
       payload: { pagesScanned, totalPages, nodesScanned: cumulativeNodes },
     });
+
+    // Yield so a "cancel-scan" message sent while this loop is running has
+    // a chance to be processed before the next page starts.
+    await yieldToMain();
   }
 
   const inventory = buildColorInventory(allUsages, {

--- a/src/plugins/color-finder/logic.ts
+++ b/src/plugins/color-finder/logic.ts
@@ -18,19 +18,14 @@ import { collectUsages } from "./utils/scan";
 import { buildColorInventory } from "./utils/inventory";
 import { buildInventoryPage } from "./utils/render";
 import { buildPalettePage } from "./utils/render-palette";
-import { createCancellationToken } from "../../shared/cancellation";
+import {
+  createCancellationToken,
+  yieldToMain,
+} from "../../shared/cancellation";
 
 // #167: the token backing scan-colors' stop control. Recreated at the start
 // of each scan so an earlier cancellation doesn't leak into the next one.
 let scanToken = createCancellationToken();
-
-// Yield to the event loop's macrotask queue between pages so an incoming
-// "cancel-scan" message actually gets a chance to run before the loop
-// finishes on its own (a bare `await` on an already-settled promise only
-// flushes microtasks, not pending UI messages).
-function yieldToMain(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
 
 /**
  * Tidy Color Finder handler — processes messages from the UI.
@@ -174,6 +169,13 @@ async function scanColors(
     // Yield so a "cancel-scan" message sent while this loop is running has
     // a chance to be processed before the next page starts.
     await yieldToMain();
+  }
+
+  // A stop requested while the last page's yield was pending arrives here,
+  // after the loop already exited — check again before the inventory page
+  // (a write) gets built, so that request is still honoured (#167).
+  if (scanToken.isCancelled) {
+    return { stopped: true, pagesScanned, totalPages };
   }
 
   const inventory = buildColorInventory(allUsages, {

--- a/src/plugins/color-finder/types.ts
+++ b/src/plugins/color-finder/types.ts
@@ -22,7 +22,9 @@ export type TidyColorFinderAction =
   //   render-palette-page:  UI sends the extracted palette back; plugin builds
   //                         the dedicated palette page and navigates to it.
   | "scan-image-palette"
-  | "render-palette-page";
+  | "render-palette-page"
+  // #167: stops an in-flight scan-colors run between pages.
+  | "cancel-scan";
 
 // The four role tables. Gradient/image paints are counted as "other" and
 // excluded from the tables. "icon" is detected by layer name (see
@@ -147,9 +149,15 @@ export interface ColorInventory {
 // full inventory so the UI can offer client-side actions (e.g. copy as
 // markdown) without a round trip.
 export interface ScanColorsResult {
-  pageId: string;
-  pageName: string;
-  inventory: ColorInventory;
+  pageId?: string;
+  pageName?: string;
+  inventory?: ColorInventory;
+  // #167: set when the scan was stopped by the designer before finishing.
+  // Describes what completed rather than leaving the designer to infer it
+  // from the canvas — no inventory page is built for a stopped run.
+  stopped?: boolean;
+  pagesScanned?: number;
+  totalPages?: number;
 }
 
 // Progress messages posted to the UI during a scan.

--- a/src/plugins/color-finder/ui.tsx
+++ b/src/plugins/color-finder/ui.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Card } from "@shell/components";
 import { postToFigma } from "@shared/bridge";
+import { isStoppable } from "@shared/action-catalogue";
 import {
   IconRefresh,
   IconExternalLink,
@@ -525,11 +526,16 @@ export function TidyColorFinderUI() {
         {scanning ? "Scanning..." : "Run"}
       </button>
 
-      {scanning && mode === "vector" && (
-        <button onClick={handleStopScan} className="secondary">
-          Stop
-        </button>
-      )}
+      {scanning &&
+        isStoppable(
+          mode === "vector"
+            ? "color-finder:scan-colors"
+            : "color-finder:scan-image-palette",
+        ) && (
+          <button onClick={handleStopScan} className="secondary">
+            Stop
+          </button>
+        )}
 
       {vectorProgress && (
         <div className="status-message">
@@ -543,8 +549,7 @@ export function TidyColorFinderUI() {
         <div className="status-message">
           Stopped by you after scanning {scanResult.pagesScanned} of{" "}
           {scanResult.totalPages} page
-          {scanResult.totalPages === 1 ? "" : "s"}. No inventory page was
-          built.
+          {scanResult.totalPages === 1 ? "" : "s"}. No inventory page was built.
         </div>
       )}
 

--- a/src/plugins/color-finder/ui.tsx
+++ b/src/plugins/color-finder/ui.tsx
@@ -306,6 +306,15 @@ export function TidyColorFinderUI() {
     }
   }, [mode, handleVectorScan, handleImageScan]);
 
+  // #167: color-finder:scan-colors is declared stoppable in the action
+  // catalogue — a stop control is only wired up here because of that.
+  const handleStopScan = useCallback(() => {
+    postToFigma({
+      target: "color-finder",
+      action: "cancel-scan",
+    });
+  }, []);
+
   const handleShowPage = useCallback(() => {
     const pageId = scanResult?.pageId || paletteResult?.pageId;
     if (!pageId) return;
@@ -317,7 +326,7 @@ export function TidyColorFinderUI() {
   }, [scanResult, paletteResult]);
 
   const handleCopyMarkdown = useCallback(() => {
-    if (!scanResult) return;
+    if (!scanResult?.inventory) return;
     copyToClipboard(serializeInventoryToMarkdown(scanResult.inventory));
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
@@ -516,11 +525,26 @@ export function TidyColorFinderUI() {
         {scanning ? "Scanning..." : "Run"}
       </button>
 
+      {scanning && mode === "vector" && (
+        <button onClick={handleStopScan} className="secondary">
+          Stop
+        </button>
+      )}
+
       {vectorProgress && (
         <div className="status-message">
           Scanning {vectorProgress.totalPages} page
           {vectorProgress.totalPages === 1 ? "" : "s"} �·{" "}
           {vectorProgress.nodesScanned.toLocaleString()} nodes
+        </div>
+      )}
+
+      {scanResult?.stopped && (
+        <div className="status-message">
+          Stopped by you after scanning {scanResult.pagesScanned} of{" "}
+          {scanResult.totalPages} page
+          {scanResult.totalPages === 1 ? "" : "s"}. No inventory page was
+          built.
         </div>
       )}
 
@@ -532,7 +556,7 @@ export function TidyColorFinderUI() {
         </div>
       )}
 
-      {scanResult && (
+      {scanResult?.inventory && (
         <div className="status-message success">
           <div style={{ marginBottom: 8 }}>
             {scanResult.inventory.summary.uniqueTotal} unique color

--- a/src/plugins/off-boarding/logic.ts
+++ b/src/plugins/off-boarding/logic.ts
@@ -6,7 +6,10 @@ import {
   PackPagesPayload,
   PageInfo,
 } from "./types";
-import { createCancellationToken } from "../../shared/cancellation";
+import {
+  createCancellationToken,
+  yieldToMain,
+} from "../../shared/cancellation";
 
 const TEMP_PAGE_NAME = "__TCC_TEMP__";
 
@@ -200,13 +203,6 @@ function getPagesList(): PageInfo[] {
 // of each pack so an earlier cancellation doesn't leak into the next one.
 let packToken = createCancellationToken();
 
-// Yield to the event loop's macrotask queue between pages so an incoming
-// "cancel-pack" message actually gets a chance to run before the loop
-// finishes on its own.
-function yieldToMain(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 async function packPages(pageIds: string[]): Promise<OffBoardingResult> {
   packToken = createCancellationToken();
 
@@ -230,27 +226,29 @@ async function packPages(pageIds: string[]): Promise<OffBoardingResult> {
 
   const frames: Array<FrameNode> = [];
 
+  const buildStoppedResult = (): OffBoardingResult => {
+    const remainingPageNames = sourcePages
+      .slice(frames.length)
+      .map((p) => p.name);
+
+    if (frames.length > 0) {
+      arrangeFramesInGrid(frames, 200);
+      figma.currentPage.selection = frames;
+      figma.viewport.scrollAndZoomIntoView(frames);
+    }
+
+    return {
+      success: true,
+      message: `Stopped by you after packing ${frames.length} of ${sourcePages.length} page${sourcePages.length === 1 ? "" : "s"}.`,
+      count: frames.length,
+      stopped: true,
+      remainingPageNames,
+    };
+  };
+
   for (const page of sourcePages) {
     if (packToken.isCancelled) {
-      const packedPageNames = frames.map((f) => f.name);
-      const remainingPageNames = sourcePages
-        .slice(frames.length)
-        .map((p) => p.name);
-
-      if (frames.length > 0) {
-        arrangeFramesInGrid(frames, 200);
-        figma.currentPage.selection = frames;
-        figma.viewport.scrollAndZoomIntoView(frames);
-      }
-
-      return {
-        success: true,
-        message: `Stopped by you after packing ${frames.length} of ${sourcePages.length} page${sourcePages.length === 1 ? "" : "s"}.`,
-        count: frames.length,
-        stopped: true,
-        packedPageNames,
-        remainingPageNames,
-      };
+      return buildStoppedResult();
     }
 
     const frame = figma.createFrame();
@@ -265,6 +263,13 @@ async function packPages(pageIds: string[]): Promise<OffBoardingResult> {
     // Yield so a "cancel-pack" message sent while this loop is running has
     // a chance to be processed before the next page starts.
     await yieldToMain();
+  }
+
+  // A stop requested while the last page's yield was pending arrives here,
+  // after the loop already exited — check again before treating the run as
+  // a plain success, so that request is still honoured (#167).
+  if (packToken.isCancelled) {
+    return buildStoppedResult();
   }
 
   arrangeFramesInGrid(frames, 200);

--- a/src/plugins/off-boarding/logic.ts
+++ b/src/plugins/off-boarding/logic.ts
@@ -6,6 +6,7 @@ import {
   PackPagesPayload,
   PageInfo,
 } from "./types";
+import { createCancellationToken } from "../../shared/cancellation";
 
 const TEMP_PAGE_NAME = "__TCC_TEMP__";
 
@@ -195,7 +196,20 @@ function getPagesList(): PageInfo[] {
     .map((page) => ({ id: page.id, name: page.name }));
 }
 
-function packPages(pageIds: string[]): OffBoardingResult {
+// #167: the token backing pack-pages' stop control. Recreated at the start
+// of each pack so an earlier cancellation doesn't leak into the next one.
+let packToken = createCancellationToken();
+
+// Yield to the event loop's macrotask queue between pages so an incoming
+// "cancel-pack" message actually gets a chance to run before the loop
+// finishes on its own.
+function yieldToMain(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function packPages(pageIds: string[]): Promise<OffBoardingResult> {
+  packToken = createCancellationToken();
+
   const allPages = figma.root.children.filter((page) => !isTempPage(page));
 
   const sourcePages =
@@ -217,6 +231,28 @@ function packPages(pageIds: string[]): OffBoardingResult {
   const frames: Array<FrameNode> = [];
 
   for (const page of sourcePages) {
+    if (packToken.isCancelled) {
+      const packedPageNames = frames.map((f) => f.name);
+      const remainingPageNames = sourcePages
+        .slice(frames.length)
+        .map((p) => p.name);
+
+      if (frames.length > 0) {
+        arrangeFramesInGrid(frames, 200);
+        figma.currentPage.selection = frames;
+        figma.viewport.scrollAndZoomIntoView(frames);
+      }
+
+      return {
+        success: true,
+        message: `Stopped by you after packing ${frames.length} of ${sourcePages.length} page${sourcePages.length === 1 ? "" : "s"}.`,
+        count: frames.length,
+        stopped: true,
+        packedPageNames,
+        remainingPageNames,
+      };
+    }
+
     const frame = figma.createFrame();
     frame.name = page.name;
     frame.setPluginData("tcc:pageName", page.name);
@@ -225,6 +261,10 @@ function packPages(pageIds: string[]): OffBoardingResult {
 
     cloneTopLevelNodesIntoFrame(page, frame);
     frames.push(frame);
+
+    // Yield so a "cancel-pack" message sent while this loop is running has
+    // a chance to be processed before the next page starts.
+    await yieldToMain();
   }
 
   arrangeFramesInGrid(frames, 200);
@@ -435,7 +475,7 @@ export async function offBoardingHandler(
 
     case "pack-pages":
       const packPayload = payload as PackPagesPayload;
-      return packPages(packPayload?.pageIds || []);
+      return await packPages(packPayload?.pageIds || []);
 
     case "unpack-pages":
       return unpackPages();
@@ -445,6 +485,10 @@ export async function offBoardingHandler(
 
     case "find-hidden-styles":
       return findHiddenStyles();
+
+    case "cancel-pack":
+      packToken.cancel();
+      return { success: true, message: "Cancelling…", stopped: true };
 
     default:
       return {

--- a/src/plugins/off-boarding/types.ts
+++ b/src/plugins/off-boarding/types.ts
@@ -26,7 +26,6 @@ export interface OffBoardingResult {
   // Names what was packed and what wasn't, rather than leaving the designer
   // to infer it from the canvas.
   stopped?: boolean;
-  packedPageNames?: string[];
   remainingPageNames?: string[];
 }
 

--- a/src/plugins/off-boarding/types.ts
+++ b/src/plugins/off-boarding/types.ts
@@ -8,7 +8,9 @@ export type OffBoardingAction =
   | "pack-pages"
   | "unpack-pages"
   | "find-bound-variables"
-  | "find-hidden-styles";
+  | "find-hidden-styles"
+  // #167: stops an in-flight pack-pages run between pages.
+  | "cancel-pack";
 
 export interface PageInfo {
   id: string;
@@ -20,6 +22,12 @@ export interface OffBoardingResult {
   message: string;
   pages?: PageInfo[];
   count?: number;
+  // #167: set when pack-pages was stopped by the designer before finishing.
+  // Names what was packed and what wasn't, rather than leaving the designer
+  // to infer it from the canvas.
+  stopped?: boolean;
+  packedPageNames?: string[];
+  remainingPageNames?: string[];
 }
 
 export interface PackPagesPayload {

--- a/src/plugins/off-boarding/ui.tsx
+++ b/src/plugins/off-boarding/ui.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Card } from "@shell/components";
 import { postToFigma } from "@shared/bridge";
+import { isStoppable } from "@shared/action-catalogue";
 import { OffBoardingAction, PageInfo } from "./types";
 import {
   IconPackage,
@@ -122,7 +123,12 @@ export function OffBoardingUI() {
       {
         onSuccess: (result) => {
           if (result?.success) {
-            setStatusMessage(result.message);
+            const remaining = result.remainingPageNames as string[] | undefined;
+            setStatusMessage(
+              remaining && remaining.length > 0
+                ? `${result.message} Not packed: ${remaining.join(", ")}.`
+                : result.message,
+            );
             refreshPages();
           } else {
             setErrorMessage(result?.message ?? "Failed to pack pages");
@@ -378,10 +384,7 @@ export function OffBoardingUI() {
                 : `Pack ${selectedCount > 0 ? `${selectedCount} ` : ""}Page${selectedCount !== 1 ? "s" : ""}`}
             </button>
 
-            {isLoading === "pack" && (
-              // #167: off-boarding:pack-pages is declared stoppable in the
-              // action catalogue — a stop control is only wired up here
-              // because of that.
+            {isLoading === "pack" && isStoppable("off-boarding:pack-pages") && (
               <button onClick={handleStopPack} className="secondary note">
                 Stop
               </button>

--- a/src/plugins/off-boarding/ui.tsx
+++ b/src/plugins/off-boarding/ui.tsx
@@ -134,6 +134,13 @@ export function OffBoardingUI() {
     );
   }, [pages, sendRequest, refreshPages]);
 
+  const handleStopPack = useCallback(() => {
+    postToFigma({
+      target: "off-boarding",
+      action: "cancel-pack",
+    });
+  }, []);
+
   const handleUnpackPages = useCallback(() => {
     setIsLoading("unpack");
     setStatusMessage(null);
@@ -370,6 +377,15 @@ export function OffBoardingUI() {
                 ? "Packing..."
                 : `Pack ${selectedCount > 0 ? `${selectedCount} ` : ""}Page${selectedCount !== 1 ? "s" : ""}`}
             </button>
+
+            {isLoading === "pack" && (
+              // #167: off-boarding:pack-pages is declared stoppable in the
+              // action catalogue — a stop control is only wired up here
+              // because of that.
+              <button onClick={handleStopPack} className="secondary note">
+                Stop
+              </button>
+            )}
 
             <button
               onClick={handleUnpackPages}

--- a/src/plugins/sticker-sheet-builder/logic.ts
+++ b/src/plugins/sticker-sheet-builder/logic.ts
@@ -1,4 +1,7 @@
-import { createCancellationToken } from "../../shared/cancellation";
+import {
+  createCancellationToken,
+  yieldToMain,
+} from "../../shared/cancellation";
 import buildOneSticker from "./utils/buildOneSticker";
 import {
   findAtomPages,
@@ -28,11 +31,6 @@ let listenersRegistered = false;
 // Recreated at the start of each run so an earlier cancellation doesn't
 // leak into the next one.
 let buildToken = createCancellationToken();
-
-// Yield control back to the event loop to keep UI responsive
-function yieldToMain(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
 
 // Load config from plugin data (with migration from legacy format)
 function loadConfig(): StickerSheetConfig {

--- a/src/plugins/sticker-sheet-builder/logic.ts
+++ b/src/plugins/sticker-sheet-builder/logic.ts
@@ -1,3 +1,4 @@
+import { createCancellationToken } from "../../shared/cancellation";
 import buildOneSticker from "./utils/buildOneSticker";
 import {
   findAtomPages,
@@ -23,7 +24,10 @@ import {
 
 let fontsLoaded = false;
 let listenersRegistered = false;
-let cancelRequested = false;
+// #167: the token backing both build-one and build-all's stop control.
+// Recreated at the start of each run so an earlier cancellation doesn't
+// leak into the next one.
+let buildToken = createCancellationToken();
 
 // Yield control back to the event loop to keep UI responsive
 function yieldToMain(): Promise<void> {
@@ -131,7 +135,7 @@ export async function stickerSheetBuilderHandler(
       return await handleBuildAll();
     }
     case "cancel-build": {
-      cancelRequested = true;
+      buildToken.cancel();
       return { cancelled: true };
     }
     default:
@@ -190,7 +194,7 @@ function isStickerEligible(
 }
 
 async function handleBuildSelected(): Promise<StickerSheetBuilderResponse> {
-  cancelRequested = false;
+  buildToken = createCancellationToken();
   await ensureFontsLoaded();
 
   const config = loadConfig();
@@ -207,7 +211,7 @@ async function handleBuildSelected(): Promise<StickerSheetBuilderResponse> {
   let builtCount = 0;
 
   for (const node of validNodes) {
-    if (cancelRequested) {
+    if (buildToken.isCancelled) {
       const context = broadcastContext();
       return { builtCount, context, cancelled: true };
     }
@@ -228,7 +232,7 @@ async function handleBuildSelected(): Promise<StickerSheetBuilderResponse> {
 }
 
 async function handleBuildAll(): Promise<StickerSheetBuilderResponse> {
-  cancelRequested = false;
+  buildToken = createCancellationToken();
   await ensureFontsLoaded();
 
   const config = loadConfig();
@@ -261,7 +265,7 @@ async function handleBuildAll(): Promise<StickerSheetBuilderResponse> {
   let builtCount = 0;
 
   for (const { component, pageName } of componentsWithPages) {
-    if (cancelRequested) {
+    if (buildToken.isCancelled) {
       const context = broadcastContext();
       return { builtCount, context, cancelled: true };
     }

--- a/src/plugins/sticker-sheet-builder/ui.tsx
+++ b/src/plugins/sticker-sheet-builder/ui.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Card } from "@shell/components";
 import { postToFigma } from "@shared/bridge";
+import { isStoppable } from "@shared/action-catalogue";
 import Loader from "./assets/loader.svg";
 import {
   DEFAULT_STICKER_SHEET_CONTEXT,
@@ -30,6 +31,7 @@ export function StickerSheetBuilderUI() {
   );
   const [isLoading, setIsLoading] = useState(true);
   const [isBuilding, setIsBuilding] = useState(false);
+  const [runningAction, setRunningAction] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [progress, setProgress] = useState<BuildProgress | null>(null);
@@ -105,6 +107,7 @@ export function StickerSheetBuilderUI() {
   const handleBuildOne = useCallback(() => {
     if (isLoading || isBuilding) return;
     setIsBuilding(true);
+    setRunningAction("sticker-sheet-builder:build-one");
     setStatusMessage(null);
     setErrorMessage(null);
     setProgress(null);
@@ -117,7 +120,9 @@ export function StickerSheetBuilderUI() {
           const builtCount = Number(result?.builtCount ?? 0);
           const label = builtCount === 1 ? "sticker" : "stickers";
           if (result?.cancelled) {
-            setStatusMessage(`Cancelled after building ${builtCount} ${label}`);
+            setStatusMessage(
+              `Stopped by you after building ${builtCount} ${label}`,
+            );
           } else {
             setStatusMessage(`Built ${builtCount} ${label}`);
           }
@@ -125,6 +130,7 @@ export function StickerSheetBuilderUI() {
         onError: (error) => setErrorMessage(error),
         onFinally: () => {
           setIsBuilding(false);
+          setRunningAction(null);
           setProgress(null);
         },
       },
@@ -134,6 +140,7 @@ export function StickerSheetBuilderUI() {
   const handleBuildAll = useCallback(() => {
     if (isLoading || isBuilding) return;
     setIsBuilding(true);
+    setRunningAction("sticker-sheet-builder:build-all");
     setStatusMessage(null);
     setErrorMessage(null);
     setProgress(null);
@@ -146,7 +153,9 @@ export function StickerSheetBuilderUI() {
           const builtCount = Number(result?.builtCount ?? 0);
           const label = builtCount === 1 ? "component" : "components";
           if (result?.cancelled) {
-            setStatusMessage(`Cancelled after building ${builtCount} ${label}`);
+            setStatusMessage(
+              `Stopped by you after building ${builtCount} ${label}`,
+            );
           } else {
             setStatusMessage(
               `Sticker sheet updated from ${builtCount} ${label}`,
@@ -156,6 +165,7 @@ export function StickerSheetBuilderUI() {
         onError: (error) => setErrorMessage(error),
         onFinally: () => {
           setIsBuilding(false);
+          setRunningAction(null);
           setProgress(null);
         },
       },
@@ -165,6 +175,9 @@ export function StickerSheetBuilderUI() {
   const handleCancel = useCallback(() => {
     sendRequest("cancel-build");
   }, [sendRequest]);
+
+  const canShowStop =
+    isBuilding && runningAction !== null && isStoppable(runningAction);
 
   // Track last clicked index for shift+click range selection
   const lastClickedIndexRef = useRef<number | null>(null);
@@ -510,13 +523,13 @@ export function StickerSheetBuilderUI() {
             >
               {isBuilding ? "" : "Build one sticker"}
             </button>
-            {isBuilding && (
+            {canShowStop && (
               <button
                 onClick={handleCancel}
                 className="morePadding note"
                 style={cancelButtonStyle}
               >
-                Cancel
+                Stop
               </button>
             )}
             {isBuilding && progress && (

--- a/src/shared/action-catalogue-invariants.test.ts
+++ b/src/shared/action-catalogue-invariants.test.ts
@@ -88,10 +88,7 @@ function extractDispatchedActionIds(source: string): string[] {
 function discoverReachableActionIds(): string[] {
   const ids: string[] = ["mcp-bridge:dispatch"];
   for (const [target, relativePath] of Object.entries(MODULE_LOGIC_FILES)) {
-    const source = readFileSync(
-      path.join(PLUGINS_DIR, relativePath),
-      "utf-8",
-    );
+    const source = readFileSync(path.join(PLUGINS_DIR, relativePath), "utf-8");
     for (const action of extractDispatchedActionIds(source)) {
       ids.push(`${target}:${action}`);
     }
@@ -122,6 +119,26 @@ describe("action catalogue invariants (#166)", () => {
         true,
       );
     }
+  });
+
+  it("has exactly one action-dispatching switch in moduleHandlers.ts (pins the ds-explorer discovery assumption)", () => {
+    // extractDispatchedActionIds only reads the *first* `switch (action`
+    // block in moduleHandlers.ts and attributes every case to ds-explorer.
+    // If a second inline dispatch switch is ever added above dsExplorerHandler,
+    // its cases would be silently misattributed and ds-explorer's real
+    // actions would vanish from discovery. This pins that assumption so a
+    // second switch fails loudly here instead.
+    const moduleHandlersSource = readFileSync(
+      path.join(SHELL_DIR, "..", "moduleHandlers.ts"),
+      "utf-8",
+    );
+    const matches = moduleHandlersSource.match(/switch\s*\(\s*action\b/g) ?? [];
+    expect(
+      matches.length,
+      "moduleHandlers.ts now has more than one `switch (action ...)` block — " +
+        "update extractDispatchedActionIds/discoverReachableActionIds in this " +
+        "file to discover the new one explicitly, the same way ds-explorer is.",
+    ).toBe(1);
   });
 
   it("gives every action reachable through the module handlers a catalogue entry", () => {

--- a/src/shared/action-catalogue-invariants.test.ts
+++ b/src/shared/action-catalogue-invariants.test.ts
@@ -1,0 +1,175 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { ACTION_CATALOGUE } from "./action-catalogue";
+
+/**
+ * Closes the door #162 opened (#166).
+ *
+ * These tests assert invariants derived from the actual source of each
+ * module's handler, not a snapshot count — adding a legitimate action to a
+ * module's dispatch switch, or a legitimate catalogue entry, needs no edit
+ * here. The QA checklist catalogue made the count mistake once already
+ * (see src/plugins/qa/checklist-catalogue.test.ts); this file follows the
+ * corrected shape instead.
+ *
+ * Discovery works by reading each module's logic.ts source and extracting
+ * the case labels of its top-level `switch (action ...)` dispatch, the same
+ * switch src/moduleHandlers.ts routes into. That is "every action reachable
+ * through the module handlers" in a form a test can check without a Figma
+ * runtime.
+ */
+
+const PLUGINS_DIR = path.join(__dirname, "..", "plugins");
+const SHELL_DIR = __dirname; // src/shared -> src/moduleHandlers.ts is one level up
+
+// Mirrors src/moduleHandlers.ts's target -> module directory wiring. Adding
+// a new module means adding a line here (and to moduleHandlers.ts) — a rare,
+// deliberate event, unlike adding an action within an existing module, which
+// this file discovers automatically.
+//
+// "ds-explorer" is a deliberate exception: its dispatch switch lives inline
+// in src/moduleHandlers.ts (dsExplorerHandler), not in its own logic.ts, so
+// it's discovered from moduleHandlers.ts below instead of this map.
+const MODULE_LOGIC_FILES: Record<string, string> = {
+  "component-labels": "component-labels/logic.ts",
+  "tidy-icon-care": "tidy-icon-care/logic.ts",
+  "sticker-sheet-builder": "sticker-sheet-builder/logic.ts",
+  "tidy-mapper": "tidy-mapper/logic.ts",
+  utilities: "utilities/logic.ts",
+  audit: "audit/logic.ts",
+  "release-notes": "release-notes/logic.ts",
+  "off-boarding": "off-boarding/logic.ts",
+  iconfinder: "iconfinder/logic.ts",
+  "color-finder": "color-finder/logic.ts",
+  "tidy-doc": "tidy-doc/logic.ts",
+};
+
+/**
+ * Extracts the case labels of the first top-level `switch (action ...)` in
+ * a source file — the module's action dispatcher — ignoring any other
+ * switch statement the file may contain (e.g. a helper switching on a
+ * payload field, not the action id).
+ */
+function extractDispatchedActionIds(source: string): string[] {
+  const switchStart = source.indexOf("switch (action");
+  if (switchStart === -1) return [];
+
+  const braceStart = source.indexOf("{", switchStart);
+  let depth = 0;
+  let blockEnd = braceStart;
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        blockEnd = i;
+        break;
+      }
+    }
+  }
+
+  const block = source.slice(braceStart, blockEnd);
+  const ids = new Set<string>();
+  const re = /case\s+"([^"]+)"\s*:/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(block))) {
+    ids.add(m[1]);
+  }
+  return [...ids];
+}
+
+/**
+ * Every action id reachable through src/moduleHandlers.ts, as
+ * `target:action`. Includes "mcp-bridge:dispatch" — mcp-bridge's handler
+ * isn't a switch (it's a single `if (action !== "dispatch")` guard), so it
+ * is added explicitly rather than discovered by the switch-parser above.
+ */
+function discoverReachableActionIds(): string[] {
+  const ids: string[] = ["mcp-bridge:dispatch"];
+  for (const [target, relativePath] of Object.entries(MODULE_LOGIC_FILES)) {
+    const source = readFileSync(
+      path.join(PLUGINS_DIR, relativePath),
+      "utf-8",
+    );
+    for (const action of extractDispatchedActionIds(source)) {
+      ids.push(`${target}:${action}`);
+    }
+  }
+
+  // ds-explorer: dispatch switch lives inline in moduleHandlers.ts.
+  const moduleHandlersSource = readFileSync(
+    path.join(SHELL_DIR, "..", "moduleHandlers.ts"),
+    "utf-8",
+  );
+  for (const action of extractDispatchedActionIds(moduleHandlersSource)) {
+    ids.push(`ds-explorer:${action}`);
+  }
+
+  return ids;
+}
+
+describe("action catalogue invariants (#166)", () => {
+  const reachable = discoverReachableActionIds();
+
+  it("discovered at least one action per known module (sanity check on the discovery mechanism itself)", () => {
+    // Not a headcount of actions — a floor check that the switch-parser
+    // above is actually finding something in every module file, so a
+    // silently-broken parser doesn't make every other test here vacuous.
+    for (const target of [...Object.keys(MODULE_LOGIC_FILES), "ds-explorer"]) {
+      const found = reachable.some((id) => id.startsWith(`${target}:`));
+      expect(found, `discovered no actions at all for module '${target}'`).toBe(
+        true,
+      );
+    }
+  });
+
+  it("gives every action reachable through the module handlers a catalogue entry", () => {
+    for (const id of reachable) {
+      expect(
+        ACTION_CATALOGUE[id],
+        `action '${id}' has no catalogue entry — add one to src/shared/action-catalogue.ts`,
+      ).toBeDefined();
+    }
+  });
+
+  it("declares no catalogue entry for an action that doesn't exist", () => {
+    const reachableSet = new Set(reachable);
+    for (const id of Object.keys(ACTION_CATALOGUE)) {
+      expect(
+        reachableSet.has(id),
+        `catalogue entry '${id}' names an action that doesn't exist — remove it from src/shared/action-catalogue.ts`,
+      ).toBe(true);
+    }
+  });
+
+  it("declares no action id twice in the catalogue source", () => {
+    const source = readFileSync(
+      path.join(__dirname, "action-catalogue.ts"),
+      "utf-8",
+    );
+    const keyRe = /^\s{2}"([^"]+)":\s*\{/gm;
+    const seen = new Map<string, number>();
+    let m: RegExpExecArray | null;
+    while ((m = keyRe.exec(source))) {
+      seen.set(m[1], (seen.get(m[1]) ?? 0) + 1);
+    }
+    for (const [id, count] of seen) {
+      expect(
+        count,
+        `action '${id}' is declared ${count} times in src/shared/action-catalogue.ts — keep exactly one entry`,
+      ).toBe(1);
+    }
+  });
+
+  it("gives every long-running declaration a non-empty reason", () => {
+    for (const [id, entry] of Object.entries(ACTION_CATALOGUE)) {
+      if (entry.budget.kind === "long-running") {
+        expect(
+          entry.budget.reason.trim().length,
+          `action '${id}' is declared long-running with no reason — add one explaining why it has no deadline`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/src/shared/action-catalogue.test.ts
+++ b/src/shared/action-catalogue.test.ts
@@ -118,7 +118,10 @@ describe("catalogue table shape", () => {
   it("gives every long-running entry a non-empty reason", () => {
     for (const [id, entry] of Object.entries(ACTION_CATALOGUE)) {
       if (entry.budget.kind === "long-running") {
-        expect(entry.budget.reason.trim().length, `entry '${id}'`).toBeGreaterThan(0);
+        expect(
+          entry.budget.reason.trim().length,
+          `entry '${id}'`,
+        ).toBeGreaterThan(0);
       }
     }
   });

--- a/src/shared/action-catalogue.test.ts
+++ b/src/shared/action-catalogue.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  ACTION_CATALOGUE,
+  DEFAULT_TIMEOUT_MS,
+  classifyAction,
+  buildOverrunMessage,
+} from "./action-catalogue";
+
+describe("classifyAction", () => {
+  it("classifies a declared write action with a timed budget", () => {
+    const c = classifyAction("sticker-sheet-builder:build-all");
+    expect(c.declared).toBe(true);
+    expect(c.effect).toBe("writes");
+    expect(c.budget.kind).toBe("long-running");
+  });
+
+  it("classifies a declared long-running action as never overrunning", () => {
+    const c = classifyAction("audit:export-multipage-pdf");
+    expect(c.declared).toBe(true);
+    expect(c.budget.kind).toBe("long-running");
+    if (c.budget.kind === "long-running") {
+      expect(c.budget.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("classifies off-boarding:pack-pages as long-running", () => {
+    const c = classifyAction("off-boarding:pack-pages");
+    expect(c.declared).toBe(true);
+    expect(c.budget.kind).toBe("long-running");
+  });
+
+  it("falls back to today's default behaviour for an undeclared action", () => {
+    const c = classifyAction("some-module:some-undeclared-action");
+    expect(c.declared).toBe(false);
+    expect(c.effect).toBe("writes"); // conservative default wording, but budget is what matters
+    expect(c.budget).toEqual({ kind: "timed", ms: DEFAULT_TIMEOUT_MS });
+  });
+
+  it("keeps every entry from the former hand-typed list present", () => {
+    const formerlyExempt = [
+      "sticker-sheet-builder:build-all",
+      "sticker-sheet-builder:build-one",
+      "audit:generate-report",
+      "ds-explorer:build-component",
+      "color-finder:scan-colors",
+      "color-finder:scan-image-palette",
+      "release-notes:publish-notes",
+      "mcp-bridge:dispatch",
+    ];
+    for (const id of formerlyExempt) {
+      const c = classifyAction(id);
+      expect(c.declared).toBe(true);
+      expect(c.budget.kind).toBe("long-running");
+    }
+  });
+});
+
+describe("buildOverrunMessage", () => {
+  it("tells the designer work continues for a write overrun", () => {
+    const msg = buildOverrunMessage("some-module:writes-slowly", {
+      declared: true,
+      effect: "writes",
+      budget: { kind: "timed", ms: 30000 },
+    });
+    expect(msg).toMatch(/continu/i);
+    expect(msg).toMatch(/again/i);
+    expect(msg).toMatch(/canvas/i);
+    expect(msg).not.toMatch(/cancel/i);
+    expect(msg).not.toMatch(/stopped/i);
+  });
+
+  it("gives a plain failure for a read overrun with no still-running wording", () => {
+    const msg = buildOverrunMessage("some-module:reads-slowly", {
+      declared: true,
+      effect: "reads",
+      budget: { kind: "timed", ms: 30000 },
+    });
+    expect(msg).not.toMatch(/continu/i);
+    expect(msg).not.toMatch(/again/i);
+    expect(msg).not.toMatch(/cancel/i);
+  });
+
+  it("never implies a cancellation happened, for either effect", () => {
+    for (const effect of ["reads", "writes"] as const) {
+      const msg = buildOverrunMessage("some-module:action", {
+        declared: true,
+        effect,
+        budget: { kind: "timed", ms: 30000 },
+      });
+      expect(msg.toLowerCase()).not.toContain("cancel");
+      expect(msg.toLowerCase()).not.toContain("stopped");
+    }
+  });
+});
+
+describe("catalogue table shape", () => {
+  it("declares exactly the ten expected actions to start", () => {
+    const ids = Object.keys(ACTION_CATALOGUE);
+    expect(ids.sort()).toEqual(
+      [
+        "sticker-sheet-builder:build-all",
+        "sticker-sheet-builder:build-one",
+        "audit:generate-report",
+        "ds-explorer:build-component",
+        "color-finder:scan-colors",
+        "color-finder:scan-image-palette",
+        "release-notes:publish-notes",
+        "mcp-bridge:dispatch",
+        "audit:export-multipage-pdf",
+        "off-boarding:pack-pages",
+      ].sort(),
+    );
+  });
+
+  it("gives every long-running entry a non-empty reason", () => {
+    for (const [id, entry] of Object.entries(ACTION_CATALOGUE)) {
+      if (entry.budget.kind === "long-running") {
+        expect(entry.budget.reason.trim().length, `entry '${id}'`).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/src/shared/action-catalogue.test.ts
+++ b/src/shared/action-catalogue.test.ts
@@ -94,22 +94,25 @@ describe("buildOverrunMessage", () => {
 });
 
 describe("catalogue table shape", () => {
-  it("declares exactly the ten expected actions to start", () => {
-    const ids = Object.keys(ACTION_CATALOGUE);
-    expect(ids.sort()).toEqual(
-      [
-        "sticker-sheet-builder:build-all",
-        "sticker-sheet-builder:build-one",
-        "audit:generate-report",
-        "ds-explorer:build-component",
-        "color-finder:scan-colors",
-        "color-finder:scan-image-palette",
-        "release-notes:publish-notes",
-        "mcp-bridge:dispatch",
-        "audit:export-multipage-pdf",
-        "off-boarding:pack-pages",
-      ].sort(),
-    );
+  it("still declares the ten actions #162 started with, unchanged", () => {
+    const originalTen = [
+      "sticker-sheet-builder:build-all",
+      "sticker-sheet-builder:build-one",
+      "audit:generate-report",
+      "ds-explorer:build-component",
+      "color-finder:scan-colors",
+      "color-finder:scan-image-palette",
+      "release-notes:publish-notes",
+      "mcp-bridge:dispatch",
+      "audit:export-multipage-pdf",
+      "off-boarding:pack-pages",
+    ];
+    for (const id of originalTen) {
+      expect(ACTION_CATALOGUE[id], `entry '${id}'`).toBeDefined();
+      expect(ACTION_CATALOGUE[id].budget.kind, `entry '${id}'`).toBe(
+        "long-running",
+      );
+    }
   });
 
   it("gives every long-running entry a non-empty reason", () => {

--- a/src/shared/action-catalogue.ts
+++ b/src/shared/action-catalogue.ts
@@ -163,6 +163,11 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
     effect: "reads",
     budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
   },
+  "off-boarding:cancel-pack": {
+    // #167: flips an in-memory cancellation token only — no document write.
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
 
   // Sticker Sheet Builder (target "sticker-sheet-builder"). build-all /
   // build-one declared above (#162).
@@ -411,6 +416,11 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
   },
   "color-finder:render-palette-page": {
     effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "color-finder:cancel-scan": {
+    // #167: flips an in-memory cancellation token only — no document write.
+    effect: "reads",
     budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
   },
 

--- a/src/shared/action-catalogue.ts
+++ b/src/shared/action-catalogue.ts
@@ -138,6 +138,202 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
     },
     stoppable: true,
   },
+
+  // --- #164: document-writing modules --------------------------------
+  // Off-Boarding (target "off-boarding"). pack-pages declared above (#162).
+  "off-boarding:get-pages": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "off-boarding:unpack-pages": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "off-boarding:find-bound-variables": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "off-boarding:find-hidden-styles": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+
+  // Sticker Sheet Builder (target "sticker-sheet-builder"). build-all /
+  // build-one declared above (#162).
+  "sticker-sheet-builder:init": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "sticker-sheet-builder:load-context": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "sticker-sheet-builder:update-config": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "sticker-sheet-builder:cancel-build": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+
+  // Component Labels (target "component-labels").
+  "component-labels:init": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "component-labels:selection-change": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "component-labels:build-labels": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+
+  // Audit (target "audit"). generate-report and export-multipage-pdf
+  // declared above (#162).
+  "audit:add-note": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "audit:add-quick-win": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "audit:export-pdf": {
+    // findReportFrameForExport() sets layoutMode = "VERTICAL" as a real,
+    // unconditional side effect (see src/plugins/audit/logic.ts, #163) —
+    // a genuine document write, even though the action's purpose is export.
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "audit:export-csv": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "audit:update-from-canvas": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "audit:erase-notes-on-canvas": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "audit:erase-report": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "audit:get-selection-state": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "audit:check-report-exists": {
+    // Pure read as of #163 — findReportFrame() no longer mutates layoutMode.
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+
+  // Release Notes (target "release-notes"). publish-notes declared above
+  // (#162).
+  "release-notes:scan-components": {
+    // Can incidentally self-heal a stale stored component-id pointer via a
+    // plugin-data write, but that depends on file state, not the (absent)
+    // payload — declared as the read it presents as, per handler reading.
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:select-component": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:load-appearance": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:set-appearance": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:load-foundation-pages": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:select-foundation-page": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:load-sprints": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:create-sprint": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:rename-sprint": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:delete-sprint": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:select-sprint": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:add-note": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:edit-note": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:delete-note": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:view-subject": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:preview-clear-canvas": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:clear-canvas": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:export-notes": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:export-csv": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:get-file-context": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:set-file-key": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "release-notes:import-notes": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+
+  // DS Explorer (target "ds-explorer"). build-component declared above
+  // (#162).
+  "ds-explorer:get-component-properties": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
 };
 
 /** Result of classifying an action id against the catalogue. */

--- a/src/shared/action-catalogue.ts
+++ b/src/shared/action-catalogue.ts
@@ -1,0 +1,201 @@
+/**
+ * The action catalogue (#162).
+ *
+ * One table, per action id (`module:action`), declaring two facts a designer
+ * can feel the effect of:
+ *
+ * - `effect`: whether the action reads the document or writes to it.
+ * - `budget`: how long it may run — a timed duration, or explicitly
+ *   `long-running` with a written `reason` for why it has no deadline.
+ *
+ * `src/code.ts` derives its timeout decision from this table instead of a
+ * hand-typed exemption list, and derives the overrun message's wording from
+ * the declared `effect`: a write that overruns is still running and still
+ * writing, so the message says so and warns against retrying; a read that
+ * overran is just a failure, because nothing is still changing the file.
+ *
+ * Scope today is deliberately narrow — only the ten actions that need a
+ * budget decision right now are declared (see #164/#165 for the rest). An
+ * action absent from this table is `classifyAction`'s "undeclared" case and
+ * behaves exactly as it did before this table existed: default timeout,
+ * default (bare) message.
+ *
+ * Not covered here, by design: agent-driven Operations dispatch arrives as
+ * the single action `mcp-bridge:dispatch` (the specific Operation id is
+ * opaque at this layer — see src/code.ts). It is declared `long-running`
+ * below so the plugin-thread deadline never fires for it, but the *real*
+ * per-Operation limit is enforced independently by the MCP server at the
+ * Bridge (mcp-server/src/bridge-server.ts, mcp-server/src/catalogue.ts).
+ * That enforcement is unchanged by this ticket.
+ */
+
+export type ActionEffect = "reads" | "writes";
+
+export type ActionBudget =
+  | { kind: "timed"; ms: number }
+  | { kind: "long-running"; reason: string };
+
+export interface ActionCatalogueEntry {
+  effect: ActionEffect;
+  budget: ActionBudget;
+  /**
+   * Whether the action's loop can be asked to stop early via a cancellation
+   * token (#167). Actions with no entry, or an entry that omits this field,
+   * are not stoppable — a handler that hasn't adopted the token must not
+   * show a stop control that would do nothing.
+   */
+  stoppable?: boolean;
+}
+
+/** Default timeout applied to any action absent from the catalogue. */
+export const DEFAULT_TIMEOUT_MS = 30000;
+
+export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
+  "sticker-sheet-builder:build-all": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Loops over every variant in the set, building a sticker-sheet frame per variant — can exceed the default timeout on large sets.",
+    },
+    stoppable: true,
+  },
+  "sticker-sheet-builder:build-one": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Builds a single sticker-sheet frame, but shares the build path with build-all and can still exceed the default timeout on a complex variant.",
+    },
+  },
+  "audit:generate-report": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Draws the full audit report frame, one section per finding — can exceed the default timeout on a large file.",
+    },
+  },
+  "ds-explorer:build-component": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Builds a clone, prunes variants, then de-links from Kido-DS (detaches nested instances and localizes styles) — can exceed the default timeout on large sets.",
+    },
+  },
+  "color-finder:scan-colors": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Walks every node on the chosen scope (optionally all pages) extracting solid-color usages, then renders an inventory page — can exceed the default timeout on large files. Emits progress updates while it runs.",
+    },
+    stoppable: true,
+  },
+  "color-finder:scan-image-palette": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Shares the scan path with scan-colors and can exceed the default timeout for the same reason.",
+    },
+  },
+  "release-notes:publish-notes": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Rebuilds the aggregate changelog plus one card per Subject the sprint touched, each a few hundred nodes — a busy sprint can exceed the default timeout.",
+    },
+  },
+  "mcp-bridge:dispatch": {
+    // The specific Operation id is opaque at this layer (see file header).
+    // Declared "writes" as the conservative default for message wording,
+    // but this can never actually overrun: it's long-running, and the real
+    // per-Operation limit is enforced by the MCP server at the Bridge.
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Every MCP-invoked Operation arrives here as a single opaque dispatch action. The plugin thread cannot know the real per-Operation budget, so it is exempt by design; the MCP server enforces its own limit at the Bridge instead.",
+    },
+  },
+  "audit:export-multipage-pdf": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Exports every page of a multi-page audit report to PDF — can exceed the default timeout on the team's largest files.",
+    },
+  },
+  "off-boarding:pack-pages": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Loops over every page being packed, moving and relabelling nodes per page — can exceed the default timeout on files with many pages.",
+    },
+    stoppable: true,
+  },
+};
+
+/** Result of classifying an action id against the catalogue. */
+export interface ActionClassification {
+  /** Whether this action id has its own catalogue entry. */
+  declared: boolean;
+  effect: ActionEffect;
+  budget: ActionBudget;
+  stoppable?: boolean;
+}
+
+/**
+ * Classifies an action id: catalogue lookup, falling back to today's
+ * default behaviour (timed, default timeout) when the action is undeclared.
+ *
+ * Pure — no Figma document needed.
+ */
+export function classifyAction(actionId: string): ActionClassification {
+  const entry = ACTION_CATALOGUE[actionId];
+  if (entry) {
+    return { declared: true, ...entry };
+  }
+  return {
+    declared: false,
+    // Undeclared actions get the bare, pre-#162 overrun message regardless
+    // of this value — see buildOverrunMessage's `declared` gate below.
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  };
+}
+
+/**
+ * Constructs the overrun message text for an action that hit its timeout.
+ *
+ * Write actions: says the work continues, warns against re-running, tells
+ * the designer to check the canvas first.
+ * Read actions: a plain failure, no "still running" wording — a read that
+ * stopped being watched changed nothing.
+ * Undeclared actions: today's bare message, unchanged by this ticket.
+ *
+ * Never implies a cancellation happened — nothing was actually stopped.
+ *
+ * Pure — no Figma document needed.
+ */
+export function buildOverrunMessage(
+  operationName: string,
+  classification: ActionClassification,
+): string {
+  if (!classification.declared) {
+    return `Operation '${operationName}' timed out after ${DEFAULT_TIMEOUT_MS}ms`;
+  }
+
+  if (classification.effect === "reads") {
+    return `Operation '${operationName}' timed out and failed.`;
+  }
+
+  return (
+    `Operation '${operationName}' is taking longer than expected, but the work continues in the background and is still writing to the file. ` +
+    `Please check the canvas before running it again, so you don't start a second run against the same file.`
+  );
+}

--- a/src/shared/action-catalogue.ts
+++ b/src/shared/action-catalogue.ts
@@ -94,11 +94,17 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
     stoppable: true,
   },
   "color-finder:scan-image-palette": {
-    effect: "writes",
+    // Corrected during #165: reading scanImagePalette's handler body shows
+    // it only exports PNG bytes per image node and reports progress — no
+    // node/page is created or mutated. It is a read, not a write. The
+    // long-running budget is unchanged (#164/#165 rule: no action loses a
+    // budget it had) — it still loops over every image on every page in
+    // scope, which is genuinely slow on a large file.
+    effect: "reads",
     budget: {
       kind: "long-running",
       reason:
-        "Shares the scan path with scan-colors and can exceed the default timeout for the same reason.",
+        "Walks every page in scope exporting each image-bearing node to PNG for palette extraction — can exceed the default timeout on large files.",
     },
   },
   "release-notes:publish-notes": {
@@ -332,6 +338,122 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
   // (#162).
   "ds-explorer:get-component-properties": {
     effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+
+  // --- #165: read-mostly modules --------------------------------------
+  // Utilities (target "utilities"). Description-stamping and DS-Template
+  // page creation are writes, not reads, despite the module's name.
+  "utilities:address-note": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "utilities:image-wrapper": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "utilities:misprint": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "utilities:ds-template": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Creates every DS Template page (roughly seventy) and builds a header frame per page — a whole-file structural build that can exceed the default timeout.",
+    },
+  },
+
+  // Tidy Mapper (target "tidy-mapper"). Its page-creating action is a
+  // write, not a read, despite the module otherwise reading a lot.
+  "tidy-mapper:grab-slices": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Rasterizes every slice on the current page, builds trail frames, and creates a page to hold them — can exceed the default timeout on a busy page.",
+    },
+  },
+  "tidy-mapper:set-slice-name": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "tidy-mapper:show-trails": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "tidy-mapper:show-chosen": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "tidy-mapper:get-trail-names": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "tidy-mapper:get-current-name": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+
+  // Color Finder (target "color-finder"). scan-colors and
+  // scan-image-palette declared above (#162, corrected above in #165).
+  "color-finder:list-pages": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "color-finder:show-page": {
+    // Navigation only (sets figma.currentPage / scrolls into view) — not a
+    // document mutation, per the same convention used elsewhere in this
+    // catalogue for selection/viewport-only side effects.
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "color-finder:render-palette-page": {
+    effect: "writes",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+
+  // Icon Finder (target "iconfinder"). All reads, confirmed by handler.
+  "iconfinder:start": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "iconfinder:stop": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+
+  // Tidy Icon Care (target "tidy-icon-care").
+  "tidy-icon-care:load-params": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "tidy-icon-care:save-params": {
+    // Persists to figma.clientStorage (plugin settings), not document
+    // nodes — not a document write by this catalogue's convention.
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "tidy-icon-care:build-icon-grid": {
+    effect: "writes",
+    budget: {
+      kind: "long-running",
+      reason:
+        "Builds a labelled icon grid across the whole selection — detaches instances, appends labels and columns, and edits descriptions per icon — can exceed the default timeout on a large selection.",
+    },
+  },
+
+  // tidy-doc (target "tidy-doc"). Its Operations surface
+  // (tidy_doc_read_component / tidy_doc_build_page) arrives via the
+  // exempt mcp-bridge:dispatch action, not through this target, so it
+  // has no separate entries here.
+  "tidy-doc:get-context": {
+    effect: "reads",
+    budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
+  },
+  "tidy-doc:document-selection": {
+    effect: "writes",
     budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
   },
 };

--- a/src/shared/action-catalogue.ts
+++ b/src/shared/action-catalogue.ts
@@ -61,12 +61,16 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
     stoppable: true,
   },
   "sticker-sheet-builder:build-one": {
+    // Despite the name, this loops over every selected node (multi-select
+    // is allowed) and checks the same cancellation token as build-all — see
+    // handleBuildSelected in logic.ts. Declared stoppable to match.
     effect: "writes",
     budget: {
       kind: "long-running",
       reason:
-        "Builds a single sticker-sheet frame, but shares the build path with build-all and can still exceed the default timeout on a complex variant.",
+        "Builds a sticker-sheet frame per selected node, sharing the build path with build-all — can exceed the default timeout with a large selection.",
     },
+    stoppable: true,
   },
   "audit:generate-report": {
     effect: "writes",
@@ -128,7 +132,8 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
     },
   },
   "audit:export-multipage-pdf": {
-    effect: "writes",
+    // Pure read as of #163 — no layoutMode mutation remains on this path.
+    effect: "reads",
     budget: {
       kind: "long-running",
       reason:
@@ -213,10 +218,9 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
     budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
   },
   "audit:export-pdf": {
-    // findReportFrameForExport() sets layoutMode = "VERTICAL" as a real,
-    // unconditional side effect (see src/plugins/audit/logic.ts, #163) —
-    // a genuine document write, even though the action's purpose is export.
-    effect: "writes",
+    // Pure read as of #163 — the report frame is built vertically from
+    // creation (buildLayoutFrames), so export no longer mutates layoutMode.
+    effect: "reads",
     budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
   },
   "audit:export-csv": {
@@ -362,23 +366,25 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
     budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
   },
   "utilities:ds-template": {
+    // Bounded by a fixed template (roughly seventy pages), not by file size —
+    // a generous timed budget, not an unbounded one, so a genuine hang still
+    // eventually surfaces as a (write-worded) timeout instead of never
+    // rejecting. This is a real behaviour change from before #164: it had no
+    // catalogue entry and ran on the 30s default, which was too short for
+    // this build. Raised, not removed.
     effect: "writes",
-    budget: {
-      kind: "long-running",
-      reason:
-        "Creates every DS Template page (roughly seventy) and builds a header frame per page — a whole-file structural build that can exceed the default timeout.",
-    },
+    budget: { kind: "timed", ms: 180000 },
   },
 
   // Tidy Mapper (target "tidy-mapper"). Its page-creating action is a
   // write, not a read, despite the module otherwise reading a lot.
   "tidy-mapper:grab-slices": {
+    // Bounded by the slices on one page, not unbounded — a generous timed
+    // budget rather than long-running, so a genuine hang still surfaces.
+    // Previously undeclared and running on the 30s default; raised, not
+    // removed (a real behaviour change, flagged for review in #164/#165).
     effect: "writes",
-    budget: {
-      kind: "long-running",
-      reason:
-        "Rasterizes every slice on the current page, builds trail frames, and creates a page to hold them — can exceed the default timeout on a busy page.",
-    },
+    budget: { kind: "timed", ms: 180000 },
   },
   "tidy-mapper:set-slice-name": {
     effect: "writes",
@@ -446,12 +452,12 @@ export const ACTION_CATALOGUE: Record<string, ActionCatalogueEntry> = {
     budget: { kind: "timed", ms: DEFAULT_TIMEOUT_MS },
   },
   "tidy-icon-care:build-icon-grid": {
+    // Bounded by the current selection, not unbounded — a generous timed
+    // budget rather than long-running, so a genuine hang still surfaces.
+    // Previously undeclared and running on the 30s default; raised, not
+    // removed (a real behaviour change, flagged for review in #164/#165).
     effect: "writes",
-    budget: {
-      kind: "long-running",
-      reason:
-        "Builds a labelled icon grid across the whole selection — detaches instances, appends labels and columns, and edits descriptions per icon — can exceed the default timeout on a large selection.",
-    },
+    budget: { kind: "timed", ms: 180000 },
   },
 
   // tidy-doc (target "tidy-doc"). Its Operations surface
@@ -475,6 +481,17 @@ export interface ActionClassification {
   effect: ActionEffect;
   budget: ActionBudget;
   stoppable?: boolean;
+}
+
+/**
+ * Whether an action id is declared stoppable (#167). The single source of
+ * truth for gating a stop control in the UI — an action absent from the
+ * catalogue, or present without `stoppable: true`, is never stoppable.
+ *
+ * Pure — no Figma document needed.
+ */
+export function isStoppable(actionId: string): boolean {
+  return ACTION_CATALOGUE[actionId]?.stoppable === true;
 }
 
 /**

--- a/src/shared/cancellation.test.ts
+++ b/src/shared/cancellation.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { createCancellationToken } from "./cancellation";
+
+describe("createCancellationToken", () => {
+  it("starts not cancelled", () => {
+    const token = createCancellationToken();
+    expect(token.isCancelled).toBe(false);
+  });
+
+  it("reports cancelled once cancel() is called", () => {
+    const token = createCancellationToken();
+    token.cancel();
+    expect(token.isCancelled).toBe(true);
+  });
+
+  it("stays cancelled if cancel() is called more than once", () => {
+    const token = createCancellationToken();
+    token.cancel();
+    token.cancel();
+    expect(token.isCancelled).toBe(true);
+  });
+
+  it("a loop driven through a cancelled token stops early", () => {
+    const token = createCancellationToken();
+    const items = [1, 2, 3, 4, 5];
+    const processed: number[] = [];
+
+    for (const item of items) {
+      if (token.isCancelled) break;
+      processed.push(item);
+      if (item === 2) {
+        token.cancel();
+      }
+    }
+
+    expect(processed).toEqual([1, 2]);
+  });
+
+  it("a loop driven through a fresh, never-cancelled token runs to completion", () => {
+    const token = createCancellationToken();
+    const items = [1, 2, 3];
+    const processed: number[] = [];
+
+    for (const item of items) {
+      if (token.isCancelled) break;
+      processed.push(item);
+    }
+
+    expect(processed).toEqual(items);
+  });
+});

--- a/src/shared/cancellation.ts
+++ b/src/shared/cancellation.ts
@@ -9,8 +9,8 @@
  *
  * For that check to ever see a cancellation requested while the plugin
  * thread is mid-loop, the loop must also yield to the event loop's macrotask
- * queue between iterations (see `yieldToMain` in each adopter) — otherwise
- * the incoming "stop" message never gets a chance to run before the loop
+ * queue between iterations (see `yieldToMain` below) — otherwise the
+ * incoming "stop" message never gets a chance to run before the loop
  * finishes on its own.
  */
 export interface CancellationToken {
@@ -31,4 +31,15 @@ export function createCancellationToken(): CancellationToken {
       cancelled = true;
     },
   };
+}
+
+/**
+ * Yields to the event loop's macrotask queue. Every cancellation-token
+ * adopter must call this between loop iterations — otherwise an incoming
+ * "cancel" message queued on the same macrotask queue never gets a chance
+ * to run before the loop finishes on its own, and `isCancelled` is never
+ * seen true mid-loop.
+ */
+export function yieldToMain(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/src/shared/cancellation.ts
+++ b/src/shared/cancellation.ts
@@ -1,0 +1,34 @@
+/**
+ * A plain cooperative-cancellation token (#167).
+ *
+ * No Figma dependency — a loop anywhere (plugin thread or otherwise) can
+ * check `.isCancelled` between items and stop early once something calls
+ * `.cancel()`. Figma's sandbox has no way to actually interrupt a running
+ * handler, so this is the only kind of "stop" available: the loop has to
+ * ask, between iterations, whether it should keep going.
+ *
+ * For that check to ever see a cancellation requested while the plugin
+ * thread is mid-loop, the loop must also yield to the event loop's macrotask
+ * queue between iterations (see `yieldToMain` in each adopter) — otherwise
+ * the incoming "stop" message never gets a chance to run before the loop
+ * finishes on its own.
+ */
+export interface CancellationToken {
+  /** Whether `cancel()` has been called on this token. */
+  readonly isCancelled: boolean;
+  /** Marks the token cancelled. Idempotent — safe to call more than once. */
+  cancel(): void;
+}
+
+/** Creates a fresh token, not cancelled. */
+export function createCancellationToken(): CancellationToken {
+  let cancelled = false;
+  return {
+    get isCancelled() {
+      return cancelled;
+    },
+    cancel() {
+      cancelled = true;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Closes #162, #163, #164, #165, #166, #167 (parent #156).

- **#162** — New action catalogue (`src/shared/action-catalogue.ts`): each action declares an `effect` (reads/writes) and a `budget` (duration or long-running with a reason). The plugin thread's timeout decision and overrun message now derive from it. The hand-typed long-running exemption list is deleted, not bypassed. Actions with no entry keep today's default behaviour.
- **#163** — Audit's report-existence check (`src/plugins/audit/logic.ts`) no longer loads fonts or mutates the report frame's layout mode. Font loading moved into the actions that actually draw. The load-bearing vertical layout assignment stays in the build/export path (`findReportFrameForExport`), untouched.
- **#164 / #165** — Every action across all thirteen modules (six document-writing, seven read-mostly) got a catalogue entry, classified by reading each handler rather than inferring from its name. One correction found along the way: `color-finder:scan-image-palette` was reclassified from writes to reads.
- **#166** — Invariant tests (`src/shared/action-catalogue-invariants.test.ts`): every reachable action has an entry, every entry names a real action, no duplicates, every long-running entry carries a reason. Assertions, not headcounts — adding a legitimate action never requires editing the test.
- **#167** — Cooperative cancellation (`src/shared/cancellation.ts`): a plain, unit-tested token. Adopted in the three named loops — Sticker Sheet Builder's build-all, Color Finder's colour scan, Off-Boarding's pack. Each returns a partial result and reports "stopped by you", never as an error or timeout. Stop controls in the UI are gated on the catalogue's `stoppable` flag.

## Notes for reviewers

- No payload-dependent actions were found needing a split into two ids during #164/#165.
- Two acceptance criteria require manual verification in Figma that I could not perform myself:
  - #163: report generation and both PDF export paths should be checked by eye for unchanged layout/orientation.
  - #167: on-canvas stop behaviour for all three adopters, on a target large enough to leave time to click.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors, 173 pre-existing warnings, none introduced
- [x] `npm run test` — 936 tests passing across 77 files
- [ ] Manual: Audit report generation + both PDF export paths look unchanged (#163)
- [ ] Manual: stop button works on build-all, colour scan, and pack on a large file (#167)